### PR TITLE
Add helper functions and tests for missing k8s fields

### DIFF
--- a/internal/k8s/ingress.go
+++ b/internal/k8s/ingress.go
@@ -67,3 +67,7 @@ func AddIngressRulePath(rule *netv1.IngressRule, path netv1.HTTPIngressPath) {
 func AddIngressTLS(ingress *netv1.Ingress, tls netv1.IngressTLS) {
 	ingress.Spec.TLS = append(ingress.Spec.TLS, tls)
 }
+
+func SetIngressDefaultBackend(ingress *netv1.Ingress, backend netv1.IngressBackend) {
+	ingress.Spec.DefaultBackend = &backend
+}

--- a/internal/k8s/ingress_test.go
+++ b/internal/k8s/ingress_test.go
@@ -44,4 +44,10 @@ func TestIngressFunctions(t *testing.T) {
 	if len(ing.Spec.TLS) != 1 || ing.Spec.TLS[0].Hosts[0] != "example.com" {
 		t.Errorf("tls not added")
 	}
+
+	backend := netv1.IngressBackend{Service: &netv1.IngressServiceBackend{Name: "svc", Port: netv1.ServiceBackendPort{Number: 80}}}
+	SetIngressDefaultBackend(ing, backend)
+	if ing.Spec.DefaultBackend == nil || ing.Spec.DefaultBackend.Service.Name != "svc" {
+		t.Errorf("default backend not set")
+	}
 }

--- a/internal/k8s/pod.go
+++ b/internal/k8s/pod.go
@@ -146,3 +146,11 @@ func SetPodDNSPolicy(pod *corev1.Pod, policy corev1.DNSPolicy) error {
 	pod.Spec.DNSPolicy = policy
 	return nil
 }
+
+func SetPodDNSConfig(pod *corev1.Pod, dnsConfig *corev1.PodDNSConfig) error {
+	if pod == nil {
+		return errors.New("nil pod")
+	}
+	pod.Spec.DNSConfig = dnsConfig
+	return nil
+}

--- a/internal/k8s/pod_test.go
+++ b/internal/k8s/pod_test.go
@@ -140,4 +140,12 @@ func TestPodFunctions(t *testing.T) {
 	if pod.Spec.DNSPolicy != corev1.DNSClusterFirstWithHostNet {
 		t.Errorf("dns policy not set")
 	}
+
+	dnsCfg := &corev1.PodDNSConfig{Nameservers: []string{"8.8.8.8"}}
+	if err := SetPodDNSConfig(pod, dnsCfg); err != nil {
+		t.Fatalf("SetPodDNSConfig returned error: %v", err)
+	}
+	if pod.Spec.DNSConfig != dnsCfg {
+		t.Errorf("dns config not set")
+	}
 }

--- a/internal/k8s/service.go
+++ b/internal/k8s/service.go
@@ -53,3 +53,11 @@ func SetServiceType(service *corev1.Service, type_ corev1.ServiceType) {
 func SetServiceExternalTrafficPolicy(service *corev1.Service, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 	service.Spec.ExternalTrafficPolicy = trafficPolicy
 }
+
+func SetServiceSessionAffinity(service *corev1.Service, affinity corev1.ServiceAffinity) {
+	service.Spec.SessionAffinity = affinity
+}
+
+func SetServiceLoadBalancerClass(service *corev1.Service, class string) {
+	service.Spec.LoadBalancerClass = &class
+}

--- a/internal/k8s/service_test.go
+++ b/internal/k8s/service_test.go
@@ -40,4 +40,14 @@ func TestServiceFunctions(t *testing.T) {
 	if svc.Spec.ExternalTrafficPolicy != corev1.ServiceExternalTrafficPolicyLocal {
 		t.Errorf("external traffic policy not set")
 	}
+
+	SetServiceSessionAffinity(svc, corev1.ServiceAffinityClientIP)
+	if svc.Spec.SessionAffinity != corev1.ServiceAffinityClientIP {
+		t.Errorf("session affinity not set")
+	}
+
+	SetServiceLoadBalancerClass(svc, "lb-class")
+	if svc.Spec.LoadBalancerClass == nil || *svc.Spec.LoadBalancerClass != "lb-class" {
+		t.Errorf("load balancer class not set")
+	}
 }


### PR DESCRIPTION
## Summary
- extend Service helpers with SessionAffinity and LoadBalancerClass
- add default backend helper for Ingress
- implement DNSConfig setter for Pod
- cover new helpers with unit tests

## Testing
- `go test ./internal/...`

------
https://chatgpt.com/codex/tasks/task_e_6878b5cbb524832faf880a1b2ea47c61