### PR TITLE
Add PersistentVolumeClaim helpers

### DIFF
--- a/internal/k8s/persistentvolumeclaim.go
+++ b/internal/k8s/persistentvolumeclaim.go
@@ -1,0 +1,78 @@
+package k8s
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreatePersistentVolumeClaim returns a PersistentVolumeClaim object with sane defaults.
+func CreatePersistentVolumeClaim(name string, namespace string) *corev1.PersistentVolumeClaim {
+	mode := corev1.PersistentVolumeFilesystem
+	obj := &corev1.PersistentVolumeClaim{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PersistentVolumeClaim",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": name,
+			},
+			Annotations: map[string]string{
+				"app": name,
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+			VolumeMode: &mode,
+		},
+	}
+	return obj
+}
+
+// AddPVCAccessMode appends an access mode to the claim.
+func AddPVCAccessMode(pvc *corev1.PersistentVolumeClaim, mode corev1.PersistentVolumeAccessMode) {
+	pvc.Spec.AccessModes = append(pvc.Spec.AccessModes, mode)
+}
+
+// SetPVCStorageClassName sets the storage class name for the claim.
+func SetPVCStorageClassName(pvc *corev1.PersistentVolumeClaim, class string) {
+	pvc.Spec.StorageClassName = &class
+}
+
+// SetPVCVolumeMode sets the volume mode of the claim.
+func SetPVCVolumeMode(pvc *corev1.PersistentVolumeClaim, mode corev1.PersistentVolumeMode) {
+	pvc.Spec.VolumeMode = &mode
+}
+
+// SetPVCResources sets the resource requirements for the claim.
+func SetPVCResources(pvc *corev1.PersistentVolumeClaim, resources corev1.VolumeResourceRequirements) {
+	pvc.Spec.Resources = resources
+}
+
+// SetPVCSelector sets the selector for the claim.
+func SetPVCSelector(pvc *corev1.PersistentVolumeClaim, selector *metav1.LabelSelector) {
+	pvc.Spec.Selector = selector
+}
+
+// SetPVCVolumeName sets the bound volume name for the claim.
+func SetPVCVolumeName(pvc *corev1.PersistentVolumeClaim, volumeName string) {
+	pvc.Spec.VolumeName = volumeName
+}
+
+// SetPVCDataSource sets the data source for the claim.
+func SetPVCDataSource(pvc *corev1.PersistentVolumeClaim, src *corev1.TypedLocalObjectReference) {
+	pvc.Spec.DataSource = src
+}
+
+// SetPVCDataSourceRef sets the data source reference for the claim.
+func SetPVCDataSourceRef(pvc *corev1.PersistentVolumeClaim, src *corev1.TypedObjectReference) {
+	pvc.Spec.DataSourceRef = src
+}

--- a/internal/k8s/persistentvolumeclaim_test.go
+++ b/internal/k8s/persistentvolumeclaim_test.go
@@ -1,0 +1,88 @@
+package k8s
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCreatePersistentVolumeClaim(t *testing.T) {
+	pvc := CreatePersistentVolumeClaim("data", "ns")
+
+	if pvc.Name != "data" {
+		t.Errorf("expected name data got %s", pvc.Name)
+	}
+	if pvc.Namespace != "ns" {
+		t.Errorf("expected namespace ns got %s", pvc.Namespace)
+	}
+	if pvc.Kind != "PersistentVolumeClaim" {
+		t.Errorf("unexpected kind %q", pvc.Kind)
+	}
+	if len(pvc.Spec.AccessModes) != 0 {
+		t.Errorf("expected no access modes")
+	}
+	if pvc.Spec.VolumeMode == nil || *pvc.Spec.VolumeMode != corev1.PersistentVolumeFilesystem {
+		t.Errorf("unexpected volume mode")
+	}
+	exp := resource.MustParse("1Gi")
+	req := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	if req.Cmp(exp) != 0 {
+		t.Errorf("unexpected storage request %v", pvc.Spec.Resources.Requests)
+	}
+}
+
+func TestPersistentVolumeClaimFunctions(t *testing.T) {
+	pvc := CreatePersistentVolumeClaim("data", "ns")
+
+	AddPVCAccessMode(pvc, corev1.ReadWriteOnce)
+	if len(pvc.Spec.AccessModes) != 1 || pvc.Spec.AccessModes[0] != corev1.ReadWriteOnce {
+		t.Errorf("access mode not added")
+	}
+
+	SetPVCStorageClassName(pvc, "fast")
+	if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName != "fast" {
+		t.Errorf("storage class name not set")
+	}
+
+	SetPVCVolumeMode(pvc, corev1.PersistentVolumeBlock)
+	if pvc.Spec.VolumeMode == nil || *pvc.Spec.VolumeMode != corev1.PersistentVolumeBlock {
+		t.Errorf("volume mode not updated")
+	}
+
+	res := corev1.VolumeResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceStorage: resource.MustParse("2Gi"),
+		},
+	}
+	SetPVCResources(pvc, res)
+	req := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	if req.Cmp(res.Requests[corev1.ResourceStorage]) != 0 {
+		t.Errorf("resources not set")
+	}
+
+	sel := &metav1.LabelSelector{MatchLabels: map[string]string{"app": "data"}}
+	SetPVCSelector(pvc, sel)
+	if pvc.Spec.Selector == nil || !reflect.DeepEqual(pvc.Spec.Selector, sel) {
+		t.Errorf("selector not set")
+	}
+
+	SetPVCVolumeName(pvc, "pv1")
+	if pvc.Spec.VolumeName != "pv1" {
+		t.Errorf("volume name not set")
+	}
+
+	ds := &corev1.TypedLocalObjectReference{Kind: "PersistentVolumeClaim", Name: "source"}
+	SetPVCDataSource(pvc, ds)
+	if pvc.Spec.DataSource != ds {
+		t.Errorf("data source not set")
+	}
+
+	dor := &corev1.TypedObjectReference{Kind: "VolumeSnapshot", Name: "snap"}
+	SetPVCDataSourceRef(pvc, dor)
+	if pvc.Spec.DataSourceRef != dor {
+		t.Errorf("data source ref not set")
+	}
+}


### PR DESCRIPTION
## Summary
- add helper functions for PersistentVolumeClaim objects in `internal/k8s`
- provide comprehensive unit tests for the PVC helpers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6877b1247ba0832fbe1b9ae59b68b6e3