### PR TITLE
Add ConfigMap creation helpers

### DIFF
--- a/internal/k8s/configmap.go
+++ b/internal/k8s/configmap.go
@@ -1,0 +1,80 @@
+package k8s
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateConfigMap returns a basic ConfigMap object with common metadata preset.
+func CreateConfigMap(name, namespace string) *corev1.ConfigMap {
+	obj := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": name,
+			},
+			Annotations: map[string]string{
+				"app": name,
+			},
+		},
+		Data:       map[string]string{},
+		BinaryData: map[string][]byte{},
+	}
+	return obj
+}
+
+// AddConfigMapData inserts a single key/value pair into the ConfigMap's Data field.
+func AddConfigMapData(cm *corev1.ConfigMap, key, value string) {
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data[key] = value
+}
+
+// AddConfigMapDataMap merges all entries from the provided map into the ConfigMap's Data field.
+func AddConfigMapDataMap(cm *corev1.ConfigMap, data map[string]string) {
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	for k, v := range data {
+		cm.Data[k] = v
+	}
+}
+
+// AddConfigMapBinaryData inserts a single binary entry into the ConfigMap.
+func AddConfigMapBinaryData(cm *corev1.ConfigMap, key string, value []byte) {
+	if cm.BinaryData == nil {
+		cm.BinaryData = make(map[string][]byte)
+	}
+	cm.BinaryData[key] = value
+}
+
+// AddConfigMapBinaryDataMap merges all binary entries into the ConfigMap's BinaryData field.
+func AddConfigMapBinaryDataMap(cm *corev1.ConfigMap, data map[string][]byte) {
+	if cm.BinaryData == nil {
+		cm.BinaryData = make(map[string][]byte)
+	}
+	for k, v := range data {
+		cm.BinaryData[k] = v
+	}
+}
+
+// SetConfigMapData replaces the ConfigMap's Data map entirely.
+func SetConfigMapData(cm *corev1.ConfigMap, data map[string]string) {
+	cm.Data = data
+}
+
+// SetConfigMapBinaryData replaces the ConfigMap's BinaryData map entirely.
+func SetConfigMapBinaryData(cm *corev1.ConfigMap, data map[string][]byte) {
+	cm.BinaryData = data
+}
+
+// SetConfigMapImmutable sets the immutable field for the ConfigMap.
+func SetConfigMapImmutable(cm *corev1.ConfigMap, immutable bool) {
+	cm.Immutable = &immutable
+}

--- a/internal/k8s/configmap_test.go
+++ b/internal/k8s/configmap_test.go
@@ -1,0 +1,80 @@
+package k8s
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCreateConfigMap(t *testing.T) {
+	cm := CreateConfigMap("cm", "ns")
+	if cm.Name != "cm" || cm.Namespace != "ns" {
+		t.Fatalf("metadata mismatch: %s/%s", cm.Namespace, cm.Name)
+	}
+	if cm.Kind != "ConfigMap" {
+		t.Errorf("unexpected kind %q", cm.Kind)
+	}
+	if len(cm.Data) != 0 {
+		t.Errorf("expected empty data map")
+	}
+	if len(cm.BinaryData) != 0 {
+		t.Errorf("expected empty binary data map")
+	}
+}
+
+func TestConfigMapDataFunctions(t *testing.T) {
+	cm := CreateConfigMap("cm", "ns")
+
+	AddConfigMapData(cm, "k", "v")
+	if val, ok := cm.Data["k"]; !ok || val != "v" {
+		t.Errorf("data not added: %+v", cm.Data)
+	}
+
+	more := map[string]string{"a": "b", "c": "d"}
+	AddConfigMapDataMap(cm, more)
+	for k, v := range more {
+		if cm.Data[k] != v {
+			t.Errorf("data map merge failed for key %s", k)
+		}
+	}
+
+	newData := map[string]string{"x": "y"}
+	SetConfigMapData(cm, newData)
+	if !reflect.DeepEqual(cm.Data, newData) {
+		t.Errorf("set data failed: %+v", cm.Data)
+	}
+}
+
+func TestConfigMapBinaryDataFunctions(t *testing.T) {
+	cm := CreateConfigMap("cm", "ns")
+
+	AddConfigMapBinaryData(cm, "bin", []byte{1})
+	if val, ok := cm.BinaryData["bin"]; !ok || !reflect.DeepEqual(val, []byte{1}) {
+		t.Errorf("binary data not added: %+v", cm.BinaryData)
+	}
+
+	more := map[string][]byte{"b1": {2, 3}, "b2": {4}}
+	AddConfigMapBinaryDataMap(cm, more)
+	for k, v := range more {
+		if !reflect.DeepEqual(cm.BinaryData[k], v) {
+			t.Errorf("binary data map merge failed for key %s", k)
+		}
+	}
+
+	newData := map[string][]byte{"x": {9}}
+	SetConfigMapBinaryData(cm, newData)
+	if !reflect.DeepEqual(cm.BinaryData, newData) {
+		t.Errorf("set binary data failed: %+v", cm.BinaryData)
+	}
+}
+
+func TestSetConfigMapImmutable(t *testing.T) {
+	cm := CreateConfigMap("cm", "ns")
+	SetConfigMapImmutable(cm, true)
+	if cm.Immutable == nil || !*cm.Immutable {
+		t.Errorf("immutable not set to true")
+	}
+	SetConfigMapImmutable(cm, false)
+	if cm.Immutable == nil || *cm.Immutable {
+		t.Errorf("immutable not updated to false")
+	}
+}


### PR DESCRIPTION
## Summary
- add `configmap.go` with functions to create and update ConfigMap objects in k8s package
- add unit tests for new ConfigMap helpers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6877b13067bc832f97ab691478fea245