### PR TITLE
Add ServiceAccount metadata helpers

### DIFF
--- a/internal/k8s/serviceaccount.go
+++ b/internal/k8s/serviceaccount.go
@@ -56,3 +56,25 @@ func SetServiceAccountAutomountToken(sa *corev1.ServiceAccount, automount bool) 
 	*sa.AutomountServiceAccountToken = automount
 	return nil
 }
+
+func AddServiceAccountLabel(sa *corev1.ServiceAccount, key, value string) {
+	if sa.Labels == nil {
+		sa.Labels = make(map[string]string)
+	}
+	sa.Labels[key] = value
+}
+
+func AddServiceAccountAnnotation(sa *corev1.ServiceAccount, key, value string) {
+	if sa.Annotations == nil {
+		sa.Annotations = make(map[string]string)
+	}
+	sa.Annotations[key] = value
+}
+
+func SetServiceAccountLabels(sa *corev1.ServiceAccount, labels map[string]string) {
+	sa.Labels = labels
+}
+
+func SetServiceAccountAnnotations(sa *corev1.ServiceAccount, annotations map[string]string) {
+	sa.Annotations = annotations
+}

--- a/internal/k8s/serviceaccount_test.go
+++ b/internal/k8s/serviceaccount_test.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -63,5 +64,29 @@ func TestSetServiceAccountAutomountToken(t *testing.T) {
 	}
 	if sa.AutomountServiceAccountToken == nil || *sa.AutomountServiceAccountToken {
 		t.Errorf("automount token not updated to false")
+	}
+}
+
+func TestServiceAccountMetadataFunctions(t *testing.T) {
+	sa := CreateServiceAccount("sa", "ns")
+	AddServiceAccountLabel(sa, "team", "dev")
+	if sa.Labels["team"] != "dev" {
+		t.Errorf("label not added")
+	}
+	AddServiceAccountAnnotation(sa, "owner", "bob")
+	if sa.Annotations["owner"] != "bob" {
+		t.Errorf("annotation not added")
+	}
+
+	newLabels := map[string]string{"a": "b"}
+	SetServiceAccountLabels(sa, newLabels)
+	if !reflect.DeepEqual(sa.Labels, newLabels) {
+		t.Errorf("labels not set")
+	}
+
+	newAnn := map[string]string{"x": "y"}
+	SetServiceAccountAnnotations(sa, newAnn)
+	if !reflect.DeepEqual(sa.Annotations, newAnn) {
+		t.Errorf("annotations not set")
 	}
 }


### PR DESCRIPTION
## Summary
- extend ServiceAccount utilities with label/annotation helpers
- test new helper functions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6878b3661088832fb486039d31c32a1c