### PR TITLE
Add nil checks to fluxcd helpers

### DIFF
--- a/internal/fluxcd/fluxinstance.go
+++ b/internal/fluxcd/fluxinstance.go
@@ -1,6 +1,8 @@
 package fluxcd
 
 import (
+	"errors"
+
 	fluxv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -22,51 +24,91 @@ func CreateFluxInstance(name, namespace string, spec fluxv1.FluxInstanceSpec) *f
 }
 
 // AddFluxInstanceComponent appends a component to the FluxInstance spec.
-func AddFluxInstanceComponent(obj *fluxv1.FluxInstance, c fluxv1.Component) {
+func AddFluxInstanceComponent(obj *fluxv1.FluxInstance, c fluxv1.Component) error {
+	if obj == nil {
+		return errors.New("nil FluxInstance")
+	}
 	obj.Spec.Components = append(obj.Spec.Components, c)
+	return nil
 }
 
 // SetFluxInstanceDistribution sets the distribution of the FluxInstance.
-func SetFluxInstanceDistribution(obj *fluxv1.FluxInstance, dist fluxv1.Distribution) {
+func SetFluxInstanceDistribution(obj *fluxv1.FluxInstance, dist fluxv1.Distribution) error {
+	if obj == nil {
+		return errors.New("nil FluxInstance")
+	}
 	obj.Spec.Distribution = dist
+	return nil
 }
 
 // SetFluxInstanceCommonMetadata sets the common metadata.
-func SetFluxInstanceCommonMetadata(obj *fluxv1.FluxInstance, cm *fluxv1.CommonMetadata) {
+func SetFluxInstanceCommonMetadata(obj *fluxv1.FluxInstance, cm *fluxv1.CommonMetadata) error {
+	if obj == nil {
+		return errors.New("nil FluxInstance")
+	}
 	obj.Spec.CommonMetadata = cm
+	return nil
 }
 
 // SetFluxInstanceCluster sets the cluster information.
-func SetFluxInstanceCluster(obj *fluxv1.FluxInstance, cluster *fluxv1.Cluster) {
+func SetFluxInstanceCluster(obj *fluxv1.FluxInstance, cluster *fluxv1.Cluster) error {
+	if obj == nil {
+		return errors.New("nil FluxInstance")
+	}
 	obj.Spec.Cluster = cluster
+	return nil
 }
 
 // SetFluxInstanceSharding sets the sharding specification.
-func SetFluxInstanceSharding(obj *fluxv1.FluxInstance, shard *fluxv1.Sharding) {
+func SetFluxInstanceSharding(obj *fluxv1.FluxInstance, shard *fluxv1.Sharding) error {
+	if obj == nil {
+		return errors.New("nil FluxInstance")
+	}
 	obj.Spec.Sharding = shard
+	return nil
 }
 
 // SetFluxInstanceStorage sets the storage specification.
-func SetFluxInstanceStorage(obj *fluxv1.FluxInstance, st *fluxv1.Storage) {
+func SetFluxInstanceStorage(obj *fluxv1.FluxInstance, st *fluxv1.Storage) error {
+	if obj == nil {
+		return errors.New("nil FluxInstance")
+	}
 	obj.Spec.Storage = st
+	return nil
 }
 
 // SetFluxInstanceKustomize sets the kustomize specification.
-func SetFluxInstanceKustomize(obj *fluxv1.FluxInstance, k *fluxv1.Kustomize) {
+func SetFluxInstanceKustomize(obj *fluxv1.FluxInstance, k *fluxv1.Kustomize) error {
+	if obj == nil {
+		return errors.New("nil FluxInstance")
+	}
 	obj.Spec.Kustomize = k
+	return nil
 }
 
 // SetFluxInstanceWait sets the wait flag.
-func SetFluxInstanceWait(obj *fluxv1.FluxInstance, wait bool) {
+func SetFluxInstanceWait(obj *fluxv1.FluxInstance, wait bool) error {
+	if obj == nil {
+		return errors.New("nil FluxInstance")
+	}
 	obj.Spec.Wait = &wait
+	return nil
 }
 
 // SetFluxInstanceMigrateResources sets the migrateResources flag.
-func SetFluxInstanceMigrateResources(obj *fluxv1.FluxInstance, m bool) {
+func SetFluxInstanceMigrateResources(obj *fluxv1.FluxInstance, m bool) error {
+	if obj == nil {
+		return errors.New("nil FluxInstance")
+	}
 	obj.Spec.MigrateResources = &m
+	return nil
 }
 
 // SetFluxInstanceSync sets the sync configuration.
-func SetFluxInstanceSync(obj *fluxv1.FluxInstance, sync *fluxv1.Sync) {
+func SetFluxInstanceSync(obj *fluxv1.FluxInstance, sync *fluxv1.Sync) error {
+	if obj == nil {
+		return errors.New("nil FluxInstance")
+	}
 	obj.Spec.Sync = sync
+	return nil
 }

--- a/internal/fluxcd/fluxinstance_test.go
+++ b/internal/fluxcd/fluxinstance_test.go
@@ -24,8 +24,12 @@ func TestCreateFluxInstance(t *testing.T) {
 
 func TestFluxInstanceHelpers(t *testing.T) {
 	fi := CreateFluxInstance("flux", "ns", fluxv1.FluxInstanceSpec{Distribution: fluxv1.Distribution{}})
-	AddFluxInstanceComponent(fi, "source-controller")
-	SetFluxInstanceWait(fi, true)
+	if err := AddFluxInstanceComponent(fi, "source-controller"); err != nil {
+		t.Fatalf("AddFluxInstanceComponent returned error: %v", err)
+	}
+	if err := SetFluxInstanceWait(fi, true); err != nil {
+		t.Fatalf("SetFluxInstanceWait returned error: %v", err)
+	}
 	if len(fi.Spec.Components) != 1 || fi.Spec.Components[0] != "source-controller" {
 		t.Errorf("component not added")
 	}

--- a/internal/fluxcd/fluxreport.go
+++ b/internal/fluxcd/fluxreport.go
@@ -1,6 +1,8 @@
 package fluxcd
 
 import (
+	"errors"
+
 	fluxv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -22,31 +24,55 @@ func CreateFluxReport(name, namespace string, spec fluxv1.FluxReportSpec) *fluxv
 }
 
 // SetFluxReportDistribution sets the distribution status.
-func SetFluxReportDistribution(fr *fluxv1.FluxReport, dist fluxv1.FluxDistributionStatus) {
+func SetFluxReportDistribution(fr *fluxv1.FluxReport, dist fluxv1.FluxDistributionStatus) error {
+	if fr == nil {
+		return errors.New("nil FluxReport")
+	}
 	fr.Spec.Distribution = dist
+	return nil
 }
 
 // SetFluxReportCluster sets the cluster info.
-func SetFluxReportCluster(fr *fluxv1.FluxReport, c *fluxv1.ClusterInfo) {
+func SetFluxReportCluster(fr *fluxv1.FluxReport, c *fluxv1.ClusterInfo) error {
+	if fr == nil {
+		return errors.New("nil FluxReport")
+	}
 	fr.Spec.Cluster = c
+	return nil
 }
 
 // SetFluxReportOperator sets the operator info.
-func SetFluxReportOperator(fr *fluxv1.FluxReport, op *fluxv1.OperatorInfo) {
+func SetFluxReportOperator(fr *fluxv1.FluxReport, op *fluxv1.OperatorInfo) error {
+	if fr == nil {
+		return errors.New("nil FluxReport")
+	}
 	fr.Spec.Operator = op
+	return nil
 }
 
 // AddFluxReportComponentStatus appends a component status.
-func AddFluxReportComponentStatus(fr *fluxv1.FluxReport, cs fluxv1.FluxComponentStatus) {
+func AddFluxReportComponentStatus(fr *fluxv1.FluxReport, cs fluxv1.FluxComponentStatus) error {
+	if fr == nil {
+		return errors.New("nil FluxReport")
+	}
 	fr.Spec.ComponentsStatus = append(fr.Spec.ComponentsStatus, cs)
+	return nil
 }
 
 // AddFluxReportReconcilerStatus appends a reconciler status.
-func AddFluxReportReconcilerStatus(fr *fluxv1.FluxReport, rs fluxv1.FluxReconcilerStatus) {
+func AddFluxReportReconcilerStatus(fr *fluxv1.FluxReport, rs fluxv1.FluxReconcilerStatus) error {
+	if fr == nil {
+		return errors.New("nil FluxReport")
+	}
 	fr.Spec.ReconcilersStatus = append(fr.Spec.ReconcilersStatus, rs)
+	return nil
 }
 
 // SetFluxReportSyncStatus sets the sync status.
-func SetFluxReportSyncStatus(fr *fluxv1.FluxReport, s *fluxv1.FluxSyncStatus) {
+func SetFluxReportSyncStatus(fr *fluxv1.FluxReport, s *fluxv1.FluxSyncStatus) error {
+	if fr == nil {
+		return errors.New("nil FluxReport")
+	}
 	fr.Spec.SyncStatus = s
+	return nil
 }

--- a/internal/fluxcd/fluxreport_test.go
+++ b/internal/fluxcd/fluxreport_test.go
@@ -24,8 +24,12 @@ func TestCreateFluxReport(t *testing.T) {
 
 func TestFluxReportHelpers(t *testing.T) {
 	fr := CreateFluxReport("flux", "ns", fluxv1.FluxReportSpec{})
-	AddFluxReportComponentStatus(fr, fluxv1.FluxComponentStatus{Name: "source-controller"})
-	AddFluxReportReconcilerStatus(fr, fluxv1.FluxReconcilerStatus{Kind: "Kustomization"})
+	if err := AddFluxReportComponentStatus(fr, fluxv1.FluxComponentStatus{Name: "source-controller"}); err != nil {
+		t.Fatalf("AddFluxReportComponentStatus returned error: %v", err)
+	}
+	if err := AddFluxReportReconcilerStatus(fr, fluxv1.FluxReconcilerStatus{Kind: "Kustomization"}); err != nil {
+		t.Fatalf("AddFluxReportReconcilerStatus returned error: %v", err)
+	}
 	if len(fr.Spec.ComponentsStatus) != 1 {
 		t.Errorf("component status not added")
 	}

--- a/internal/fluxcd/resourceset.go
+++ b/internal/fluxcd/resourceset.go
@@ -1,6 +1,8 @@
 package fluxcd
 
 import (
+	"errors"
+
 	fluxv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,41 +25,73 @@ func CreateResourceSet(name, namespace string, spec fluxv1.ResourceSetSpec) *flu
 }
 
 // AddResourceSetInput appends an input to the ResourceSet.
-func AddResourceSetInput(rs *fluxv1.ResourceSet, in fluxv1.ResourceSetInput) {
+func AddResourceSetInput(rs *fluxv1.ResourceSet, in fluxv1.ResourceSetInput) error {
+	if rs == nil {
+		return errors.New("nil ResourceSet")
+	}
 	rs.Spec.Inputs = append(rs.Spec.Inputs, in)
+	return nil
 }
 
 // AddResourceSetInputFrom appends an input provider reference.
-func AddResourceSetInputFrom(rs *fluxv1.ResourceSet, ref fluxv1.InputProviderReference) {
+func AddResourceSetInputFrom(rs *fluxv1.ResourceSet, ref fluxv1.InputProviderReference) error {
+	if rs == nil {
+		return errors.New("nil ResourceSet")
+	}
 	rs.Spec.InputsFrom = append(rs.Spec.InputsFrom, ref)
+	return nil
 }
 
 // AddResourceSetResource appends a resource to reconcile.
-func AddResourceSetResource(rs *fluxv1.ResourceSet, r *apiextensionsv1.JSON) {
+func AddResourceSetResource(rs *fluxv1.ResourceSet, r *apiextensionsv1.JSON) error {
+	if rs == nil || r == nil {
+		return errors.New("nil ResourceSet or resource")
+	}
 	rs.Spec.Resources = append(rs.Spec.Resources, r)
+	return nil
 }
 
 // SetResourceSetResourcesTemplate sets the resources template.
-func SetResourceSetResourcesTemplate(rs *fluxv1.ResourceSet, tpl string) {
+func SetResourceSetResourcesTemplate(rs *fluxv1.ResourceSet, tpl string) error {
+	if rs == nil {
+		return errors.New("nil ResourceSet")
+	}
 	rs.Spec.ResourcesTemplate = tpl
+	return nil
 }
 
 // AddResourceSetDependency appends a dependency.
-func AddResourceSetDependency(rs *fluxv1.ResourceSet, dep fluxv1.Dependency) {
+func AddResourceSetDependency(rs *fluxv1.ResourceSet, dep fluxv1.Dependency) error {
+	if rs == nil {
+		return errors.New("nil ResourceSet")
+	}
 	rs.Spec.DependsOn = append(rs.Spec.DependsOn, dep)
+	return nil
 }
 
 // SetResourceSetServiceAccountName sets the service account name.
-func SetResourceSetServiceAccountName(rs *fluxv1.ResourceSet, name string) {
+func SetResourceSetServiceAccountName(rs *fluxv1.ResourceSet, name string) error {
+	if rs == nil {
+		return errors.New("nil ResourceSet")
+	}
 	rs.Spec.ServiceAccountName = name
+	return nil
 }
 
 // SetResourceSetWait sets the wait flag.
-func SetResourceSetWait(rs *fluxv1.ResourceSet, wait bool) {
+func SetResourceSetWait(rs *fluxv1.ResourceSet, wait bool) error {
+	if rs == nil {
+		return errors.New("nil ResourceSet")
+	}
 	rs.Spec.Wait = wait
+	return nil
 }
 
 // SetResourceSetCommonMetadata sets the common metadata.
-func SetResourceSetCommonMetadata(rs *fluxv1.ResourceSet, cm *fluxv1.CommonMetadata) {
+func SetResourceSetCommonMetadata(rs *fluxv1.ResourceSet, cm *fluxv1.CommonMetadata) error {
+	if rs == nil {
+		return errors.New("nil ResourceSet")
+	}
 	rs.Spec.CommonMetadata = cm
+	return nil
 }

--- a/internal/fluxcd/resourceset_test.go
+++ b/internal/fluxcd/resourceset_test.go
@@ -19,12 +19,24 @@ func TestCreateResourceSet(t *testing.T) {
 
 func TestResourceSetHelpers(t *testing.T) {
 	rs := CreateResourceSet("rs", "ns", fluxv1.ResourceSetSpec{})
-	AddResourceSetInput(rs, fluxv1.ResourceSetInput{"k": &apiextensionsv1.JSON{Raw: []byte("1")}})
-	AddResourceSetInputFrom(rs, fluxv1.InputProviderReference{Kind: fluxv1.ResourceSetInputProviderKind})
-	AddResourceSetResource(rs, &apiextensionsv1.JSON{Raw: []byte("{}")})
-	AddResourceSetDependency(rs, fluxv1.Dependency{Kind: "ConfigMap", Name: "cm"})
-	SetResourceSetServiceAccountName(rs, "sa")
-	SetResourceSetWait(rs, true)
+	if err := AddResourceSetInput(rs, fluxv1.ResourceSetInput{"k": &apiextensionsv1.JSON{Raw: []byte("1")}}); err != nil {
+		t.Fatalf("AddResourceSetInput returned error: %v", err)
+	}
+	if err := AddResourceSetInputFrom(rs, fluxv1.InputProviderReference{Kind: fluxv1.ResourceSetInputProviderKind}); err != nil {
+		t.Fatalf("AddResourceSetInputFrom returned error: %v", err)
+	}
+	if err := AddResourceSetResource(rs, &apiextensionsv1.JSON{Raw: []byte("{}")}); err != nil {
+		t.Fatalf("AddResourceSetResource returned error: %v", err)
+	}
+	if err := AddResourceSetDependency(rs, fluxv1.Dependency{Kind: "ConfigMap", Name: "cm"}); err != nil {
+		t.Fatalf("AddResourceSetDependency returned error: %v", err)
+	}
+	if err := SetResourceSetServiceAccountName(rs, "sa"); err != nil {
+		t.Fatalf("SetResourceSetServiceAccountName returned error: %v", err)
+	}
+	if err := SetResourceSetWait(rs, true); err != nil {
+		t.Fatalf("SetResourceSetWait returned error: %v", err)
+	}
 	if len(rs.Spec.Inputs) != 1 {
 		t.Errorf("input not added")
 	}

--- a/internal/fluxcd/resourcesetinputprovider.go
+++ b/internal/fluxcd/resourcesetinputprovider.go
@@ -1,6 +1,8 @@
 package fluxcd
 
 import (
+	"errors"
+
 	fluxv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 	meta "github.com/fluxcd/pkg/apis/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,31 +25,55 @@ func CreateResourceSetInputProvider(name, namespace string, spec fluxv1.Resource
 }
 
 // SetResourceSetInputProviderType sets the provider type.
-func SetResourceSetInputProviderType(obj *fluxv1.ResourceSetInputProvider, typ string) {
+func SetResourceSetInputProviderType(obj *fluxv1.ResourceSetInputProvider, typ string) error {
+	if obj == nil {
+		return errors.New("nil ResourceSetInputProvider")
+	}
 	obj.Spec.Type = typ
+	return nil
 }
 
 // SetResourceSetInputProviderURL sets the provider URL.
-func SetResourceSetInputProviderURL(obj *fluxv1.ResourceSetInputProvider, url string) {
+func SetResourceSetInputProviderURL(obj *fluxv1.ResourceSetInputProvider, url string) error {
+	if obj == nil {
+		return errors.New("nil ResourceSetInputProvider")
+	}
 	obj.Spec.URL = url
+	return nil
 }
 
 // SetResourceSetInputProviderServiceAccountName sets the service account name.
-func SetResourceSetInputProviderServiceAccountName(obj *fluxv1.ResourceSetInputProvider, name string) {
+func SetResourceSetInputProviderServiceAccountName(obj *fluxv1.ResourceSetInputProvider, name string) error {
+	if obj == nil {
+		return errors.New("nil ResourceSetInputProvider")
+	}
 	obj.Spec.ServiceAccountName = name
+	return nil
 }
 
 // SetResourceSetInputProviderSecretRef sets the secret reference.
-func SetResourceSetInputProviderSecretRef(obj *fluxv1.ResourceSetInputProvider, ref *meta.LocalObjectReference) {
+func SetResourceSetInputProviderSecretRef(obj *fluxv1.ResourceSetInputProvider, ref *meta.LocalObjectReference) error {
+	if obj == nil {
+		return errors.New("nil ResourceSetInputProvider")
+	}
 	obj.Spec.SecretRef = ref
+	return nil
 }
 
 // SetResourceSetInputProviderCertSecretRef sets the certificate secret reference.
-func SetResourceSetInputProviderCertSecretRef(obj *fluxv1.ResourceSetInputProvider, ref *meta.LocalObjectReference) {
+func SetResourceSetInputProviderCertSecretRef(obj *fluxv1.ResourceSetInputProvider, ref *meta.LocalObjectReference) error {
+	if obj == nil {
+		return errors.New("nil ResourceSetInputProvider")
+	}
 	obj.Spec.CertSecretRef = ref
+	return nil
 }
 
 // AddResourceSetInputProviderSchedule appends a schedule to the provider.
-func AddResourceSetInputProviderSchedule(obj *fluxv1.ResourceSetInputProvider, s fluxv1.Schedule) {
+func AddResourceSetInputProviderSchedule(obj *fluxv1.ResourceSetInputProvider, s fluxv1.Schedule) error {
+	if obj == nil {
+		return errors.New("nil ResourceSetInputProvider")
+	}
 	obj.Spec.Schedule = append(obj.Spec.Schedule, s)
+	return nil
 }

--- a/internal/fluxcd/resourcesetinputprovider_test.go
+++ b/internal/fluxcd/resourcesetinputprovider_test.go
@@ -19,12 +19,24 @@ func TestCreateResourceSetInputProvider(t *testing.T) {
 
 func TestResourceSetInputProviderHelpers(t *testing.T) {
 	rsip := CreateResourceSetInputProvider("prov", "ns", fluxv1.ResourceSetInputProviderSpec{})
-	SetResourceSetInputProviderType(rsip, fluxv1.InputProviderGitHubBranch)
-	SetResourceSetInputProviderURL(rsip, "https://example.com/repo")
-	SetResourceSetInputProviderServiceAccountName(rsip, "sa")
-	SetResourceSetInputProviderSecretRef(rsip, &meta.LocalObjectReference{Name: "secret"})
-	SetResourceSetInputProviderCertSecretRef(rsip, &meta.LocalObjectReference{Name: "cert"})
-	AddResourceSetInputProviderSchedule(rsip, CreateSchedule("@daily"))
+	if err := SetResourceSetInputProviderType(rsip, fluxv1.InputProviderGitHubBranch); err != nil {
+		t.Fatalf("SetResourceSetInputProviderType returned error: %v", err)
+	}
+	if err := SetResourceSetInputProviderURL(rsip, "https://example.com/repo"); err != nil {
+		t.Fatalf("SetResourceSetInputProviderURL returned error: %v", err)
+	}
+	if err := SetResourceSetInputProviderServiceAccountName(rsip, "sa"); err != nil {
+		t.Fatalf("SetResourceSetInputProviderServiceAccountName returned error: %v", err)
+	}
+	if err := SetResourceSetInputProviderSecretRef(rsip, &meta.LocalObjectReference{Name: "secret"}); err != nil {
+		t.Fatalf("SetResourceSetInputProviderSecretRef returned error: %v", err)
+	}
+	if err := SetResourceSetInputProviderCertSecretRef(rsip, &meta.LocalObjectReference{Name: "cert"}); err != nil {
+		t.Fatalf("SetResourceSetInputProviderCertSecretRef returned error: %v", err)
+	}
+	if err := AddResourceSetInputProviderSchedule(rsip, CreateSchedule("@daily")); err != nil {
+		t.Fatalf("AddResourceSetInputProviderSchedule returned error: %v", err)
+	}
 	if rsip.Spec.Type != fluxv1.InputProviderGitHubBranch {
 		t.Errorf("type not set")
 	}

--- a/internal/fluxcd/schedule.go
+++ b/internal/fluxcd/schedule.go
@@ -1,6 +1,8 @@
 package fluxcd
 
 import (
+	"errors"
+
 	fluxv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -11,11 +13,19 @@ func CreateSchedule(cron string) fluxv1.Schedule {
 }
 
 // SetScheduleTimeZone sets the time zone on the schedule.
-func SetScheduleTimeZone(s *fluxv1.Schedule, tz string) {
+func SetScheduleTimeZone(s *fluxv1.Schedule, tz string) error {
+	if s == nil {
+		return errors.New("nil Schedule")
+	}
 	s.TimeZone = tz
+	return nil
 }
 
 // SetScheduleWindow sets the execution window.
-func SetScheduleWindow(s *fluxv1.Schedule, d metav1.Duration) {
+func SetScheduleWindow(s *fluxv1.Schedule, d metav1.Duration) error {
+	if s == nil {
+		return errors.New("nil Schedule")
+	}
 	s.Window = d
+	return nil
 }

--- a/internal/fluxcd/schedule_test.go
+++ b/internal/fluxcd/schedule_test.go
@@ -7,8 +7,12 @@ import (
 
 func TestScheduleHelpers(t *testing.T) {
 	sc := CreateSchedule("@hourly")
-	SetScheduleTimeZone(&sc, "UTC")
-	SetScheduleWindow(&sc, metav1.Duration{Duration: 0})
+	if err := SetScheduleTimeZone(&sc, "UTC"); err != nil {
+		t.Fatalf("SetScheduleTimeZone returned error: %v", err)
+	}
+	if err := SetScheduleWindow(&sc, metav1.Duration{Duration: 0}); err != nil {
+		t.Fatalf("SetScheduleWindow returned error: %v", err)
+	}
 	if sc.Cron != "@hourly" {
 		t.Errorf("cron not set")
 	}

--- a/main.go
+++ b/main.go
@@ -323,17 +323,17 @@ func main() {
 	fi := fluxcd.CreateFluxInstance("flux", "flux-system", fluxv1.FluxInstanceSpec{
 		Distribution: fluxv1.Distribution{Version: "2.x", Registry: "ghcr.io/fluxcd"},
 	})
-	fluxcd.AddFluxInstanceComponent(fi, "source-controller")
+	_ = fluxcd.AddFluxInstanceComponent(fi, "source-controller")
 
 	fr := fluxcd.CreateFluxReport("flux", "flux-system", fluxv1.FluxReportSpec{
 		Distribution: fluxv1.FluxDistributionStatus{Entitlement: "oss", Status: "Running"},
 	})
 
 	rs := fluxcd.CreateResourceSet("demo-rs", "demo", fluxv1.ResourceSetSpec{})
-	fluxcd.AddResourceSetResource(rs, &apiextensionsv1.JSON{Raw: []byte("{}")})
+	_ = fluxcd.AddResourceSetResource(rs, &apiextensionsv1.JSON{Raw: []byte("{}")})
 
 	prov := fluxcd.CreateResourceSetInputProvider("demo-rsip", "demo", fluxv1.ResourceSetInputProviderSpec{Type: fluxv1.InputProviderStatic})
-	fluxcd.AddResourceSetInputProviderSchedule(prov, fluxcd.CreateSchedule("@daily"))
+	_ = fluxcd.AddResourceSetInputProviderSchedule(prov, fluxcd.CreateSchedule("@daily"))
 
 	// Print objects as YAML
 	y.PrintObj(sa, os.Stdout)


### PR DESCRIPTION
## Summary
- add nil checks with error returns across fluxcd helper functions
- update tests for new error signatures
- adjust example code to ignore returned errors

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6878ab38a66c832f85cb85b765d38ceb