### PR TITLE
Add secret metadata helpers

### DIFF
--- a/internal/k8s/secret.go
+++ b/internal/k8s/secret.go
@@ -53,3 +53,25 @@ func SetSecretImmutable(secret *corev1.Secret, immutable bool) {
 	}
 	*secret.Immutable = immutable
 }
+
+func AddSecretLabel(secret *corev1.Secret, key, value string) {
+	if secret.Labels == nil {
+		secret.Labels = make(map[string]string)
+	}
+	secret.Labels[key] = value
+}
+
+func AddSecretAnnotation(secret *corev1.Secret, key, value string) {
+	if secret.Annotations == nil {
+		secret.Annotations = make(map[string]string)
+	}
+	secret.Annotations[key] = value
+}
+
+func SetSecretLabels(secret *corev1.Secret, labels map[string]string) {
+	secret.Labels = labels
+}
+
+func SetSecretAnnotations(secret *corev1.Secret, anns map[string]string) {
+	secret.Annotations = anns
+}

--- a/internal/k8s/secret_test.go
+++ b/internal/k8s/secret_test.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -61,5 +62,31 @@ func TestSetSecretImmutable(t *testing.T) {
 	SetSecretImmutable(sec, false)
 	if sec.Immutable == nil || *sec.Immutable {
 		t.Errorf("immutable not updated to false")
+	}
+}
+
+func TestSecretLabelFunctions(t *testing.T) {
+	sec := CreateSecret("s", "ns")
+	AddSecretLabel(sec, "env", "prod")
+	if sec.Labels["env"] != "prod" {
+		t.Errorf("label not added")
+	}
+	newLabels := map[string]string{"a": "b"}
+	SetSecretLabels(sec, newLabels)
+	if !reflect.DeepEqual(sec.Labels, newLabels) {
+		t.Errorf("labels not set correctly")
+	}
+}
+
+func TestSecretAnnotationFunctions(t *testing.T) {
+	sec := CreateSecret("s", "ns")
+	AddSecretAnnotation(sec, "team", "dev")
+	if sec.Annotations["team"] != "dev" {
+		t.Errorf("annotation not added")
+	}
+	newAnn := map[string]string{"x": "y"}
+	SetSecretAnnotations(sec, newAnn)
+	if !reflect.DeepEqual(sec.Annotations, newAnn) {
+		t.Errorf("annotations not set correctly")
 	}
 }


### PR DESCRIPTION
## Summary
- add helper functions to set labels and annotations on Secret objects
- extend tests for secret helpers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6878b365a250832f843cb46ea1e641e2