### PR TITLE
Extend YAML import scheme coverage

### DIFF
--- a/internal/yaml/import.go
+++ b/internal/yaml/import.go
@@ -6,11 +6,40 @@ import (
 	"reflect"
 	"strings"
 
+	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	imagev1 "github.com/fluxcd/image-automation-controller/api/v1beta2"
+	kustv1 "github.com/fluxcd/kustomize-controller/api/v1"
+	notificationv1beta2 "github.com/fluxcd/notification-controller/api/v1beta2"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-
-	kustv1 "github.com/fluxcd/kustomize-controller/api/v1"
 )
+
+func init() {
+	if err := kustv1.AddToScheme(scheme.Scheme); err != nil {
+		log.Printf("failed to register kustomize scheme: %v", err)
+	}
+	if err := helmv2.AddToScheme(scheme.Scheme); err != nil {
+		log.Printf("failed to register helm scheme: %v", err)
+	}
+	if err := imagev1.AddToScheme(scheme.Scheme); err != nil {
+		log.Printf("failed to register image automation scheme: %v", err)
+	}
+	if err := notificationv1beta2.AddToScheme(scheme.Scheme); err != nil {
+		log.Printf("failed to register notification scheme: %v", err)
+	}
+	if err := sourcev1.AddToScheme(scheme.Scheme); err != nil {
+		log.Printf("failed to register source scheme: %v", err)
+	}
+	if err := certv1.AddToScheme(scheme.Scheme); err != nil {
+		log.Printf("failed to register cert-manager scheme: %v", err)
+	}
+	if err := metallbv1beta1.AddToScheme(scheme.Scheme); err != nil {
+		log.Printf("failed to register metallb scheme: %v", err)
+	}
+}
 
 func parse(yamlbytes []byte) []runtime.Object {
 
@@ -22,9 +51,6 @@ func parse(yamlbytes []byte) []runtime.Object {
 	sepYamlfiles := strings.Split(fileAsString, "---")
 	retVal := make([]runtime.Object, 0, len(sepYamlfiles))
 
-	if err := kustv1.AddToScheme(scheme.Scheme); err != nil {
-		log.Printf("failed to register kustomize scheme: %v", err)
-	}
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 
 	for _, f := range sepYamlfiles {

--- a/internal/yaml/import_test.go
+++ b/internal/yaml/import_test.go
@@ -3,6 +3,12 @@ package yaml
 import (
 	"testing"
 
+	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	imagev1 "github.com/fluxcd/image-automation-controller/api/v1beta2"
+	notificationv1beta2 "github.com/fluxcd/notification-controller/api/v1beta2"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -52,5 +58,66 @@ func TestCheckType(t *testing.T) {
 	bad := &corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}}
 	if err := checkType(bad); err == nil {
 		t.Fatalf("expected type mismatch error")
+	}
+}
+
+func TestParseCustomObjects(t *testing.T) {
+	data := `apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: hr
+spec: {}
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageUpdateAutomation
+metadata:
+  name: img
+spec: {}
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Provider
+metadata:
+  name: prov
+spec: {}
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: repo
+spec: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cert
+spec: {}
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: pool
+spec: {}
+`
+	objs := parse([]byte(data))
+	if len(objs) != 6 {
+		t.Fatalf("expected 6 objects, got %d", len(objs))
+	}
+	if _, ok := objs[0].(*helmv2.HelmRelease); !ok {
+		t.Fatalf("unexpected object 0: %#v", objs[0])
+	}
+	if _, ok := objs[1].(*imagev1.ImageUpdateAutomation); !ok {
+		t.Fatalf("unexpected object 1: %#v", objs[1])
+	}
+	if _, ok := objs[2].(*notificationv1beta2.Provider); !ok {
+		t.Fatalf("unexpected object 2: %#v", objs[2])
+	}
+	if _, ok := objs[3].(*sourcev1.GitRepository); !ok {
+		t.Fatalf("unexpected object 3: %#v", objs[3])
+	}
+	if _, ok := objs[4].(*certv1.Certificate); !ok {
+		t.Fatalf("unexpected object 4: %#v", objs[4])
+	}
+	if _, ok := objs[5].(*metallbv1beta1.IPAddressPool); !ok {
+		t.Fatalf("unexpected object 5: %#v", objs[5])
 	}
 }


### PR DESCRIPTION
## Summary
- add scheme registration for Helm, Image automation, Notification, Source, Cert-Manager and MetalLB CRDs
- parse a custom object from each CRD group in tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687819e0765c832fbb94f6dccd9eaf7f