### PR TITLE
Add pod helper utilities

### DIFF
--- a/internal/k8s/pod.go
+++ b/internal/k8s/pod.go
@@ -37,3 +37,46 @@ func CreatePod(name string, namespace string) *corev1.Pod {
 	}
 	return &obj
 }
+
+func AddPodContainer(pod *corev1.Pod, container *corev1.Container) {
+	pod.Spec.Containers = append(pod.Spec.Containers, *container)
+}
+
+func AddPodInitContainer(pod *corev1.Pod, container *corev1.Container) {
+	pod.Spec.InitContainers = append(pod.Spec.InitContainers, *container)
+}
+
+func AddPodVolume(pod *corev1.Pod, volume *corev1.Volume) {
+	pod.Spec.Volumes = append(pod.Spec.Volumes, *volume)
+}
+
+func AddPodImagePullSecret(pod *corev1.Pod, imagePullSecret *corev1.LocalObjectReference) {
+	pod.Spec.ImagePullSecrets = append(pod.Spec.ImagePullSecrets, *imagePullSecret)
+}
+
+func AddPodToleration(pod *corev1.Pod, toleration *corev1.Toleration) {
+	pod.Spec.Tolerations = append(pod.Spec.Tolerations, *toleration)
+}
+
+func AddPodTopologySpreadConstraints(pod *corev1.Pod, topologySpreadConstraint *corev1.TopologySpreadConstraint) {
+	if topologySpreadConstraint == nil {
+		return
+	}
+	pod.Spec.TopologySpreadConstraints = append(pod.Spec.TopologySpreadConstraints, *topologySpreadConstraint)
+}
+
+func SetPodServiceAccountName(pod *corev1.Pod, serviceAccountName string) {
+	pod.Spec.ServiceAccountName = serviceAccountName
+}
+
+func SetPodSecurityContext(pod *corev1.Pod, securityContext *corev1.PodSecurityContext) {
+	pod.Spec.SecurityContext = securityContext
+}
+
+func SetPodAffinity(pod *corev1.Pod, affinity *corev1.Affinity) {
+	pod.Spec.Affinity = affinity
+}
+
+func SetPodNodeSelector(pod *corev1.Pod, nodeSelector map[string]string) {
+	pod.Spec.NodeSelector = nodeSelector
+}

--- a/internal/k8s/pod_test.go
+++ b/internal/k8s/pod_test.go
@@ -1,9 +1,11 @@
 package k8s
 
 import (
+	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCreatePod(t *testing.T) {
@@ -26,5 +28,74 @@ func TestCreatePod(t *testing.T) {
 	}
 	if pod.Spec.TerminationGracePeriodSeconds == nil {
 		t.Errorf("expected TerminationGracePeriodSeconds to be set")
+	}
+}
+
+func TestPodFunctions(t *testing.T) {
+	pod := CreatePod("app", "ns")
+	if pod.Name != "app" || pod.Namespace != "ns" {
+		t.Fatalf("metadata mismatch: %s/%s", pod.Namespace, pod.Name)
+	}
+	if pod.Kind != "Pod" {
+		t.Errorf("unexpected kind %q", pod.Kind)
+	}
+
+	c := corev1.Container{Name: "c"}
+	AddPodContainer(pod, &c)
+	if len(pod.Spec.Containers) != 1 || pod.Spec.Containers[0].Name != "c" {
+		t.Errorf("container not added")
+	}
+
+	ic := corev1.Container{Name: "init"}
+	AddPodInitContainer(pod, &ic)
+	if len(pod.Spec.InitContainers) != 1 {
+		t.Errorf("init container not added")
+	}
+
+	v := corev1.Volume{Name: "vol"}
+	AddPodVolume(pod, &v)
+	if len(pod.Spec.Volumes) != 1 {
+		t.Errorf("volume not added")
+	}
+
+	secret := corev1.LocalObjectReference{Name: "secret"}
+	AddPodImagePullSecret(pod, &secret)
+	if len(pod.Spec.ImagePullSecrets) != 1 {
+		t.Errorf("image pull secret not added")
+	}
+
+	tol := corev1.Toleration{Key: "k"}
+	AddPodToleration(pod, &tol)
+	if len(pod.Spec.Tolerations) != 1 {
+		t.Errorf("toleration not added")
+	}
+
+	tsc := corev1.TopologySpreadConstraint{MaxSkew: 1, TopologyKey: "zone", WhenUnsatisfiable: corev1.ScheduleAnyway, LabelSelector: &metav1.LabelSelector{}}
+	AddPodTopologySpreadConstraints(pod, &tsc)
+	if len(pod.Spec.TopologySpreadConstraints) != 1 {
+		t.Errorf("topology constraint not added")
+	}
+
+	SetPodServiceAccountName(pod, "sa")
+	if pod.Spec.ServiceAccountName != "sa" {
+		t.Errorf("service account name not set")
+	}
+
+	sc := &corev1.PodSecurityContext{RunAsUser: func(i int64) *int64 { return &i }(1)}
+	SetPodSecurityContext(pod, sc)
+	if pod.Spec.SecurityContext != sc {
+		t.Errorf("security context not set")
+	}
+
+	aff := &corev1.Affinity{}
+	SetPodAffinity(pod, aff)
+	if pod.Spec.Affinity != aff {
+		t.Errorf("affinity not set")
+	}
+
+	ns := map[string]string{"role": "db"}
+	SetPodNodeSelector(pod, ns)
+	if !reflect.DeepEqual(pod.Spec.NodeSelector, ns) {
+		t.Errorf("node selector not set")
 	}
 }


### PR DESCRIPTION
## Summary
- add a set of helper functions for manipulating Pod specs
- extend pod test suite to cover the new helpers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6877adb57754832f91238e82a3a99e41