### PR TITLE
Improve yaml type checking

### DIFF
--- a/internal/yaml/import.go
+++ b/internal/yaml/import.go
@@ -3,11 +3,9 @@ package yaml
 import (
 	"fmt"
 	"log"
-	"regexp"
+	"reflect"
 	"strings"
 
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -24,14 +22,14 @@ func parse(yamlbytes []byte) []runtime.Object {
 	sepYamlfiles := strings.Split(fileAsString, "---")
 	retVal := make([]runtime.Object, 0, len(sepYamlfiles))
 
-	err := kustv1.AddToScheme(scheme.Scheme)
-	if err != nil {
+	if err := kustv1.AddToScheme(scheme.Scheme); err != nil {
+		log.Printf("failed to register kustomize scheme: %v", err)
 	}
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 
 	for _, f := range sepYamlfiles {
 		// skip empty documents, `Decode` will fail on them
-		if len(f) == 0 {
+		if len(strings.TrimSpace(f)) == 0 {
 			continue
 		}
 		obj, _, err := decode([]byte(f), nil, nil)
@@ -40,27 +38,31 @@ func parse(yamlbytes []byte) []runtime.Object {
 			log.Fatal(fmt.Sprintf("Error while decoding YAML object. Err was: %s", err))
 			continue
 		}
+		if err := checkType(obj); err != nil {
+			log.Printf("skipping unsupported object: %v", err)
+			continue
+		}
 		retVal = append(retVal, obj)
 	}
 
 	return retVal
 }
 
-func checkType(obj runtime.Object) {
-	acceptedK8sTypes := regexp.MustCompile(`(Role|ClusterRole|RoleBinding|ClusterRoleBinding|ServiceAccount)`)
-	groupVersionKind := obj.GetObjectKind().GroupVersionKind()
-	if !acceptedK8sTypes.MatchString(groupVersionKind.Kind) {
-		log.Printf("The custom-roles configMap contained K8s object types which are not supported! Skipping object with type: %s", groupVersionKind.Kind)
-	} else {
-		switch obj.(type) {
-		case nil:
-		case *corev1.Pod:
-		case *rbacv1.Role:
-		case *rbacv1.RoleBinding:
-		case *rbacv1.ClusterRole:
-		case *rbacv1.ClusterRoleBinding:
-		case *corev1.ServiceAccount:
-		default:
-		}
+func checkType(obj runtime.Object) error {
+	if obj == nil {
+		return fmt.Errorf("nil runtime object provided")
 	}
+
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	expected, ok := scheme.Scheme.AllKnownTypes()[gvk]
+	if !ok {
+		return fmt.Errorf("unsupported object kind %s", gvk.String())
+	}
+
+	objType := reflect.TypeOf(obj)
+	if objType != expected && objType != reflect.PointerTo(expected) {
+		return fmt.Errorf("object kind %s expected type %v but got %T", gvk.Kind, expected, obj)
+	}
+
+	return nil
 }

--- a/internal/yaml/import_test.go
+++ b/internal/yaml/import_test.go
@@ -4,7 +4,13 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
+
+type dummy struct{ runtime.TypeMeta }
+
+func (d *dummy) DeepCopyObject() runtime.Object { return &dummy{} }
 
 func TestParse(t *testing.T) {
 	data := `apiVersion: v1
@@ -28,5 +34,23 @@ spec:
 	}
 	if pod, ok := objs[1].(*corev1.Pod); !ok || pod.Name != "pod" {
 		t.Fatalf("unexpected second object: %#v", objs[1])
+	}
+}
+
+func TestCheckType(t *testing.T) {
+	pod := &corev1.Pod{}
+	pod.TypeMeta = metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}
+	if err := checkType(pod); err != nil {
+		t.Fatalf("expected pod to be supported: %v", err)
+	}
+
+	var unknown runtime.Object = &dummy{}
+	if err := checkType(unknown); err == nil {
+		t.Fatalf("expected unsupported object error")
+	}
+
+	bad := &corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}}
+	if err := checkType(bad); err == nil {
+		t.Fatalf("expected type mismatch error")
 	}
 }


### PR DESCRIPTION
## Summary
- validate imported object kinds against all registered Kubernetes types
- filter unsupported objects when parsing YAML
- cover `checkType` with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6877fdaab198832fbc3d9de2273479ed