### PR TITLE
Add additional helper functions

### DIFF
--- a/internal/k8s/container.go
+++ b/internal/k8s/container.go
@@ -73,3 +73,31 @@ func SetContainerImagePullPolicy(container *corev1.Container, imagePullPolicy co
 func SetContainerSecurityContext(container *corev1.Container, securityContext corev1.SecurityContext) {
 	container.SecurityContext = &securityContext
 }
+
+func SetContainerWorkingDir(container *corev1.Container, dir string) {
+	container.WorkingDir = dir
+}
+
+func SetContainerLifecycle(container *corev1.Container, lifecycle *corev1.Lifecycle) {
+	container.Lifecycle = lifecycle
+}
+
+func SetContainerTerminationMessagePath(container *corev1.Container, path string) {
+	container.TerminationMessagePath = path
+}
+
+func SetContainerTerminationMessagePolicy(container *corev1.Container, policy corev1.TerminationMessagePolicy) {
+	container.TerminationMessagePolicy = policy
+}
+
+func SetContainerStdin(container *corev1.Container, stdin bool) {
+	container.Stdin = stdin
+}
+
+func SetContainerStdinOnce(container *corev1.Container, once bool) {
+	container.StdinOnce = once
+}
+
+func SetContainerTTY(container *corev1.Container, tty bool) {
+	container.TTY = tty
+}

--- a/internal/k8s/container_test.go
+++ b/internal/k8s/container_test.go
@@ -520,3 +520,43 @@ func TestAdditionalContainerFunctions(t *testing.T) {
 		t.Errorf("security context not set")
 	}
 }
+
+func TestContainerMiscFunctions(t *testing.T) {
+	c := &corev1.Container{}
+
+	SetContainerWorkingDir(c, "/work")
+	if c.WorkingDir != "/work" {
+		t.Errorf("working dir not set")
+	}
+
+	lc := &corev1.Lifecycle{}
+	SetContainerLifecycle(c, lc)
+	if c.Lifecycle != lc {
+		t.Errorf("lifecycle not set")
+	}
+
+	SetContainerTerminationMessagePath(c, "/tmp/msg")
+	if c.TerminationMessagePath != "/tmp/msg" {
+		t.Errorf("termination message path not set")
+	}
+
+	SetContainerTerminationMessagePolicy(c, corev1.TerminationMessageReadFile)
+	if c.TerminationMessagePolicy != corev1.TerminationMessageReadFile {
+		t.Errorf("termination message policy not set")
+	}
+
+	SetContainerStdin(c, true)
+	if !c.Stdin {
+		t.Errorf("stdin not set")
+	}
+
+	SetContainerStdinOnce(c, true)
+	if !c.StdinOnce {
+		t.Errorf("stdin once not set")
+	}
+
+	SetContainerTTY(c, true)
+	if !c.TTY {
+		t.Errorf("tty not set")
+	}
+}

--- a/internal/k8s/service.go
+++ b/internal/k8s/service.go
@@ -53,3 +53,25 @@ func SetServiceType(service *corev1.Service, type_ corev1.ServiceType) {
 func SetServiceExternalTrafficPolicy(service *corev1.Service, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 	service.Spec.ExternalTrafficPolicy = trafficPolicy
 }
+
+func AddServiceLabel(svc *corev1.Service, key, value string) {
+	if svc.Labels == nil {
+		svc.Labels = make(map[string]string)
+	}
+	svc.Labels[key] = value
+}
+
+func AddServiceAnnotation(svc *corev1.Service, key, value string) {
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	svc.Annotations[key] = value
+}
+
+func SetServiceLabels(svc *corev1.Service, labels map[string]string) {
+	svc.Labels = labels
+}
+
+func SetServiceAnnotations(svc *corev1.Service, anns map[string]string) {
+	svc.Annotations = anns
+}

--- a/internal/k8s/service_test.go
+++ b/internal/k8s/service_test.go
@@ -41,3 +41,29 @@ func TestServiceFunctions(t *testing.T) {
 		t.Errorf("external traffic policy not set")
 	}
 }
+
+func TestServiceMetadataFunctions(t *testing.T) {
+	svc := CreateService("svc", "ns")
+
+	AddServiceLabel(svc, "k", "v")
+	if svc.Labels["k"] != "v" {
+		t.Errorf("label not added")
+	}
+
+	AddServiceAnnotation(svc, "a", "b")
+	if svc.Annotations["a"] != "b" {
+		t.Errorf("annotation not added")
+	}
+
+	labels := map[string]string{"x": "y"}
+	SetServiceLabels(svc, labels)
+	if !reflect.DeepEqual(svc.Labels, labels) {
+		t.Errorf("labels not set")
+	}
+
+	anns := map[string]string{"c": "d"}
+	SetServiceAnnotations(svc, anns)
+	if !reflect.DeepEqual(svc.Annotations, anns) {
+		t.Errorf("annotations not set")
+	}
+}


### PR DESCRIPTION
## Summary
- add helper functions for container lifecycle, working dir, stdin, and more
- allow managing labels and annotations on Services
- test new helper functions

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6878b8613234832f8011b79b661a2318