### PR TITLE
Add ConfigMap label/annotation helpers

### DIFF
--- a/internal/k8s/configmap.go
+++ b/internal/k8s/configmap.go
@@ -78,3 +78,29 @@ func SetConfigMapBinaryData(cm *corev1.ConfigMap, data map[string][]byte) {
 func SetConfigMapImmutable(cm *corev1.ConfigMap, immutable bool) {
 	cm.Immutable = &immutable
 }
+
+// AddConfigMapLabel adds a label to the ConfigMap.
+func AddConfigMapLabel(cm *corev1.ConfigMap, key, value string) {
+	if cm.Labels == nil {
+		cm.Labels = make(map[string]string)
+	}
+	cm.Labels[key] = value
+}
+
+// AddConfigMapAnnotation adds an annotation to the ConfigMap.
+func AddConfigMapAnnotation(cm *corev1.ConfigMap, key, value string) {
+	if cm.Annotations == nil {
+		cm.Annotations = make(map[string]string)
+	}
+	cm.Annotations[key] = value
+}
+
+// SetConfigMapLabels replaces all labels on the ConfigMap.
+func SetConfigMapLabels(cm *corev1.ConfigMap, labels map[string]string) {
+	cm.Labels = labels
+}
+
+// SetConfigMapAnnotations replaces all annotations on the ConfigMap.
+func SetConfigMapAnnotations(cm *corev1.ConfigMap, anns map[string]string) {
+	cm.Annotations = anns
+}

--- a/internal/k8s/configmap_test.go
+++ b/internal/k8s/configmap_test.go
@@ -78,3 +78,27 @@ func TestSetConfigMapImmutable(t *testing.T) {
 		t.Errorf("immutable not updated to false")
 	}
 }
+
+func TestConfigMapMetadataFunctions(t *testing.T) {
+	cm := CreateConfigMap("cm", "ns")
+
+	AddConfigMapLabel(cm, "k", "v")
+	if cm.Labels["k"] != "v" {
+		t.Errorf("label not added")
+	}
+
+	AddConfigMapAnnotation(cm, "a", "b")
+	if cm.Annotations["a"] != "b" {
+		t.Errorf("annotation not added")
+	}
+
+	SetConfigMapLabels(cm, map[string]string{"x": "y"})
+	if !reflect.DeepEqual(cm.Labels, map[string]string{"x": "y"}) {
+		t.Errorf("labels not set")
+	}
+
+	SetConfigMapAnnotations(cm, map[string]string{"c": "d"})
+	if !reflect.DeepEqual(cm.Annotations, map[string]string{"c": "d"}) {
+		t.Errorf("annotations not set")
+	}
+}


### PR DESCRIPTION
## Summary
- add helper functions to modify ConfigMap labels and annotations
- test ConfigMap metadata helper methods

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6878b364dcdc832fa2d313e6d344acf4