### PR TITLE
Add missing tests for k8s utilities

### DIFF
--- a/internal/k8s/container_test.go
+++ b/internal/k8s/container_test.go
@@ -471,3 +471,52 @@ func TestAddContainerEnv(t *testing.T) {
 		})
 	}
 }
+
+func TestAdditionalContainerFunctions(t *testing.T) {
+	c := &corev1.Container{}
+
+	mount := corev1.VolumeMount{Name: "data", MountPath: "/data"}
+	AddContainerVolumeMount(c, mount)
+	if len(c.VolumeMounts) != 1 || c.VolumeMounts[0] != mount {
+		t.Errorf("volume mount not added")
+	}
+
+	dev := corev1.VolumeDevice{Name: "block", DevicePath: "/dev/block"}
+	AddContainerVolumeDevice(c, dev)
+	if len(c.VolumeDevices) != 1 || c.VolumeDevices[0] != dev {
+		t.Errorf("volume device not added")
+	}
+
+	probe := corev1.Probe{TimeoutSeconds: 5}
+	SetContainerLivenessProbe(c, probe)
+	if c.LivenessProbe == nil || *c.LivenessProbe != probe {
+		t.Errorf("liveness probe not set")
+	}
+
+	SetContainerReadinessProbe(c, probe)
+	if c.ReadinessProbe == nil || *c.ReadinessProbe != probe {
+		t.Errorf("readiness probe not set")
+	}
+
+	SetContainerStartupProbe(c, probe)
+	if c.StartupProbe == nil || *c.StartupProbe != probe {
+		t.Errorf("startup probe not set")
+	}
+
+	resources := corev1.ResourceRequirements{}
+	SetContainerResources(c, resources)
+	if !reflect.DeepEqual(c.Resources, resources) {
+		t.Errorf("resources not set")
+	}
+
+	SetContainerImagePullPolicy(c, corev1.PullAlways)
+	if c.ImagePullPolicy != corev1.PullAlways {
+		t.Errorf("image pull policy not set")
+	}
+
+	sc := corev1.SecurityContext{RunAsUser: new(int64)}
+	SetContainerSecurityContext(c, sc)
+	if c.SecurityContext == nil || *c.SecurityContext != sc {
+		t.Errorf("security context not set")
+	}
+}

--- a/internal/k8s/deployment.go
+++ b/internal/k8s/deployment.go
@@ -78,7 +78,7 @@ func AddDeploymentTopologySpreadConstraints(deployment *appsv1.Deployment, topol
 	if topologySpreadConstraint == nil {
 		return
 	}
-	deployment.Spec.Template.Spec.TopologySpreadConstraints = append(deployment.Spec.Template.Spec.TopologySpreadConstraints)
+	deployment.Spec.Template.Spec.TopologySpreadConstraints = append(deployment.Spec.Template.Spec.TopologySpreadConstraints, *topologySpreadConstraint)
 }
 
 func SetDeploymentServiceAccountName(deployment *appsv1.Deployment, serviceAccountName string) {

--- a/internal/k8s/deployment_test.go
+++ b/internal/k8s/deployment_test.go
@@ -1,0 +1,78 @@
+package k8s
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDeploymentFunctions(t *testing.T) {
+	dep := CreateDeployment("app", "ns")
+	if dep.Name != "app" || dep.Namespace != "ns" {
+		t.Fatalf("metadata mismatch: %s/%s", dep.Namespace, dep.Name)
+	}
+	if dep.Kind != "Deployment" {
+		t.Errorf("unexpected kind %q", dep.Kind)
+	}
+
+	c := corev1.Container{Name: "c"}
+	AddDeploymentContainer(dep, &c)
+	if len(dep.Spec.Template.Spec.Containers) != 1 || dep.Spec.Template.Spec.Containers[0].Name != "c" {
+		t.Errorf("container not added")
+	}
+
+	ic := corev1.Container{Name: "init"}
+	AddDeploymentInitContainer(dep, &ic)
+	if len(dep.Spec.Template.Spec.InitContainers) != 1 {
+		t.Errorf("init container not added")
+	}
+
+	v := corev1.Volume{Name: "vol"}
+	AddDeploymentVolume(dep, &v)
+	if len(dep.Spec.Template.Spec.Volumes) != 1 {
+		t.Errorf("volume not added")
+	}
+
+	secret := corev1.LocalObjectReference{Name: "secret"}
+	AddDeploymentImagePullSecret(dep, &secret)
+	if len(dep.Spec.Template.Spec.ImagePullSecrets) != 1 {
+		t.Errorf("image pull secret not added")
+	}
+
+	tol := corev1.Toleration{Key: "k"}
+	AddDeploymentToleration(dep, &tol)
+	if len(dep.Spec.Template.Spec.Tolerations) != 1 {
+		t.Errorf("toleration not added")
+	}
+
+	tsc := corev1.TopologySpreadConstraint{MaxSkew: 1, TopologyKey: "zone", WhenUnsatisfiable: corev1.ScheduleAnyway, LabelSelector: &metav1.LabelSelector{}}
+	AddDeploymentTopologySpreadConstraints(dep, &tsc)
+	if len(dep.Spec.Template.Spec.TopologySpreadConstraints) != 1 {
+		t.Errorf("topology constraint not added")
+	}
+
+	SetDeploymentServiceAccountName(dep, "sa")
+	if dep.Spec.Template.Spec.ServiceAccountName != "sa" {
+		t.Errorf("service account name not set")
+	}
+
+	sc := &corev1.PodSecurityContext{RunAsUser: func(i int64) *int64 { return &i }(1)}
+	SetDeploymentSecurityContext(dep, sc)
+	if dep.Spec.Template.Spec.SecurityContext != sc {
+		t.Errorf("security context not set")
+	}
+
+	aff := &corev1.Affinity{}
+	SetDeploymentAffinity(dep, aff)
+	if dep.Spec.Template.Spec.Affinity != aff {
+		t.Errorf("affinity not set")
+	}
+
+	ns := map[string]string{"role": "db"}
+	SetDeploymentNodeSelector(dep, ns)
+	if !reflect.DeepEqual(dep.Spec.Template.Spec.NodeSelector, ns) {
+		t.Errorf("node selector not set")
+	}
+}

--- a/internal/k8s/ingress_test.go
+++ b/internal/k8s/ingress_test.go
@@ -1,0 +1,47 @@
+package k8s
+
+import (
+	"testing"
+
+	netv1 "k8s.io/api/networking/v1"
+)
+
+func TestIngressFunctions(t *testing.T) {
+	ing := CreateIngress("ing", "ns", "class")
+	if ing.Name != "ing" || ing.Namespace != "ns" {
+		t.Fatalf("metadata mismatch: %s/%s", ing.Namespace, ing.Name)
+	}
+	if ing.Kind != "Ingress" {
+		t.Errorf("unexpected kind %q", ing.Kind)
+	}
+	if *ing.Spec.IngressClassName != "class" {
+		t.Errorf("unexpected class name %q", *ing.Spec.IngressClassName)
+	}
+
+	rule := CreateIngressRule("example.com")
+	if rule.Host != "example.com" {
+		t.Errorf("rule host mismatch")
+	}
+
+	pt := netv1.PathTypePrefix
+	path := CreateIngressPath("/", &pt, "svc", "http")
+	if path.Path != "/" || path.Backend.Service.Name != "svc" {
+		t.Errorf("unexpected path")
+	}
+
+	AddIngressRulePath(rule, path)
+	if len(rule.IngressRuleValue.HTTP.Paths) != 1 {
+		t.Errorf("path not added")
+	}
+
+	AddIngressRule(ing, rule)
+	if len(ing.Spec.Rules) != 1 {
+		t.Errorf("rule not added")
+	}
+
+	tls := netv1.IngressTLS{Hosts: []string{"example.com"}}
+	AddIngressTls(ing, tls)
+	if len(ing.Spec.TLS) != 1 || ing.Spec.TLS[0].Hosts[0] != "example.com" {
+		t.Errorf("tls not added")
+	}
+}

--- a/internal/k8s/pod_test.go
+++ b/internal/k8s/pod_test.go
@@ -1,0 +1,30 @@
+package k8s
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestCreatePod(t *testing.T) {
+	pod := CreatePod("test-pod", "default")
+
+	if pod.Name != "test-pod" {
+		t.Errorf("expected name %q got %q", "test-pod", pod.Name)
+	}
+	if pod.Namespace != "default" {
+		t.Errorf("expected namespace %q got %q", "default", pod.Namespace)
+	}
+	if pod.Kind != "Pod" {
+		t.Errorf("expected kind Pod got %q", pod.Kind)
+	}
+	if pod.APIVersion != "v1" {
+		t.Errorf("expected apiVersion v1 got %q", pod.APIVersion)
+	}
+	if pod.Spec.RestartPolicy != corev1.RestartPolicyAlways {
+		t.Errorf("unexpected restart policy %v", pod.Spec.RestartPolicy)
+	}
+	if pod.Spec.TerminationGracePeriodSeconds == nil {
+		t.Errorf("expected TerminationGracePeriodSeconds to be set")
+	}
+}

--- a/internal/k8s/service_test.go
+++ b/internal/k8s/service_test.go
@@ -1,0 +1,43 @@
+package k8s
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestServiceFunctions(t *testing.T) {
+	svc := CreateService("svc", "ns")
+	if svc.Name != "svc" || svc.Namespace != "ns" {
+		t.Fatalf("unexpected metadata: %s/%s", svc.Namespace, svc.Name)
+	}
+	if svc.Kind != "Service" {
+		t.Errorf("unexpected kind %q", svc.Kind)
+	}
+	if len(svc.Spec.Ports) != 0 {
+		t.Errorf("expected no ports got %d", len(svc.Spec.Ports))
+	}
+
+	port := corev1.ServicePort{Name: "http", Port: 80}
+	AddServicePort(svc, port)
+	if len(svc.Spec.Ports) != 1 || svc.Spec.Ports[0] != port {
+		t.Errorf("port not added correctly: %+v", svc.Spec.Ports)
+	}
+
+	selector := map[string]string{"app": "svc"}
+	SetServiceSelector(svc, selector)
+	if !reflect.DeepEqual(svc.Spec.Selector, selector) {
+		t.Errorf("selector not set: %+v", svc.Spec.Selector)
+	}
+
+	SetServiceType(svc, corev1.ServiceTypeNodePort)
+	if svc.Spec.Type != corev1.ServiceTypeNodePort {
+		t.Errorf("service type not set")
+	}
+
+	SetServiceExternalTrafficPolicy(svc, corev1.ServiceExternalTrafficPolicyLocal)
+	if svc.Spec.ExternalTrafficPolicy != corev1.ServiceExternalTrafficPolicyLocal {
+		t.Errorf("external traffic policy not set")
+	}
+}

--- a/internal/yaml/import_test.go
+++ b/internal/yaml/import_test.go
@@ -1,0 +1,32 @@
+package yaml
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestParse(t *testing.T) {
+	data := `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+spec:
+  containers: []
+`
+	objs := parse([]byte(data))
+	if len(objs) != 2 {
+		t.Fatalf("expected 2 objects, got %d", len(objs))
+	}
+	if sa, ok := objs[0].(*corev1.ServiceAccount); !ok || sa.Name != "sa" {
+		t.Fatalf("unexpected first object: %#v", objs[0])
+	}
+	if pod, ok := objs[1].(*corev1.Pod); !ok || pod.Name != "pod" {
+		t.Fatalf("unexpected second object: %#v", objs[1])
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for Deployment, Service, Ingress, Pod and container helper functions
- add tests for YAML parser
- fix AddDeploymentTopologySpreadConstraints

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6877a2401fdc832f89c4d9ed582f3291