### PR TITLE
Improve YAML decoder in parse

### DIFF
--- a/internal/yaml/import.go
+++ b/internal/yaml/import.go
@@ -1,12 +1,14 @@
 package yaml
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"log"
 	"reflect"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	kustv1 "github.com/fluxcd/kustomize-controller/api/v1"
@@ -18,22 +20,27 @@ func parse(yamlbytes []byte) []runtime.Object {
 	   https://dx13.co.uk/articles/2021/01/15/kubernetes-types-using-go/
 	*/
 
-	fileAsString := string(yamlbytes[:])
-	sepYamlfiles := strings.Split(fileAsString, "---")
-	retVal := make([]runtime.Object, 0, len(sepYamlfiles))
+	decoder := yamlutil.NewYAMLOrJSONDecoder(bytes.NewReader(yamlbytes), 4096)
+	retVal := make([]runtime.Object, 0)
 
 	if err := kustv1.AddToScheme(scheme.Scheme); err != nil {
 		log.Printf("failed to register kustomize scheme: %v", err)
 	}
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 
-	for _, f := range sepYamlfiles {
-		// skip empty documents, `Decode` will fail on them
-		if len(strings.TrimSpace(f)) == 0 {
+	for {
+		var raw runtime.RawExtension
+		if err := decoder.Decode(&raw); err != nil {
+			if err == io.EOF {
+				break
+			}
+			log.Fatal(fmt.Sprintf("Error while decoding YAML object. Err was: %s", err))
 			continue
 		}
-		obj, _, err := decode([]byte(f), nil, nil)
-
+		if len(bytes.TrimSpace(raw.Raw)) == 0 {
+			continue
+		}
+		obj, _, err := decode(raw.Raw, nil, nil)
 		if err != nil {
 			log.Fatal(fmt.Sprintf("Error while decoding YAML object. Err was: %s", err))
 			continue


### PR DESCRIPTION
## Summary
- use `yaml.NewYAMLOrJSONDecoder` instead of splitting the YAML file
- iterate decoder and append decoded runtime objects

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687819de2cb8832fad571dd4f9540818