### PR TITLE
Add pod ephemeral container helpers

### DIFF
--- a/internal/k8s/pod.go
+++ b/internal/k8s/pod.go
@@ -56,6 +56,14 @@ func AddPodInitContainer(pod *corev1.Pod, container *corev1.Container) error {
 	return nil
 }
 
+func AddPodEphemeralContainer(pod *corev1.Pod, container *corev1.EphemeralContainer) error {
+	if pod == nil || container == nil {
+		return errors.New("nil pod or container")
+	}
+	pod.Spec.EphemeralContainers = append(pod.Spec.EphemeralContainers, *container)
+	return nil
+}
+
 func AddPodVolume(pod *corev1.Pod, volume *corev1.Volume) error {
 	if pod == nil || volume == nil {
 		return errors.New("nil pod or volume")
@@ -120,5 +128,21 @@ func SetPodNodeSelector(pod *corev1.Pod, nodeSelector map[string]string) error {
 		return errors.New("nil pod")
 	}
 	pod.Spec.NodeSelector = nodeSelector
+	return nil
+}
+
+func SetPodHostNetwork(pod *corev1.Pod, hostNetwork bool) error {
+	if pod == nil {
+		return errors.New("nil pod")
+	}
+	pod.Spec.HostNetwork = hostNetwork
+	return nil
+}
+
+func SetPodDNSPolicy(pod *corev1.Pod, policy corev1.DNSPolicy) error {
+	if pod == nil {
+		return errors.New("nil pod")
+	}
+	pod.Spec.DNSPolicy = policy
 	return nil
 }

--- a/internal/k8s/pod_test.go
+++ b/internal/k8s/pod_test.go
@@ -118,4 +118,26 @@ func TestPodFunctions(t *testing.T) {
 	if !reflect.DeepEqual(pod.Spec.NodeSelector, ns) {
 		t.Errorf("node selector not set")
 	}
+
+	ec := corev1.EphemeralContainer{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "debug"}}
+	if err := AddPodEphemeralContainer(pod, &ec); err != nil {
+		t.Fatalf("AddPodEphemeralContainer returned error: %v", err)
+	}
+	if len(pod.Spec.EphemeralContainers) != 1 {
+		t.Errorf("ephemeral container not added")
+	}
+
+	if err := SetPodHostNetwork(pod, true); err != nil {
+		t.Fatalf("SetPodHostNetwork returned error: %v", err)
+	}
+	if !pod.Spec.HostNetwork {
+		t.Errorf("host network not set")
+	}
+
+	if err := SetPodDNSPolicy(pod, corev1.DNSClusterFirstWithHostNet); err != nil {
+		t.Fatalf("SetPodDNSPolicy returned error: %v", err)
+	}
+	if pod.Spec.DNSPolicy != corev1.DNSClusterFirstWithHostNet {
+		t.Errorf("dns policy not set")
+	}
 }


### PR DESCRIPTION
## Summary
- add helper for `EphemeralContainers` on `Pod`
- allow configuring host network and DNS policy
- cover new helpers in tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6878b366e3f0832f94e1103ee029608f