### PR TITLE
Add serviceaccount helpers

### DIFF
--- a/internal/k8s/serviceaccount.go
+++ b/internal/k8s/serviceaccount.go
@@ -1,0 +1,44 @@
+package k8s
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CreateServiceAccount(name, namespace string) *corev1.ServiceAccount {
+	obj := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceAccount",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": name,
+			},
+			Annotations: map[string]string{
+				"app": name,
+			},
+		},
+		Secrets:                      []corev1.ObjectReference{},
+		ImagePullSecrets:             []corev1.LocalObjectReference{},
+		AutomountServiceAccountToken: new(bool),
+	}
+	return obj
+}
+
+func AddServiceAccountSecret(sa *corev1.ServiceAccount, secret corev1.ObjectReference) {
+	sa.Secrets = append(sa.Secrets, secret)
+}
+
+func AddServiceAccountImagePullSecret(sa *corev1.ServiceAccount, secret corev1.LocalObjectReference) {
+	sa.ImagePullSecrets = append(sa.ImagePullSecrets, secret)
+}
+
+func SetServiceAccountAutomountToken(sa *corev1.ServiceAccount, automount bool) {
+	if sa.AutomountServiceAccountToken == nil {
+		sa.AutomountServiceAccountToken = new(bool)
+	}
+	*sa.AutomountServiceAccountToken = automount
+}

--- a/internal/k8s/serviceaccount_test.go
+++ b/internal/k8s/serviceaccount_test.go
@@ -1,0 +1,59 @@
+package k8s
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestCreateServiceAccount(t *testing.T) {
+	sa := CreateServiceAccount("sa", "default")
+	if sa.Name != "sa" {
+		t.Errorf("expected name sa got %s", sa.Name)
+	}
+	if sa.Namespace != "default" {
+		t.Errorf("expected namespace default got %s", sa.Namespace)
+	}
+	if sa.Kind != "ServiceAccount" {
+		t.Errorf("unexpected kind %q", sa.Kind)
+	}
+	if len(sa.Secrets) != 0 {
+		t.Errorf("expected no secrets got %d", len(sa.Secrets))
+	}
+	if len(sa.ImagePullSecrets) != 0 {
+		t.Errorf("expected no image pull secrets got %d", len(sa.ImagePullSecrets))
+	}
+	if sa.AutomountServiceAccountToken == nil {
+		t.Errorf("expected automount token pointer set")
+	}
+}
+
+func TestAddServiceAccountSecret(t *testing.T) {
+	sa := CreateServiceAccount("sa", "ns")
+	ref := corev1.ObjectReference{Name: "secret"}
+	AddServiceAccountSecret(sa, ref)
+	if len(sa.Secrets) != 1 || sa.Secrets[0] != ref {
+		t.Errorf("secret not added")
+	}
+}
+
+func TestAddServiceAccountImagePullSecret(t *testing.T) {
+	sa := CreateServiceAccount("sa", "ns")
+	ref := corev1.LocalObjectReference{Name: "pullsecret"}
+	AddServiceAccountImagePullSecret(sa, ref)
+	if len(sa.ImagePullSecrets) != 1 || sa.ImagePullSecrets[0] != ref {
+		t.Errorf("image pull secret not added")
+	}
+}
+
+func TestSetServiceAccountAutomountToken(t *testing.T) {
+	sa := CreateServiceAccount("sa", "ns")
+	SetServiceAccountAutomountToken(sa, true)
+	if sa.AutomountServiceAccountToken == nil || !*sa.AutomountServiceAccountToken {
+		t.Errorf("automount token not set to true")
+	}
+	SetServiceAccountAutomountToken(sa, false)
+	if sa.AutomountServiceAccountToken == nil || *sa.AutomountServiceAccountToken {
+		t.Errorf("automount token not updated to false")
+	}
+}


### PR DESCRIPTION
## Summary
- support creating ServiceAccount objects and mutating them
- cover serviceaccount helpers with unit tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6877ae51e384832f827ab2a7dd3df00f