### PR TITLE
Implement full YAML importer

### DIFF
--- a/internal/yaml/import.go
+++ b/internal/yaml/import.go
@@ -4,16 +4,86 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"reflect"
+	"strings"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	imagev1 "github.com/fluxcd/image-automation-controller/api/v1beta2"
 	kustv1 "github.com/fluxcd/kustomize-controller/api/v1"
+	notifv1beta2 "github.com/fluxcd/notification-controller/api/v1beta2"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 )
+
+// ParseErrors aggregates multiple errors returned during YAML decoding.
+// It implements the error interface and unwraps to the underlying errors.
+type ParseErrors struct {
+	Errors []error
+}
+
+func (pe *ParseErrors) Error() string {
+	if len(pe.Errors) == 0 {
+		return ""
+	}
+	if len(pe.Errors) == 1 {
+		return pe.Errors[0].Error()
+	}
+	var b strings.Builder
+	b.WriteString("multiple parse errors:")
+	for _, err := range pe.Errors {
+		b.WriteString(" ")
+		b.WriteString(err.Error())
+		b.WriteString(";")
+	}
+	return strings.TrimSuffix(b.String(), ";")
+}
+
+func (pe *ParseErrors) Unwrap() []error {
+	return pe.Errors
+}
+
+var (
+	schemeOnce sync.Once
+	schemeErr  error
+)
+
+func registerSchemes() error {
+	schemeOnce.Do(func() {
+		var errs []error
+		if err := kustv1.AddToScheme(scheme.Scheme); err != nil {
+			errs = append(errs, fmt.Errorf("kustomize: %w", err))
+		}
+		if err := helmv2.AddToScheme(scheme.Scheme); err != nil {
+			errs = append(errs, fmt.Errorf("helm: %w", err))
+		}
+		if err := imagev1.AddToScheme(scheme.Scheme); err != nil {
+			errs = append(errs, fmt.Errorf("image: %w", err))
+		}
+		if err := notifv1beta2.AddToScheme(scheme.Scheme); err != nil {
+			errs = append(errs, fmt.Errorf("notification: %w", err))
+		}
+		if err := sourcev1.AddToScheme(scheme.Scheme); err != nil {
+			errs = append(errs, fmt.Errorf("source: %w", err))
+		}
+		if err := certv1.AddToScheme(scheme.Scheme); err != nil {
+			errs = append(errs, fmt.Errorf("cert-manager: %w", err))
+		}
+		if err := metallbv1beta1.AddToScheme(scheme.Scheme); err != nil {
+			errs = append(errs, fmt.Errorf("metallb: %w", err))
+		}
+		if len(errs) > 0 {
+			schemeErr = &ParseErrors{Errors: errs}
+		}
+	})
+	return schemeErr
+}
 
 func parse(yamlbytes []byte) ([]runtime.Object, error) {
 
@@ -24,10 +94,12 @@ func parse(yamlbytes []byte) ([]runtime.Object, error) {
 	decoder := yamlutil.NewYAMLOrJSONDecoder(bytes.NewReader(yamlbytes), 4096)
 	retVal := make([]runtime.Object, 0)
 
-	if err := kustv1.AddToScheme(scheme.Scheme); err != nil {
-		log.Printf("failed to register kustomize scheme: %v", err)
+	if err := registerSchemes(); err != nil {
+		return nil, fmt.Errorf("register schemes: %w", err)
 	}
 	decode := scheme.Codecs.UniversalDeserializer().Decode
+
+	var errs []error
 
 	for {
 		var raw runtime.RawExtension
@@ -35,7 +107,7 @@ func parse(yamlbytes []byte) ([]runtime.Object, error) {
 			if err == io.EOF {
 				break
 			}
-			log.Fatal(fmt.Sprintf("Error while decoding YAML object. Err was: %s", err))
+			errs = append(errs, fmt.Errorf("decode document: %w", err))
 			continue
 		}
 		if len(bytes.TrimSpace(raw.Raw)) == 0 {
@@ -43,15 +115,19 @@ func parse(yamlbytes []byte) ([]runtime.Object, error) {
 		}
 		obj, _, err := decode(raw.Raw, nil, nil)
 		if err != nil {
-			return nil, fmt.Errorf("decode YAML object: %w", err)
+			errs = append(errs, fmt.Errorf("decode object: %w", err))
+			continue
 		}
 		if err := checkType(obj); err != nil {
-			log.Printf("skipping unsupported object: %v", err)
+			errs = append(errs, err)
 			continue
 		}
 		retVal = append(retVal, obj)
 	}
 
+	if len(errs) > 0 {
+		return retVal, &ParseErrors{Errors: errs}
+	}
 	return retVal, nil
 }
 

--- a/internal/yaml/import_test.go
+++ b/internal/yaml/import_test.go
@@ -1,6 +1,7 @@
 package yaml
 
 import (
+	"errors"
 	"os"
 	"testing"
 
@@ -83,5 +84,99 @@ spec:
 	}
 	if len(objs) != 2 {
 		t.Fatalf("expected 2 objects, got %d", len(objs))
+	}
+}
+
+func TestParseErrors(t *testing.T) {
+	data := `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa
+---
+notvalid
+---
+apiVersion: foo/v1
+kind: Unsupported
+metadata:
+  name: x
+`
+	objs, err := parse([]byte(data))
+	if err == nil {
+		t.Fatalf("expected parse error")
+	}
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 valid object, got %d", len(objs))
+	}
+	var pe *ParseErrors
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected ParseErrors, got %T", err)
+	}
+	if len(pe.Errors) != 2 {
+		t.Fatalf("expected 2 errors, got %d", len(pe.Errors))
+	}
+}
+
+func TestParseCRDs(t *testing.T) {
+	data := `apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: hr
+spec: {}
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageUpdateAutomation
+metadata:
+  name: ia
+spec:
+  interval: 1m
+  sourceRef:
+    kind: GitRepository
+    name: repo
+  git:
+    checkout: {}
+    commit:
+      author:
+        name: bot
+        email: bot@example.com
+    push: {}
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Provider
+metadata:
+  name: prov
+spec:
+  type: slack
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: repo
+spec:
+  url: https://example.com/git.git
+  interval: 1m
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cert
+spec:
+  secretName: s
+  issuerRef:
+    name: issuer
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: pool
+spec:
+  addresses:
+  - 1.2.3.4-1.2.3.5
+`
+	objs, err := parse([]byte(data))
+	if err != nil {
+		t.Fatalf("parse returned error: %v", err)
+	}
+	if len(objs) != 6 {
+		t.Fatalf("expected 6 objects, got %d", len(objs))
 	}
 }


### PR DESCRIPTION
## Summary
- add `ParseErrors` for multi-error reporting
- register Flux, cert-manager, and MetalLB CRDs
- collect parsing errors instead of exiting
- test invalid docs and CRD decoding

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6878172301f8832f8d5972b1d99d9f06