### PR TITLE
Add cert-manager ACME helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ replace (
 )
 
 require (
+	github.com/cert-manager/cert-manager v1.13.3
 	github.com/fluxcd/helm-controller/api v1.2.0
 	github.com/fluxcd/image-automation-controller/api v0.41.2
 	github.com/fluxcd/kustomize-controller/api v1.5.1
@@ -44,6 +45,7 @@ require (
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e // indirect
 	sigs.k8s.io/controller-runtime v0.21.0 // indirect
+	sigs.k8s.io/gateway-api v0.8.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/cert-manager/cert-manager v1.13.3 h1:3R4G0RI7K0OkTZhWlVOC5SGZMYa2NwqmQJoyKydrz/M=
+github.com/cert-manager/cert-manager v1.13.3/go.mod h1:BM2+Pt/NmSv1Zr25/MHv6BgIEF9IUxA1xAjp80qkxgc=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -26,6 +28,7 @@ github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vt
 github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -131,6 +134,8 @@ k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e h1:KqK5c/ghOm8xkHYhlodbp6i6+r+Ch
 k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/controller-runtime v0.21.0 h1:CYfjpEuicjUecRk+KAeyYh+ouUBn4llGyDYytIGcJS8=
 sigs.k8s.io/controller-runtime v0.21.0/go.mod h1:OSg14+F65eWqIu4DceX7k/+QRAbTTvxeQSNSOQpukWM=
+sigs.k8s.io/gateway-api v0.8.0 h1:isQQ3Jx2qFP7vaA3ls0846F0Amp9Eq14P08xbSwVbQg=
+sigs.k8s.io/gateway-api v0.8.0/go.mod h1:okOnjPNBFbIS/Rw9kAhuIUaIkLhTKEu+ARIuXk2dgaM=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v0.0.0-20250304075658-069ef1bbf016/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=

--- a/internal/certmanager/acme.go
+++ b/internal/certmanager/acme.go
@@ -1,0 +1,73 @@
+package certmanager
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+)
+
+// CreateACMEIssuer returns an ACMEIssuer with the mandatory fields set.
+func CreateACMEIssuer(server, email string, key cmmeta.SecretKeySelector) *cmacme.ACMEIssuer {
+	return &cmacme.ACMEIssuer{
+		Email:                       email,
+		Server:                      server,
+		PrivateKey:                  key,
+		Solvers:                     []cmacme.ACMEChallengeSolver{},
+		SkipTLSVerify:               false,
+		DisableAccountKeyGeneration: false,
+	}
+}
+
+// AddACMEIssuerSolver appends a challenge solver to the issuer.
+func AddACMEIssuerSolver(issuer *cmacme.ACMEIssuer, solver cmacme.ACMEChallengeSolver) {
+	issuer.Solvers = append(issuer.Solvers, solver)
+}
+
+// CreateACMEHTTP01Solver creates a solver using HTTP01 via ingress class.
+func CreateACMEHTTP01Solver(serviceType corev1.ServiceType, class string) cmacme.ACMEChallengeSolver {
+	solver := cmacme.ACMEChallengeSolver{
+		HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+			Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+				ServiceType: serviceType,
+			},
+		},
+	}
+	if class != "" {
+		solver.HTTP01.Ingress.IngressClassName = &class
+	}
+	return solver
+}
+
+// CreateACMEDNS01SolverCloudflare creates a DNS01 solver for Cloudflare.
+func CreateACMEDNS01SolverCloudflare(email string, token cmmeta.SecretKeySelector) cmacme.ACMEChallengeSolver {
+	provider := &cmacme.ACMEChallengeSolverDNS01{
+		Cloudflare: &cmacme.ACMEIssuerDNS01ProviderCloudflare{
+			Email:    email,
+			APIToken: &token,
+		},
+	}
+	return cmacme.ACMEChallengeSolver{DNS01: provider}
+}
+
+// CreateACMEDNS01SolverRoute53 creates a DNS01 solver for AWS Route53.
+func CreateACMEDNS01SolverRoute53(region string, key cmmeta.SecretKeySelector) cmacme.ACMEChallengeSolver {
+	provider := &cmacme.ACMEChallengeSolverDNS01{
+		Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+			Region:          region,
+			SecretAccessKey: key,
+		},
+	}
+	return cmacme.ACMEChallengeSolver{DNS01: provider}
+}
+
+// CreateACMEDNS01SolverGoogle creates a DNS01 solver for Google CloudDNS.
+func CreateACMEDNS01SolverGoogle(project string, sa *cmmeta.SecretKeySelector) cmacme.ACMEChallengeSolver {
+	provider := &cmacme.ACMEChallengeSolverDNS01{
+		CloudDNS: &cmacme.ACMEIssuerDNS01ProviderCloudDNS{
+			Project:        project,
+			ServiceAccount: sa,
+		},
+	}
+	return cmacme.ACMEChallengeSolver{DNS01: provider}
+}

--- a/internal/certmanager/acme_test.go
+++ b/internal/certmanager/acme_test.go
@@ -1,0 +1,44 @@
+package certmanager
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+)
+
+func TestACMEHelpers(t *testing.T) {
+	key := cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: "key"}}
+	acmeIssuer := CreateACMEIssuer("https://acme.example.com", "test@example.com", key)
+
+	if acmeIssuer.Server != "https://acme.example.com" || acmeIssuer.Email != "test@example.com" {
+		t.Fatalf("unexpected issuer fields")
+	}
+
+	solver := CreateACMEHTTP01Solver(corev1.ServiceTypeNodePort, "nginx")
+	AddACMEIssuerSolver(acmeIssuer, solver)
+	if len(acmeIssuer.Solvers) != 1 || acmeIssuer.Solvers[0].HTTP01 == nil {
+		t.Fatalf("solver not added")
+	}
+
+	cfTok := cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: "cloudflare"}}
+	dnsSolver := CreateACMEDNS01SolverCloudflare("me@example.com", cfTok)
+	AddACMEIssuerSolver(acmeIssuer, dnsSolver)
+	if acmeIssuer.Solvers[1].DNS01 == nil || acmeIssuer.Solvers[1].DNS01.Cloudflare == nil {
+		t.Fatalf("dns solver not added")
+	}
+
+	route53Key := cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: "aws"}}
+	r53 := CreateACMEDNS01SolverRoute53("us-east-1", route53Key)
+	AddACMEIssuerSolver(acmeIssuer, r53)
+	if acmeIssuer.Solvers[2].DNS01.Route53.Region != "us-east-1" {
+		t.Fatalf("route53 region mismatch")
+	}
+
+	gsa := cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: "gcp"}}
+	gsolver := CreateACMEDNS01SolverGoogle("my-project", &gsa)
+	if gsolver.DNS01.CloudDNS == nil || gsolver.DNS01.CloudDNS.Project != "my-project" {
+		t.Fatalf("gcp solver not configured")
+	}
+}

--- a/internal/certmanager/certificate.go
+++ b/internal/certmanager/certificate.go
@@ -1,0 +1,59 @@
+package certmanager
+
+import (
+	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateCertificate returns a new Certificate object with the provided name, namespace and spec.
+func CreateCertificate(name, namespace string, spec certv1.CertificateSpec) *certv1.Certificate {
+	obj := &certv1.Certificate{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Certificate",
+			APIVersion: certv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: spec,
+	}
+	return obj
+}
+
+// AddCertificateLabel adds or updates a label on the Certificate metadata.
+func AddCertificateLabel(obj *certv1.Certificate, key, value string) {
+	if obj.Labels == nil {
+		obj.Labels = make(map[string]string)
+	}
+	obj.Labels[key] = value
+}
+
+// AddCertificateAnnotation adds or updates an annotation on the Certificate metadata.
+func AddCertificateAnnotation(obj *certv1.Certificate, key, value string) {
+	if obj.Annotations == nil {
+		obj.Annotations = make(map[string]string)
+	}
+	obj.Annotations[key] = value
+}
+
+// AddCertificateDNSName appends a DNS name to the Certificate spec.
+func AddCertificateDNSName(obj *certv1.Certificate, dns string) {
+	obj.Spec.DNSNames = append(obj.Spec.DNSNames, dns)
+}
+
+// SetCertificateIssuerRef sets the issuer reference for the certificate.
+func SetCertificateIssuerRef(obj *certv1.Certificate, ref cmmeta.ObjectReference) {
+	obj.Spec.IssuerRef = ref
+}
+
+// SetCertificateDuration sets the desired certificate duration.
+func SetCertificateDuration(obj *certv1.Certificate, dur *metav1.Duration) {
+	obj.Spec.Duration = dur
+}
+
+// SetCertificateRenewBefore sets the renewBefore field of the certificate spec.
+func SetCertificateRenewBefore(obj *certv1.Certificate, dur *metav1.Duration) {
+	obj.Spec.RenewBefore = dur
+}

--- a/internal/certmanager/certificate_test.go
+++ b/internal/certmanager/certificate_test.go
@@ -1,0 +1,53 @@
+package certmanager
+
+import (
+	"testing"
+
+	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCertificateFunctions(t *testing.T) {
+	spec := certv1.CertificateSpec{}
+	crt := CreateCertificate("demo", "ns", spec)
+
+	if crt.Name != "demo" || crt.Namespace != "ns" {
+		t.Fatalf("metadata mismatch: %s/%s", crt.Namespace, crt.Name)
+	}
+	if crt.Kind != "Certificate" {
+		t.Errorf("unexpected kind %q", crt.Kind)
+	}
+
+	AddCertificateLabel(crt, "app", "demo")
+	if crt.Labels["app"] != "demo" {
+		t.Errorf("label not set")
+	}
+
+	AddCertificateAnnotation(crt, "team", "dev")
+	if crt.Annotations["team"] != "dev" {
+		t.Errorf("annotation not set")
+	}
+
+	AddCertificateDNSName(crt, "example.com")
+	if len(crt.Spec.DNSNames) != 1 || crt.Spec.DNSNames[0] != "example.com" {
+		t.Errorf("dns name not added")
+	}
+
+	ref := cmmeta.ObjectReference{Name: "issuer"}
+	SetCertificateIssuerRef(crt, ref)
+	if crt.Spec.IssuerRef.Name != "issuer" {
+		t.Errorf("issuerRef not set")
+	}
+
+	dur := metav1.Duration{Duration: 0}
+	SetCertificateDuration(crt, &dur)
+	if crt.Spec.Duration == nil {
+		t.Errorf("duration not set")
+	}
+
+	SetCertificateRenewBefore(crt, &dur)
+	if crt.Spec.RenewBefore == nil {
+		t.Errorf("renewBefore not set")
+	}
+}

--- a/internal/certmanager/clusterissuer.go
+++ b/internal/certmanager/clusterissuer.go
@@ -1,0 +1,43 @@
+package certmanager
+
+import (
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateClusterIssuer returns a new ClusterIssuer with the provided name and spec.
+func CreateClusterIssuer(name string, spec certv1.IssuerSpec) *certv1.ClusterIssuer {
+	obj := &certv1.ClusterIssuer{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterIssuer",
+			APIVersion: certv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: spec,
+	}
+	return obj
+}
+
+// AddClusterIssuerLabel adds or updates a label on the ClusterIssuer metadata.
+func AddClusterIssuerLabel(obj *certv1.ClusterIssuer, key, value string) {
+	if obj.Labels == nil {
+		obj.Labels = make(map[string]string)
+	}
+	obj.Labels[key] = value
+}
+
+// AddClusterIssuerAnnotation adds or updates an annotation on the ClusterIssuer metadata.
+func AddClusterIssuerAnnotation(obj *certv1.ClusterIssuer, key, value string) {
+	if obj.Annotations == nil {
+		obj.Annotations = make(map[string]string)
+	}
+	obj.Annotations[key] = value
+}
+
+// SetClusterIssuerACME sets the ACME config on the ClusterIssuer.
+func SetClusterIssuerACME(obj *certv1.ClusterIssuer, acme *cmacme.ACMEIssuer) {
+	obj.Spec.IssuerConfig.ACME = acme
+}

--- a/internal/certmanager/clusterissuer_test.go
+++ b/internal/certmanager/clusterissuer_test.go
@@ -1,0 +1,36 @@
+package certmanager
+
+import (
+	"testing"
+
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+)
+
+func TestClusterIssuerFunctions(t *testing.T) {
+	spec := certv1.IssuerSpec{}
+	ci := CreateClusterIssuer("demo", spec)
+
+	if ci.Name != "demo" {
+		t.Fatalf("name mismatch: %s", ci.Name)
+	}
+	if ci.Kind != "ClusterIssuer" {
+		t.Errorf("unexpected kind %q", ci.Kind)
+	}
+
+	AddClusterIssuerLabel(ci, "app", "demo")
+	if ci.Labels["app"] != "demo" {
+		t.Errorf("label not set")
+	}
+
+	AddClusterIssuerAnnotation(ci, "team", "dev")
+	if ci.Annotations["team"] != "dev" {
+		t.Errorf("annotation not set")
+	}
+
+	acme := &cmacme.ACMEIssuer{Server: "https://acme.example.com"}
+	SetClusterIssuerACME(ci, acme)
+	if ci.Spec.IssuerConfig.ACME == nil || ci.Spec.IssuerConfig.ACME.Server != "https://acme.example.com" {
+		t.Errorf("acme config not set")
+	}
+}

--- a/internal/certmanager/issuer.go
+++ b/internal/certmanager/issuer.go
@@ -1,0 +1,52 @@
+package certmanager
+
+import (
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateIssuer returns a new Issuer object with the provided name, namespace and spec.
+func CreateIssuer(name, namespace string, spec certv1.IssuerSpec) *certv1.Issuer {
+	obj := &certv1.Issuer{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Issuer",
+			APIVersion: certv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: spec,
+	}
+	return obj
+}
+
+// AddIssuerLabel adds or updates a label on the Issuer metadata.
+func AddIssuerLabel(obj *certv1.Issuer, key, value string) {
+	if obj.Labels == nil {
+		obj.Labels = make(map[string]string)
+	}
+	obj.Labels[key] = value
+}
+
+// AddIssuerAnnotation adds or updates an annotation on the Issuer metadata.
+func AddIssuerAnnotation(obj *certv1.Issuer, key, value string) {
+	if obj.Annotations == nil {
+		obj.Annotations = make(map[string]string)
+	}
+	obj.Annotations[key] = value
+}
+
+// SetIssuerACME sets the ACME configuration on the issuer spec.
+func SetIssuerACME(obj *certv1.Issuer, acme *cmacme.ACMEIssuer) {
+	if obj == nil {
+		return
+	}
+	obj.Spec.IssuerConfig.ACME = acme
+}
+
+// SetIssuerCA sets the CA configuration on the issuer spec.
+func SetIssuerCA(obj *certv1.Issuer, ca *certv1.CAIssuer) {
+	obj.Spec.IssuerConfig.CA = ca
+}

--- a/internal/certmanager/issuer_test.go
+++ b/internal/certmanager/issuer_test.go
@@ -1,0 +1,42 @@
+package certmanager
+
+import (
+	"testing"
+
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+)
+
+func TestIssuerFunctions(t *testing.T) {
+	spec := certv1.IssuerSpec{}
+	issuer := CreateIssuer("demo", "ns", spec)
+
+	if issuer.Name != "demo" || issuer.Namespace != "ns" {
+		t.Fatalf("metadata mismatch: %s/%s", issuer.Namespace, issuer.Name)
+	}
+	if issuer.Kind != "Issuer" {
+		t.Errorf("unexpected kind %q", issuer.Kind)
+	}
+
+	AddIssuerLabel(issuer, "env", "prod")
+	if issuer.Labels["env"] != "prod" {
+		t.Errorf("label not set")
+	}
+
+	AddIssuerAnnotation(issuer, "team", "dev")
+	if issuer.Annotations["team"] != "dev" {
+		t.Errorf("annotation not set")
+	}
+
+	acme := &cmacme.ACMEIssuer{Server: "https://acme.example.com"}
+	SetIssuerACME(issuer, acme)
+	if issuer.Spec.IssuerConfig.ACME == nil || issuer.Spec.IssuerConfig.ACME.Server != "https://acme.example.com" {
+		t.Errorf("acme config not set")
+	}
+
+	ca := &certv1.CAIssuer{SecretName: "ca"}
+	SetIssuerCA(issuer, ca)
+	if issuer.Spec.IssuerConfig.CA == nil || issuer.Spec.IssuerConfig.CA.SecretName != "ca" {
+		t.Errorf("ca config not set")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,12 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 
+	certmanagerapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager"
+	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+
+	"github.com/go-kure/kure/internal/certmanager"
+
 	"github.com/go-kure/kure/internal/fluxcd"
 	"github.com/go-kure/kure/internal/k8s"
 
@@ -274,6 +280,19 @@ func main() {
 	auto := fluxcd.CreateImageUpdateAutomation("demo-auto", "demo", autoSpec)
 	fluxcd.SetImageUpdateAutomationSuspend(auto, false)
 
+	// cert-manager examples
+	issuer := certmanager.CreateIssuer("demo-issuer", "demo", certv1.IssuerSpec{})
+	acme := certmanager.CreateACMEIssuer("https://acme.example.com", "ops@example.com",
+		cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: "acme-key"}})
+	certmanager.AddACMEIssuerSolver(acme, certmanager.CreateACMEHTTP01Solver(apiv1.ServiceTypeNodePort, "nginx"))
+	certmanager.SetIssuerACME(issuer, acme)
+
+	certmanager.SetIssuerCA(issuer, &certv1.CAIssuer{SecretName: "ca-key"})
+	cert := certmanager.CreateCertificate("demo-cert", "demo", certv1.CertificateSpec{})
+	certmanager.AddCertificateDNSName(cert, "example.com")
+	certmanager.SetCertificateIssuerRef(cert, cmmeta.ObjectReference{Name: issuer.Name, Kind: "Issuer", Group: certmanagerapi.GroupName})
+	clusterIssuer := certmanager.CreateClusterIssuer("demo-clusterissuer", certv1.IssuerSpec{})
+
 	// Print objects as YAML
 	y.PrintObj(sa, os.Stdout)
 	y.PrintObj(ns, os.Stdout)
@@ -306,4 +325,7 @@ func main() {
 	y.PrintObj(alert, os.Stdout)
 	y.PrintObj(receiver, os.Stdout)
 	y.PrintObj(auto, os.Stdout)
+	y.PrintObj(issuer, os.Stdout)
+	y.PrintObj(clusterIssuer, os.Stdout)
+	y.PrintObj(cert, os.Stdout)
 }


### PR DESCRIPTION
## Summary
- add helper functions to build ACMEIssuer specs
- cover new helpers with unit tests
- showcase ACMEIssuer usage in `main.go`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6877d833ee98832faebf9e0ad57a64ad