### PR TITLE
Add external-secrets helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,9 @@ require (
 	github.com/fluxcd/notification-controller/api v1.6.0
 	github.com/fluxcd/pkg/apis/acl v0.7.0
 	github.com/fluxcd/pkg/apis/kustomize v1.9.0
-	github.com/fluxcd/pkg/apis/meta v1.12.0
-	github.com/fluxcd/source-controller/api v1.6.1
+       github.com/fluxcd/pkg/apis/meta v1.12.0
+       github.com/external-secrets/external-secrets v0.18.2
+       github.com/fluxcd/source-controller/api v1.6.1
 	k8s.io/api v0.33.0
 	k8s.io/apiextensions-apiserver v0.33.0
 	k8s.io/apimachinery v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/external-secrets/external-secrets v0.18.2 h1:uTGUkEeclsLu93SkhToDGBs8+aaSwkstLWIQ3g21ZMI=
+github.com/external-secrets/external-secrets v0.18.2/go.mod h1:+l6+AHa3kb/d1/9BHlrLzHw9LO+rjHwI+kC5KS1+CRc=
 github.com/fluxcd/helm-controller/api v1.2.0 h1:cjpHBpJQv+8WyYQNwoujoNMFOQx2llllv4peLIiWyxU=
 github.com/fluxcd/helm-controller/api v1.2.0/go.mod h1:3NZts/4n6PpD4sONSDJWXPQzfPpBk3YpknIFA6rLW3I=
 github.com/fluxcd/image-automation-controller/api v0.41.2 h1:miYjID4Mg51xcObVLQPRGkiWFYGpBSgItTXfQ4jVUVI=

--- a/internal/externalsecrets/clusterexternalsecret.go
+++ b/internal/externalsecrets/clusterexternalsecret.go
@@ -1,0 +1,38 @@
+package externalsecrets
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
+)
+
+// CreateClusterExternalSecret returns a new ClusterExternalSecret object.
+func CreateClusterExternalSecret(name string, spec esv1beta1.ClusterExternalSecretSpec) *esv1beta1.ClusterExternalSecret {
+	obj := &esv1beta1.ClusterExternalSecret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterExternalSecret",
+			APIVersion: esv1beta1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: spec,
+	}
+	return obj
+}
+
+// AddClusterExternalSecretLabel adds a label to the ClusterExternalSecret metadata.
+func AddClusterExternalSecretLabel(obj *esv1beta1.ClusterExternalSecret, key, value string) {
+	if obj.Labels == nil {
+		obj.Labels = map[string]string{}
+	}
+	obj.Labels[key] = value
+}
+
+// AddClusterExternalSecretAnnotation adds an annotation to the ClusterExternalSecret metadata.
+func AddClusterExternalSecretAnnotation(obj *esv1beta1.ClusterExternalSecret, key, value string) {
+	if obj.Annotations == nil {
+		obj.Annotations = map[string]string{}
+	}
+	obj.Annotations[key] = value
+}

--- a/internal/externalsecrets/clusterexternalsecret_test.go
+++ b/internal/externalsecrets/clusterexternalsecret_test.go
@@ -1,0 +1,21 @@
+package externalsecrets
+
+import (
+	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
+	"testing"
+)
+
+func TestClusterExternalSecretHelpers(t *testing.T) {
+	ces := CreateClusterExternalSecret("demo", esv1beta1.ClusterExternalSecretSpec{})
+	if ces.Name != "demo" {
+		t.Fatalf("name mismatch: %s", ces.Name)
+	}
+	AddClusterExternalSecretLabel(ces, "env", "prod")
+	if ces.Labels["env"] != "prod" {
+		t.Errorf("label not set")
+	}
+	AddClusterExternalSecretAnnotation(ces, "team", "dev")
+	if ces.Annotations["team"] != "dev" {
+		t.Errorf("annotation not set")
+	}
+}

--- a/internal/externalsecrets/clustersecretstore.go
+++ b/internal/externalsecrets/clustersecretstore.go
@@ -1,0 +1,43 @@
+package externalsecrets
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
+)
+
+// CreateClusterSecretStore returns a new ClusterSecretStore object.
+func CreateClusterSecretStore(name string, spec esv1beta1.SecretStoreSpec) *esv1beta1.ClusterSecretStore {
+	obj := &esv1beta1.ClusterSecretStore{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterSecretStore",
+			APIVersion: esv1beta1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: spec,
+	}
+	return obj
+}
+
+// AddClusterSecretStoreLabel adds a label to the ClusterSecretStore metadata.
+func AddClusterSecretStoreLabel(obj *esv1beta1.ClusterSecretStore, key, value string) {
+	if obj.Labels == nil {
+		obj.Labels = map[string]string{}
+	}
+	obj.Labels[key] = value
+}
+
+// AddClusterSecretStoreAnnotation adds an annotation to the ClusterSecretStore metadata.
+func AddClusterSecretStoreAnnotation(obj *esv1beta1.ClusterSecretStore, key, value string) {
+	if obj.Annotations == nil {
+		obj.Annotations = map[string]string{}
+	}
+	obj.Annotations[key] = value
+}
+
+// SetClusterSecretStoreProvider sets the provider configuration on the ClusterSecretStore.
+func SetClusterSecretStoreProvider(obj *esv1beta1.ClusterSecretStore, provider *esv1beta1.SecretStoreProvider) {
+	obj.Spec.Provider = provider
+}

--- a/internal/externalsecrets/clustersecretstore_test.go
+++ b/internal/externalsecrets/clustersecretstore_test.go
@@ -1,0 +1,26 @@
+package externalsecrets
+
+import (
+	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
+	"testing"
+)
+
+func TestClusterSecretStoreHelpers(t *testing.T) {
+	css := CreateClusterSecretStore("demo", esv1beta1.SecretStoreSpec{})
+	if css.Name != "demo" {
+		t.Fatalf("name mismatch")
+	}
+	AddClusterSecretStoreLabel(css, "env", "prod")
+	if css.Labels["env"] != "prod" {
+		t.Errorf("label not set")
+	}
+	AddClusterSecretStoreAnnotation(css, "team", "dev")
+	if css.Annotations["team"] != "dev" {
+		t.Errorf("annotation not set")
+	}
+	provider := &esv1beta1.SecretStoreProvider{}
+	SetClusterSecretStoreProvider(css, provider)
+	if css.Spec.Provider == nil {
+		t.Errorf("provider not set")
+	}
+}

--- a/internal/externalsecrets/externalsecret.go
+++ b/internal/externalsecrets/externalsecret.go
@@ -1,0 +1,54 @@
+package externalsecrets
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
+)
+
+// CreateExternalSecret returns a new ExternalSecret object with the provided name, namespace and spec.
+func CreateExternalSecret(name, namespace string, spec esv1beta1.ExternalSecretSpec) *esv1beta1.ExternalSecret {
+	obj := &esv1beta1.ExternalSecret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ExternalSecret",
+			APIVersion: esv1beta1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: spec,
+	}
+	return obj
+}
+
+// AddExternalSecretLabel adds a label to the ExternalSecret metadata.
+func AddExternalSecretLabel(obj *esv1beta1.ExternalSecret, key, value string) {
+	if obj.Labels == nil {
+		obj.Labels = map[string]string{}
+	}
+	obj.Labels[key] = value
+}
+
+// AddExternalSecretAnnotation adds an annotation to the ExternalSecret metadata.
+func AddExternalSecretAnnotation(obj *esv1beta1.ExternalSecret, key, value string) {
+	if obj.Annotations == nil {
+		obj.Annotations = map[string]string{}
+	}
+	obj.Annotations[key] = value
+}
+
+// AddExternalSecretData appends a data mapping to the ExternalSecret spec.
+func AddExternalSecretData(obj *esv1beta1.ExternalSecret, data esv1beta1.ExternalSecretData) {
+	obj.Spec.Data = append(obj.Spec.Data, data)
+}
+
+// AddExternalSecretDataFrom appends a dataFrom entry to the ExternalSecret spec.
+func AddExternalSecretDataFrom(obj *esv1beta1.ExternalSecret, ref esv1beta1.ExternalSecretDataFromRemoteRef) {
+	obj.Spec.DataFrom = append(obj.Spec.DataFrom, ref)
+}
+
+// SetExternalSecretRefreshInterval sets the refresh interval on the ExternalSecret spec.
+func SetExternalSecretRefreshInterval(obj *esv1beta1.ExternalSecret, interval metav1.Duration) {
+	obj.Spec.RefreshInterval = &interval
+}

--- a/internal/externalsecrets/externalsecret_test.go
+++ b/internal/externalsecrets/externalsecret_test.go
@@ -1,0 +1,35 @@
+package externalsecrets
+
+import (
+	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestExternalSecretHelpers(t *testing.T) {
+	es := CreateExternalSecret("demo", "ns", esv1beta1.ExternalSecretSpec{})
+	if es.Name != "demo" || es.Namespace != "ns" {
+		t.Fatalf("metadata mismatch: %s/%s", es.Namespace, es.Name)
+	}
+	AddExternalSecretLabel(es, "env", "prod")
+	if es.Labels["env"] != "prod" {
+		t.Errorf("label not set")
+	}
+	AddExternalSecretAnnotation(es, "team", "dev")
+	if es.Annotations["team"] != "dev" {
+		t.Errorf("annotation not set")
+	}
+	AddExternalSecretData(es, esv1beta1.ExternalSecretData{SecretKey: "foo"})
+	if len(es.Spec.Data) != 1 || es.Spec.Data[0].SecretKey != "foo" {
+		t.Errorf("data not added")
+	}
+	AddExternalSecretDataFrom(es, esv1beta1.ExternalSecretDataFromRemoteRef{Key: "ref"})
+	if len(es.Spec.DataFrom) != 1 || es.Spec.DataFrom[0].Key != "ref" {
+		t.Errorf("dataFrom not added")
+	}
+	dur := metav1.Duration{Duration: 0}
+	SetExternalSecretRefreshInterval(es, dur)
+	if es.Spec.RefreshInterval == nil {
+		t.Errorf("refresh interval not set")
+	}
+}

--- a/internal/externalsecrets/secretstore.go
+++ b/internal/externalsecrets/secretstore.go
@@ -1,0 +1,44 @@
+package externalsecrets
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
+)
+
+// CreateSecretStore returns a new SecretStore object with the provided name, namespace and spec.
+func CreateSecretStore(name, namespace string, spec esv1beta1.SecretStoreSpec) *esv1beta1.SecretStore {
+	obj := &esv1beta1.SecretStore{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SecretStore",
+			APIVersion: esv1beta1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: spec,
+	}
+	return obj
+}
+
+// AddSecretStoreLabel adds a label to the SecretStore metadata.
+func AddSecretStoreLabel(obj *esv1beta1.SecretStore, key, value string) {
+	if obj.Labels == nil {
+		obj.Labels = map[string]string{}
+	}
+	obj.Labels[key] = value
+}
+
+// AddSecretStoreAnnotation adds an annotation to the SecretStore metadata.
+func AddSecretStoreAnnotation(obj *esv1beta1.SecretStore, key, value string) {
+	if obj.Annotations == nil {
+		obj.Annotations = map[string]string{}
+	}
+	obj.Annotations[key] = value
+}
+
+// SetSecretStoreProvider sets the provider configuration on the SecretStore.
+func SetSecretStoreProvider(obj *esv1beta1.SecretStore, provider *esv1beta1.SecretStoreProvider) {
+	obj.Spec.Provider = provider
+}

--- a/internal/externalsecrets/secretstore_test.go
+++ b/internal/externalsecrets/secretstore_test.go
@@ -1,0 +1,26 @@
+package externalsecrets
+
+import (
+	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
+	"testing"
+)
+
+func TestSecretStoreHelpers(t *testing.T) {
+	ss := CreateSecretStore("demo", "ns", esv1beta1.SecretStoreSpec{})
+	if ss.Name != "demo" || ss.Namespace != "ns" {
+		t.Fatalf("metadata mismatch")
+	}
+	AddSecretStoreLabel(ss, "env", "prod")
+	if ss.Labels["env"] != "prod" {
+		t.Errorf("label not set")
+	}
+	AddSecretStoreAnnotation(ss, "team", "dev")
+	if ss.Annotations["team"] != "dev" {
+		t.Errorf("annotation not set")
+	}
+	provider := &esv1beta1.SecretStoreProvider{}
+	SetSecretStoreProvider(ss, provider)
+	if ss.Spec.Provider == nil {
+		t.Errorf("provider not set")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -26,9 +26,11 @@ import (
 
 	"github.com/go-kure/kure/internal/certmanager"
 
+	"github.com/go-kure/kure/internal/externalsecrets"
 	"github.com/go-kure/kure/internal/fluxcd"
 	"github.com/go-kure/kure/internal/k8s"
 
+	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
 	v1 "github.com/fluxcd/notification-controller/api/v1"
 	notificationv1beta2 "github.com/fluxcd/notification-controller/api/v1beta2"
 	meta "github.com/fluxcd/pkg/apis/meta"
@@ -293,6 +295,12 @@ func main() {
 	certmanager.SetCertificateIssuerRef(cert, cmmeta.ObjectReference{Name: issuer.Name, Kind: "Issuer", Group: certmanagerapi.GroupName})
 	clusterIssuer := certmanager.CreateClusterIssuer("demo-clusterissuer", certv1.IssuerSpec{})
 
+	// external-secrets examples
+	esStore := externalsecrets.CreateSecretStore("demo-store", "demo", esv1beta1.SecretStoreSpec{})
+	cesStore := externalsecrets.CreateClusterSecretStore("demo-clusterstore", esv1beta1.SecretStoreSpec{})
+	es := externalsecrets.CreateExternalSecret("demo-es", "demo", esv1beta1.ExternalSecretSpec{})
+	ces := externalsecrets.CreateClusterExternalSecret("demo-ces", esv1beta1.ClusterExternalSecretSpec{})
+
 	// Print objects as YAML
 	y.PrintObj(sa, os.Stdout)
 	y.PrintObj(ns, os.Stdout)
@@ -328,4 +336,8 @@ func main() {
 	y.PrintObj(issuer, os.Stdout)
 	y.PrintObj(clusterIssuer, os.Stdout)
 	y.PrintObj(cert, os.Stdout)
+	y.PrintObj(esStore, os.Stdout)
+	y.PrintObj(cesStore, os.Stdout)
+	y.PrintObj(es, os.Stdout)
+	y.PrintObj(ces, os.Stdout)
 }


### PR DESCRIPTION
## Summary
- add external-secrets dependencies
- implement helper functions for ExternalSecret, ClusterExternalSecret, SecretStore and ClusterSecretStore
- provide unit tests for the new helpers
- show example usage in main.go

## Testing
- `go test ./...` *(fails: requires Go 1.24.4)*

------
https://chatgpt.com/codex/tasks/task_e_6877fb7cf068832f8163f31f29232882