### PR TITLE
Add storageclass helpers

### DIFF
--- a/internal/k8s/storageclass.go
+++ b/internal/k8s/storageclass.go
@@ -1,0 +1,120 @@
+package k8s
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateStorageClass returns a StorageClass object with sane defaults.
+func CreateStorageClass(name string, provisioner string) *storagev1.StorageClass {
+	policy := corev1.PersistentVolumeReclaimDelete
+	binding := storagev1.VolumeBindingImmediate
+	obj := &storagev1.StorageClass{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "StorageClass",
+			APIVersion: storagev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"app": name,
+			},
+			Annotations: map[string]string{
+				"app": name,
+			},
+		},
+		Provisioner:          provisioner,
+		Parameters:           map[string]string{},
+		MountOptions:         []string{},
+		ReclaimPolicy:        &policy,
+		AllowVolumeExpansion: new(bool),
+		VolumeBindingMode:    &binding,
+		AllowedTopologies:    []corev1.TopologySelectorTerm{},
+	}
+	return obj
+}
+
+// AddStorageClassParameter inserts a single parameter into the StorageClass.
+func AddStorageClassParameter(sc *storagev1.StorageClass, key, value string) {
+	if sc.Parameters == nil {
+		sc.Parameters = make(map[string]string)
+	}
+	sc.Parameters[key] = value
+}
+
+// AddStorageClassParameters merges the provided parameters into the StorageClass.
+func AddStorageClassParameters(sc *storagev1.StorageClass, params map[string]string) {
+	if sc.Parameters == nil {
+		sc.Parameters = make(map[string]string)
+	}
+	for k, v := range params {
+		sc.Parameters[k] = v
+	}
+}
+
+// SetStorageClassParameters replaces the parameters map entirely.
+func SetStorageClassParameters(sc *storagev1.StorageClass, params map[string]string) {
+	sc.Parameters = params
+}
+
+// AddStorageClassMountOption appends a mount option to the StorageClass.
+func AddStorageClassMountOption(sc *storagev1.StorageClass, option string) {
+	sc.MountOptions = append(sc.MountOptions, option)
+}
+
+// AddStorageClassMountOptions appends multiple mount options to the StorageClass.
+func AddStorageClassMountOptions(sc *storagev1.StorageClass, options []string) {
+	sc.MountOptions = append(sc.MountOptions, options...)
+}
+
+// SetStorageClassMountOptions replaces all mount options.
+func SetStorageClassMountOptions(sc *storagev1.StorageClass, options []string) {
+	sc.MountOptions = options
+}
+
+// SetStorageClassProvisioner sets the provisioner field.
+func SetStorageClassProvisioner(sc *storagev1.StorageClass, provisioner string) {
+	sc.Provisioner = provisioner
+}
+
+// SetStorageClassReclaimPolicy sets the reclaim policy.
+func SetStorageClassReclaimPolicy(sc *storagev1.StorageClass, policy corev1.PersistentVolumeReclaimPolicy) {
+	sc.ReclaimPolicy = &policy
+}
+
+// SetStorageClassAllowVolumeExpansion sets the allowVolumeExpansion field.
+func SetStorageClassAllowVolumeExpansion(sc *storagev1.StorageClass, allow bool) {
+	if sc.AllowVolumeExpansion == nil {
+		sc.AllowVolumeExpansion = new(bool)
+	}
+	*sc.AllowVolumeExpansion = allow
+}
+
+// SetStorageClassVolumeBindingMode sets the volume binding mode.
+func SetStorageClassVolumeBindingMode(sc *storagev1.StorageClass, mode storagev1.VolumeBindingMode) {
+	sc.VolumeBindingMode = &mode
+}
+
+// AddStorageClassAllowedTopology appends an allowed topology term.
+func AddStorageClassAllowedTopology(sc *storagev1.StorageClass, topo corev1.TopologySelectorTerm) {
+	sc.AllowedTopologies = append(sc.AllowedTopologies, topo)
+}
+
+// AddStorageClassAllowedTopologies appends multiple allowed topology terms.
+func AddStorageClassAllowedTopologies(sc *storagev1.StorageClass, topos []corev1.TopologySelectorTerm) {
+	sc.AllowedTopologies = append(sc.AllowedTopologies, topos...)
+}
+
+// SetStorageClassAllowedTopologies replaces the allowed topologies slice.
+func SetStorageClassAllowedTopologies(sc *storagev1.StorageClass, topos []corev1.TopologySelectorTerm) {
+	sc.AllowedTopologies = topos
+}
+
+// SetPVCStorageClass sets the StorageClass for the claim by name.
+func SetPVCStorageClass(pvc *corev1.PersistentVolumeClaim, sc *storagev1.StorageClass) {
+	if sc == nil {
+		return
+	}
+	pvc.Spec.StorageClassName = &sc.Name
+}

--- a/internal/k8s/storageclass_test.go
+++ b/internal/k8s/storageclass_test.go
@@ -1,0 +1,120 @@
+package k8s
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+)
+
+func TestCreateStorageClass(t *testing.T) {
+	sc := CreateStorageClass("standard", "kubernetes.io/no-provisioner")
+
+	if sc.Name != "standard" {
+		t.Errorf("expected name standard got %s", sc.Name)
+	}
+	if sc.Provisioner != "kubernetes.io/no-provisioner" {
+		t.Errorf("unexpected provisioner %s", sc.Provisioner)
+	}
+	if sc.Kind != "StorageClass" {
+		t.Errorf("unexpected kind %q", sc.Kind)
+	}
+	if sc.ReclaimPolicy == nil || *sc.ReclaimPolicy != corev1.PersistentVolumeReclaimDelete {
+		t.Errorf("unexpected reclaim policy")
+	}
+	if sc.AllowVolumeExpansion == nil {
+		t.Errorf("expected allowVolumeExpansion pointer set")
+	}
+	if sc.VolumeBindingMode == nil || *sc.VolumeBindingMode != storagev1.VolumeBindingImmediate {
+		t.Errorf("unexpected volume binding mode")
+	}
+	if len(sc.Parameters) != 0 {
+		t.Errorf("expected no parameters")
+	}
+	if len(sc.MountOptions) != 0 {
+		t.Errorf("expected no mount options")
+	}
+	if len(sc.AllowedTopologies) != 0 {
+		t.Errorf("expected no allowed topologies")
+	}
+}
+
+func TestStorageClassFunctions(t *testing.T) {
+	sc := CreateStorageClass("standard", "prov")
+
+	AddStorageClassParameter(sc, "fstype", "xfs")
+	if sc.Parameters["fstype"] != "xfs" {
+		t.Errorf("parameter not added")
+	}
+
+	moreParams := map[string]string{"a": "b"}
+	AddStorageClassParameters(sc, moreParams)
+	for k, v := range moreParams {
+		if sc.Parameters[k] != v {
+			t.Errorf("parameter %s not merged", k)
+		}
+	}
+
+	SetStorageClassParameters(sc, map[string]string{"x": "y"})
+	if !reflect.DeepEqual(sc.Parameters, map[string]string{"x": "y"}) {
+		t.Errorf("parameters not set")
+	}
+
+	AddStorageClassMountOption(sc, "ro")
+	if sc.MountOptions[0] != "ro" {
+		t.Errorf("mount option not added")
+	}
+
+	AddStorageClassMountOptions(sc, []string{"sync"})
+	if !reflect.DeepEqual(sc.MountOptions, []string{"ro", "sync"}) {
+		t.Errorf("mount options not appended")
+	}
+
+	SetStorageClassMountOptions(sc, []string{"rw"})
+	if !reflect.DeepEqual(sc.MountOptions, []string{"rw"}) {
+		t.Errorf("mount options not set")
+	}
+
+	SetStorageClassProvisioner(sc, "other")
+	if sc.Provisioner != "other" {
+		t.Errorf("provisioner not set")
+	}
+
+	SetStorageClassReclaimPolicy(sc, corev1.PersistentVolumeReclaimRetain)
+	if sc.ReclaimPolicy == nil || *sc.ReclaimPolicy != corev1.PersistentVolumeReclaimRetain {
+		t.Errorf("reclaim policy not set")
+	}
+
+	SetStorageClassAllowVolumeExpansion(sc, true)
+	if sc.AllowVolumeExpansion == nil || !*sc.AllowVolumeExpansion {
+		t.Errorf("allow expansion not set")
+	}
+
+	SetStorageClassVolumeBindingMode(sc, storagev1.VolumeBindingWaitForFirstConsumer)
+	if sc.VolumeBindingMode == nil || *sc.VolumeBindingMode != storagev1.VolumeBindingWaitForFirstConsumer {
+		t.Errorf("binding mode not set")
+	}
+
+	topo := corev1.TopologySelectorTerm{MatchLabelExpressions: []corev1.TopologySelectorLabelRequirement{{Key: "k", Values: []string{"v"}}}}
+	AddStorageClassAllowedTopology(sc, topo)
+	if len(sc.AllowedTopologies) != 1 {
+		t.Errorf("topology not added")
+	}
+
+	AddStorageClassAllowedTopologies(sc, []corev1.TopologySelectorTerm{topo})
+	if len(sc.AllowedTopologies) != 2 {
+		t.Errorf("topologies not appended")
+	}
+
+	SetStorageClassAllowedTopologies(sc, []corev1.TopologySelectorTerm{})
+	if len(sc.AllowedTopologies) != 0 {
+		t.Errorf("topologies not set")
+	}
+
+	pvc := CreatePersistentVolumeClaim("pvc", "ns")
+	SetPVCStorageClass(pvc, sc)
+	if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName != sc.Name {
+		t.Errorf("pvc storage class not set")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -61,6 +61,12 @@ func main() {
 	k8s.SetPVCDataSource(pvc, &apiv1.TypedLocalObjectReference{Kind: "PersistentVolumeClaim", Name: "source"})
 	k8s.SetPVCDataSourceRef(pvc, &apiv1.TypedObjectReference{Kind: "PersistentVolumeClaim", Name: "source"})
 
+	// StorageClass example
+	sc := k8s.CreateStorageClass("demo-sc", "kubernetes.io/no-provisioner")
+	k8s.AddStorageClassParameter(sc, "type", "local")
+	k8s.SetStorageClassAllowVolumeExpansion(sc, true)
+	k8s.SetPVCStorageClass(pvc, sc)
+
 	// Pod example
 	pod := k8s.CreatePod("demo-pod", "demo")
 	mainCtr := k8s.CreateContainer("app", "nginx", nil, nil)


### PR DESCRIPTION
## Summary
- extend k8s helpers with StorageClass creation utilities
- allow linking a PVC to a StorageClass
- add unit tests for new helpers
- demonstrate usage in `main.go`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6877c31d5cd0832f8e0354c7af6b7346