### PR TITLE
Add helpers for StatefulSet and DaemonSet objects

### DIFF
--- a/internal/k8s/daemonset.go
+++ b/internal/k8s/daemonset.go
@@ -1,0 +1,106 @@
+package k8s
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateDaemonSet returns a DaemonSet with sane defaults.
+func CreateDaemonSet(name, namespace string) *appsv1.DaemonSet {
+	obj := &appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DaemonSet",
+			APIVersion: appsv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": name,
+			},
+			Annotations: map[string]string{
+				"app": name,
+			},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
+				Spec: corev1.PodSpec{
+					Containers:                    []corev1.Container{},
+					InitContainers:                []corev1.Container{},
+					Volumes:                       []corev1.Volume{},
+					RestartPolicy:                 corev1.RestartPolicyAlways,
+					TerminationGracePeriodSeconds: new(int64),
+					SecurityContext:               &corev1.PodSecurityContext{},
+					ImagePullSecrets:              []corev1.LocalObjectReference{},
+					ServiceAccountName:            "",
+					NodeSelector:                  map[string]string{},
+					Affinity:                      &corev1.Affinity{},
+					Tolerations:                   []corev1.Toleration{},
+				},
+			},
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{},
+		},
+	}
+	return obj
+}
+
+// AddDaemonSetContainer appends a container to the DaemonSet pod template.
+func AddDaemonSetContainer(ds *appsv1.DaemonSet, c *corev1.Container) {
+	ds.Spec.Template.Spec.Containers = append(ds.Spec.Template.Spec.Containers, *c)
+}
+
+// AddDaemonSetInitContainer appends an init container to the pod template.
+func AddDaemonSetInitContainer(ds *appsv1.DaemonSet, c *corev1.Container) {
+	ds.Spec.Template.Spec.InitContainers = append(ds.Spec.Template.Spec.InitContainers, *c)
+}
+
+// AddDaemonSetVolume appends a volume to the pod template.
+func AddDaemonSetVolume(ds *appsv1.DaemonSet, v *corev1.Volume) {
+	ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes, *v)
+}
+
+// AddDaemonSetImagePullSecret appends an image pull secret to the pod template.
+func AddDaemonSetImagePullSecret(ds *appsv1.DaemonSet, s *corev1.LocalObjectReference) {
+	ds.Spec.Template.Spec.ImagePullSecrets = append(ds.Spec.Template.Spec.ImagePullSecrets, *s)
+}
+
+// AddDaemonSetToleration appends a toleration to the pod template.
+func AddDaemonSetToleration(ds *appsv1.DaemonSet, t *corev1.Toleration) {
+	ds.Spec.Template.Spec.Tolerations = append(ds.Spec.Template.Spec.Tolerations, *t)
+}
+
+// AddDaemonSetTopologySpreadConstraints appends a topology spread constraint if not nil.
+func AddDaemonSetTopologySpreadConstraints(ds *appsv1.DaemonSet, c *corev1.TopologySpreadConstraint) {
+	if c == nil {
+		return
+	}
+	ds.Spec.Template.Spec.TopologySpreadConstraints = append(ds.Spec.Template.Spec.TopologySpreadConstraints, *c)
+}
+
+// SetDaemonSetServiceAccountName sets the service account name.
+func SetDaemonSetServiceAccountName(ds *appsv1.DaemonSet, name string) {
+	ds.Spec.Template.Spec.ServiceAccountName = name
+}
+
+// SetDaemonSetSecurityContext sets the pod security context.
+func SetDaemonSetSecurityContext(ds *appsv1.DaemonSet, sc *corev1.PodSecurityContext) {
+	ds.Spec.Template.Spec.SecurityContext = sc
+}
+
+// SetDaemonSetAffinity sets the pod affinity rules.
+func SetDaemonSetAffinity(ds *appsv1.DaemonSet, aff *corev1.Affinity) {
+	ds.Spec.Template.Spec.Affinity = aff
+}
+
+// SetDaemonSetNodeSelector sets the node selector.
+func SetDaemonSetNodeSelector(ds *appsv1.DaemonSet, ns map[string]string) {
+	ds.Spec.Template.Spec.NodeSelector = ns
+}
+
+// SetDaemonSetUpdateStrategy sets the update strategy.
+func SetDaemonSetUpdateStrategy(ds *appsv1.DaemonSet, strat appsv1.DaemonSetUpdateStrategy) {
+	ds.Spec.UpdateStrategy = strat
+}

--- a/internal/k8s/daemonset_test.go
+++ b/internal/k8s/daemonset_test.go
@@ -1,0 +1,139 @@
+package k8s
+
+import (
+	"reflect"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAddDaemonSetTopologySpreadConstraints(t *testing.T) {
+	t.Run("nil constraint", func(t *testing.T) {
+		ds := CreateDaemonSet("test", "default")
+		AddDaemonSetTopologySpreadConstraints(ds, nil)
+		if len(ds.Spec.Template.Spec.TopologySpreadConstraints) != 0 {
+			t.Errorf("expected no constraints, got %d", len(ds.Spec.Template.Spec.TopologySpreadConstraints))
+		}
+	})
+
+	t.Run("append single constraint", func(t *testing.T) {
+		ds := CreateDaemonSet("test", "default")
+		c := corev1.TopologySpreadConstraint{
+			MaxSkew:           1,
+			TopologyKey:       "zone",
+			WhenUnsatisfiable: corev1.DoNotSchedule,
+			LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+		}
+		AddDaemonSetTopologySpreadConstraints(ds, &c)
+		if len(ds.Spec.Template.Spec.TopologySpreadConstraints) != 1 {
+			t.Fatalf("expected 1 constraint, got %d", len(ds.Spec.Template.Spec.TopologySpreadConstraints))
+		}
+		if !reflect.DeepEqual(ds.Spec.Template.Spec.TopologySpreadConstraints[0], c) {
+			t.Errorf("constraint mismatch: got %+v, want %+v", ds.Spec.Template.Spec.TopologySpreadConstraints[0], c)
+		}
+	})
+
+	t.Run("append additional constraint", func(t *testing.T) {
+		ds := CreateDaemonSet("test", "default")
+		first := corev1.TopologySpreadConstraint{
+			MaxSkew:           1,
+			TopologyKey:       "zone",
+			WhenUnsatisfiable: corev1.DoNotSchedule,
+			LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+		}
+		second := corev1.TopologySpreadConstraint{
+			MaxSkew:           2,
+			TopologyKey:       "hostname",
+			WhenUnsatisfiable: corev1.DoNotSchedule,
+			LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+		}
+		AddDaemonSetTopologySpreadConstraints(ds, &first)
+		AddDaemonSetTopologySpreadConstraints(ds, &second)
+		if len(ds.Spec.Template.Spec.TopologySpreadConstraints) != 2 {
+			t.Fatalf("expected 2 constraints, got %d", len(ds.Spec.Template.Spec.TopologySpreadConstraints))
+		}
+		if !reflect.DeepEqual(ds.Spec.Template.Spec.TopologySpreadConstraints[0], first) {
+			t.Errorf("first constraint mismatch")
+		}
+		if !reflect.DeepEqual(ds.Spec.Template.Spec.TopologySpreadConstraints[1], second) {
+			t.Errorf("second constraint mismatch")
+		}
+	})
+}
+
+func TestDaemonSetFunctions(t *testing.T) {
+	ds := CreateDaemonSet("app", "ns")
+	if ds.Name != "app" || ds.Namespace != "ns" {
+		t.Fatalf("metadata mismatch: %s/%s", ds.Namespace, ds.Name)
+	}
+	if ds.Kind != "DaemonSet" {
+		t.Errorf("unexpected kind %q", ds.Kind)
+	}
+
+	c := corev1.Container{Name: "c"}
+	AddDaemonSetContainer(ds, &c)
+	if len(ds.Spec.Template.Spec.Containers) != 1 || ds.Spec.Template.Spec.Containers[0].Name != "c" {
+		t.Errorf("container not added")
+	}
+
+	ic := corev1.Container{Name: "init"}
+	AddDaemonSetInitContainer(ds, &ic)
+	if len(ds.Spec.Template.Spec.InitContainers) != 1 {
+		t.Errorf("init container not added")
+	}
+
+	v := corev1.Volume{Name: "vol"}
+	AddDaemonSetVolume(ds, &v)
+	if len(ds.Spec.Template.Spec.Volumes) != 1 {
+		t.Errorf("volume not added")
+	}
+
+	secret := corev1.LocalObjectReference{Name: "secret"}
+	AddDaemonSetImagePullSecret(ds, &secret)
+	if len(ds.Spec.Template.Spec.ImagePullSecrets) != 1 {
+		t.Errorf("image pull secret not added")
+	}
+
+	tol := corev1.Toleration{Key: "k"}
+	AddDaemonSetToleration(ds, &tol)
+	if len(ds.Spec.Template.Spec.Tolerations) != 1 {
+		t.Errorf("toleration not added")
+	}
+
+	tsc := corev1.TopologySpreadConstraint{MaxSkew: 1, TopologyKey: "zone", WhenUnsatisfiable: corev1.ScheduleAnyway, LabelSelector: &metav1.LabelSelector{}}
+	AddDaemonSetTopologySpreadConstraints(ds, &tsc)
+	if len(ds.Spec.Template.Spec.TopologySpreadConstraints) != 1 {
+		t.Errorf("topology constraint not added")
+	}
+
+	SetDaemonSetServiceAccountName(ds, "sa")
+	if ds.Spec.Template.Spec.ServiceAccountName != "sa" {
+		t.Errorf("service account name not set")
+	}
+
+	sc := &corev1.PodSecurityContext{}
+	SetDaemonSetSecurityContext(ds, sc)
+	if ds.Spec.Template.Spec.SecurityContext != sc {
+		t.Errorf("security context not set")
+	}
+
+	aff := &corev1.Affinity{}
+	SetDaemonSetAffinity(ds, aff)
+	if ds.Spec.Template.Spec.Affinity != aff {
+		t.Errorf("affinity not set")
+	}
+
+	ns := map[string]string{"role": "db"}
+	SetDaemonSetNodeSelector(ds, ns)
+	if !reflect.DeepEqual(ds.Spec.Template.Spec.NodeSelector, ns) {
+		t.Errorf("node selector not set")
+	}
+
+	strat := appsv1.DaemonSetUpdateStrategy{Type: appsv1.RollingUpdateDaemonSetStrategyType}
+	SetDaemonSetUpdateStrategy(ds, strat)
+	if ds.Spec.UpdateStrategy.Type != appsv1.RollingUpdateDaemonSetStrategyType {
+		t.Errorf("update strategy not set")
+	}
+}

--- a/internal/k8s/statefulset.go
+++ b/internal/k8s/statefulset.go
@@ -1,0 +1,133 @@
+package k8s
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateStatefulSet returns a StatefulSet with sensible defaults set.
+func CreateStatefulSet(name, namespace string) *appsv1.StatefulSet {
+	obj := &appsv1.StatefulSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "StatefulSet",
+			APIVersion: appsv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": name,
+			},
+			Annotations: map[string]string{
+				"app": name,
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: new(int32),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
+				Spec: corev1.PodSpec{
+					Containers:                    []corev1.Container{},
+					InitContainers:                []corev1.Container{},
+					Volumes:                       []corev1.Volume{},
+					RestartPolicy:                 corev1.RestartPolicyAlways,
+					TerminationGracePeriodSeconds: new(int64),
+					SecurityContext:               &corev1.PodSecurityContext{},
+					ImagePullSecrets:              []corev1.LocalObjectReference{},
+					ServiceAccountName:            "",
+					NodeSelector:                  map[string]string{},
+					Affinity:                      &corev1.Affinity{},
+					Tolerations:                   []corev1.Toleration{},
+				},
+			},
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{},
+			ServiceName:          "",
+			PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+			UpdateStrategy:       appsv1.StatefulSetUpdateStrategy{},
+		},
+	}
+	return obj
+}
+
+// AddStatefulSetContainer appends a container to the StatefulSet pod template.
+func AddStatefulSetContainer(sts *appsv1.StatefulSet, c *corev1.Container) {
+	sts.Spec.Template.Spec.Containers = append(sts.Spec.Template.Spec.Containers, *c)
+}
+
+// AddStatefulSetInitContainer appends an init container to the pod template.
+func AddStatefulSetInitContainer(sts *appsv1.StatefulSet, c *corev1.Container) {
+	sts.Spec.Template.Spec.InitContainers = append(sts.Spec.Template.Spec.InitContainers, *c)
+}
+
+// AddStatefulSetVolume appends a volume to the pod template.
+func AddStatefulSetVolume(sts *appsv1.StatefulSet, v *corev1.Volume) {
+	sts.Spec.Template.Spec.Volumes = append(sts.Spec.Template.Spec.Volumes, *v)
+}
+
+// AddStatefulSetImagePullSecret appends an image pull secret to the pod template.
+func AddStatefulSetImagePullSecret(sts *appsv1.StatefulSet, s *corev1.LocalObjectReference) {
+	sts.Spec.Template.Spec.ImagePullSecrets = append(sts.Spec.Template.Spec.ImagePullSecrets, *s)
+}
+
+// AddStatefulSetToleration appends a toleration to the pod template.
+func AddStatefulSetToleration(sts *appsv1.StatefulSet, t *corev1.Toleration) {
+	sts.Spec.Template.Spec.Tolerations = append(sts.Spec.Template.Spec.Tolerations, *t)
+}
+
+// AddStatefulSetTopologySpreadConstraints appends a topology spread constraint if not nil.
+func AddStatefulSetTopologySpreadConstraints(sts *appsv1.StatefulSet, c *corev1.TopologySpreadConstraint) {
+	if c == nil {
+		return
+	}
+	sts.Spec.Template.Spec.TopologySpreadConstraints = append(sts.Spec.Template.Spec.TopologySpreadConstraints, *c)
+}
+
+// AddStatefulSetVolumeClaimTemplate appends a PVC template to the StatefulSet.
+func AddStatefulSetVolumeClaimTemplate(sts *appsv1.StatefulSet, pvc corev1.PersistentVolumeClaim) {
+	sts.Spec.VolumeClaimTemplates = append(sts.Spec.VolumeClaimTemplates, pvc)
+}
+
+// SetStatefulSetServiceAccountName sets the service account name for the pod template.
+func SetStatefulSetServiceAccountName(sts *appsv1.StatefulSet, name string) {
+	sts.Spec.Template.Spec.ServiceAccountName = name
+}
+
+// SetStatefulSetSecurityContext sets the pod security context.
+func SetStatefulSetSecurityContext(sts *appsv1.StatefulSet, sc *corev1.PodSecurityContext) {
+	sts.Spec.Template.Spec.SecurityContext = sc
+}
+
+// SetStatefulSetAffinity sets the pod affinity rules.
+func SetStatefulSetAffinity(sts *appsv1.StatefulSet, aff *corev1.Affinity) {
+	sts.Spec.Template.Spec.Affinity = aff
+}
+
+// SetStatefulSetNodeSelector sets the node selector.
+func SetStatefulSetNodeSelector(sts *appsv1.StatefulSet, ns map[string]string) {
+	sts.Spec.Template.Spec.NodeSelector = ns
+}
+
+// SetStatefulSetUpdateStrategy sets the update strategy for the StatefulSet.
+func SetStatefulSetUpdateStrategy(sts *appsv1.StatefulSet, strat appsv1.StatefulSetUpdateStrategy) {
+	sts.Spec.UpdateStrategy = strat
+}
+
+// SetStatefulSetReplicas sets the replica count.
+func SetStatefulSetReplicas(sts *appsv1.StatefulSet, replicas int32) {
+	if sts.Spec.Replicas == nil {
+		sts.Spec.Replicas = new(int32)
+	}
+	*sts.Spec.Replicas = replicas
+}
+
+// SetStatefulSetServiceName sets the service name used by the StatefulSet.
+func SetStatefulSetServiceName(sts *appsv1.StatefulSet, svc string) {
+	sts.Spec.ServiceName = svc
+}
+
+// SetStatefulSetPodManagementPolicy sets the pod management policy.
+func SetStatefulSetPodManagementPolicy(sts *appsv1.StatefulSet, policy appsv1.PodManagementPolicyType) {
+	sts.Spec.PodManagementPolicy = policy
+}

--- a/internal/k8s/statefulset_test.go
+++ b/internal/k8s/statefulset_test.go
@@ -1,0 +1,160 @@
+package k8s
+
+import (
+	"reflect"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAddStatefulSetTopologySpreadConstraints(t *testing.T) {
+	t.Run("nil constraint", func(t *testing.T) {
+		sts := CreateStatefulSet("test", "default")
+		AddStatefulSetTopologySpreadConstraints(sts, nil)
+		if len(sts.Spec.Template.Spec.TopologySpreadConstraints) != 0 {
+			t.Errorf("expected no constraints, got %d", len(sts.Spec.Template.Spec.TopologySpreadConstraints))
+		}
+	})
+
+	t.Run("append single constraint", func(t *testing.T) {
+		sts := CreateStatefulSet("test", "default")
+		c := corev1.TopologySpreadConstraint{
+			MaxSkew:           1,
+			TopologyKey:       "zone",
+			WhenUnsatisfiable: corev1.DoNotSchedule,
+			LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+		}
+		AddStatefulSetTopologySpreadConstraints(sts, &c)
+		if len(sts.Spec.Template.Spec.TopologySpreadConstraints) != 1 {
+			t.Fatalf("expected 1 constraint, got %d", len(sts.Spec.Template.Spec.TopologySpreadConstraints))
+		}
+		if !reflect.DeepEqual(sts.Spec.Template.Spec.TopologySpreadConstraints[0], c) {
+			t.Errorf("constraint mismatch: got %+v, want %+v", sts.Spec.Template.Spec.TopologySpreadConstraints[0], c)
+		}
+	})
+
+	t.Run("append additional constraint", func(t *testing.T) {
+		sts := CreateStatefulSet("test", "default")
+		first := corev1.TopologySpreadConstraint{
+			MaxSkew:           1,
+			TopologyKey:       "zone",
+			WhenUnsatisfiable: corev1.DoNotSchedule,
+			LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+		}
+		second := corev1.TopologySpreadConstraint{
+			MaxSkew:           2,
+			TopologyKey:       "hostname",
+			WhenUnsatisfiable: corev1.DoNotSchedule,
+			LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+		}
+		AddStatefulSetTopologySpreadConstraints(sts, &first)
+		AddStatefulSetTopologySpreadConstraints(sts, &second)
+		if len(sts.Spec.Template.Spec.TopologySpreadConstraints) != 2 {
+			t.Fatalf("expected 2 constraints, got %d", len(sts.Spec.Template.Spec.TopologySpreadConstraints))
+		}
+		if !reflect.DeepEqual(sts.Spec.Template.Spec.TopologySpreadConstraints[0], first) {
+			t.Errorf("first constraint mismatch")
+		}
+		if !reflect.DeepEqual(sts.Spec.Template.Spec.TopologySpreadConstraints[1], second) {
+			t.Errorf("second constraint mismatch")
+		}
+	})
+}
+
+func TestStatefulSetFunctions(t *testing.T) {
+	sts := CreateStatefulSet("app", "ns")
+	if sts.Name != "app" || sts.Namespace != "ns" {
+		t.Fatalf("metadata mismatch: %s/%s", sts.Namespace, sts.Name)
+	}
+	if sts.Kind != "StatefulSet" {
+		t.Errorf("unexpected kind %q", sts.Kind)
+	}
+
+	c := corev1.Container{Name: "c"}
+	AddStatefulSetContainer(sts, &c)
+	if len(sts.Spec.Template.Spec.Containers) != 1 || sts.Spec.Template.Spec.Containers[0].Name != "c" {
+		t.Errorf("container not added")
+	}
+
+	ic := corev1.Container{Name: "init"}
+	AddStatefulSetInitContainer(sts, &ic)
+	if len(sts.Spec.Template.Spec.InitContainers) != 1 {
+		t.Errorf("init container not added")
+	}
+
+	v := corev1.Volume{Name: "vol"}
+	AddStatefulSetVolume(sts, &v)
+	if len(sts.Spec.Template.Spec.Volumes) != 1 {
+		t.Errorf("volume not added")
+	}
+
+	secret := corev1.LocalObjectReference{Name: "secret"}
+	AddStatefulSetImagePullSecret(sts, &secret)
+	if len(sts.Spec.Template.Spec.ImagePullSecrets) != 1 {
+		t.Errorf("image pull secret not added")
+	}
+
+	tol := corev1.Toleration{Key: "k"}
+	AddStatefulSetToleration(sts, &tol)
+	if len(sts.Spec.Template.Spec.Tolerations) != 1 {
+		t.Errorf("toleration not added")
+	}
+
+	tsc := corev1.TopologySpreadConstraint{MaxSkew: 1, TopologyKey: "zone", WhenUnsatisfiable: corev1.ScheduleAnyway, LabelSelector: &metav1.LabelSelector{}}
+	AddStatefulSetTopologySpreadConstraints(sts, &tsc)
+	if len(sts.Spec.Template.Spec.TopologySpreadConstraints) != 1 {
+		t.Errorf("topology constraint not added")
+	}
+
+	pvc := corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "data"}}
+	AddStatefulSetVolumeClaimTemplate(sts, pvc)
+	if len(sts.Spec.VolumeClaimTemplates) != 1 {
+		t.Errorf("volume claim template not added")
+	}
+
+	SetStatefulSetServiceAccountName(sts, "sa")
+	if sts.Spec.Template.Spec.ServiceAccountName != "sa" {
+		t.Errorf("service account name not set")
+	}
+
+	sc := &corev1.PodSecurityContext{}
+	SetStatefulSetSecurityContext(sts, sc)
+	if sts.Spec.Template.Spec.SecurityContext != sc {
+		t.Errorf("security context not set")
+	}
+
+	aff := &corev1.Affinity{}
+	SetStatefulSetAffinity(sts, aff)
+	if sts.Spec.Template.Spec.Affinity != aff {
+		t.Errorf("affinity not set")
+	}
+
+	ns := map[string]string{"role": "db"}
+	SetStatefulSetNodeSelector(sts, ns)
+	if !reflect.DeepEqual(sts.Spec.Template.Spec.NodeSelector, ns) {
+		t.Errorf("node selector not set")
+	}
+
+	strat := appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType}
+	SetStatefulSetUpdateStrategy(sts, strat)
+	if sts.Spec.UpdateStrategy.Type != appsv1.RollingUpdateStatefulSetStrategyType {
+		t.Errorf("update strategy not set")
+	}
+
+	SetStatefulSetReplicas(sts, 3)
+	if sts.Spec.Replicas == nil || *sts.Spec.Replicas != 3 {
+		t.Errorf("replicas not set")
+	}
+
+	SetStatefulSetServiceName(sts, "svc")
+	if sts.Spec.ServiceName != "svc" {
+		t.Errorf("service name not set")
+	}
+
+	SetStatefulSetPodManagementPolicy(sts, appsv1.ParallelPodManagement)
+	if sts.Spec.PodManagementPolicy != appsv1.ParallelPodManagement {
+		t.Errorf("pod management policy not set")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -109,6 +109,26 @@ func main() {
 	k8s.SetDeploymentAffinity(dep, &apiv1.Affinity{})
 	k8s.SetDeploymentNodeSelector(dep, map[string]string{"role": "web"})
 
+	// StatefulSet example
+	sts := k8s.CreateStatefulSet("demo-sts", "demo")
+	k8s.AddStatefulSetContainer(sts, mainCtr)
+	k8s.AddStatefulSetInitContainer(sts, initCtr)
+	k8s.AddStatefulSetVolume(sts, &apiv1.Volume{Name: "data"})
+	k8s.AddStatefulSetVolumeClaimTemplate(sts, *k8s.CreatePersistentVolumeClaim("data", "demo"))
+	k8s.AddStatefulSetToleration(sts, &apiv1.Toleration{Key: "role"})
+	k8s.SetStatefulSetServiceAccountName(sts, sa.Name)
+	k8s.SetStatefulSetServiceName(sts, "demo-svc")
+	k8s.SetStatefulSetReplicas(sts, 3)
+
+	// DaemonSet example
+	ds := k8s.CreateDaemonSet("demo-ds", "demo")
+	k8s.AddDaemonSetContainer(ds, mainCtr)
+	k8s.AddDaemonSetInitContainer(ds, initCtr)
+	k8s.AddDaemonSetVolume(ds, &apiv1.Volume{Name: "data"})
+	k8s.AddDaemonSetToleration(ds, &apiv1.Toleration{Key: "role"})
+	k8s.SetDaemonSetServiceAccountName(ds, sa.Name)
+	k8s.SetDaemonSetNodeSelector(ds, map[string]string{"type": "worker"})
+
 	// Service and ingress example
 	svc := k8s.CreateService("demo-svc", "demo")
 	k8s.SetServiceSelector(svc, map[string]string{"app": "demo"})
@@ -132,6 +152,8 @@ func main() {
 	y.PrintObj(pvc, os.Stdout)
 	y.PrintObj(pod, os.Stdout)
 	y.PrintObj(dep, os.Stdout)
+	y.PrintObj(sts, os.Stdout)
+	y.PrintObj(ds, os.Stdout)
 	y.PrintObj(svc, os.Stdout)
 	y.PrintObj(ing, os.Stdout)
 }


### PR DESCRIPTION
## Summary
- add Kubernetes helpers for creating and modifying StatefulSet objects
- add Kubernetes helpers for creating and modifying DaemonSet objects
- add corresponding tests
- demonstrate new helpers in main example

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6877c1450f24832f8777f6b45b80c661