### PR TITLE
Add extra k8s helpers

### DIFF
--- a/internal/k8s/deployment.go
+++ b/internal/k8s/deployment.go
@@ -138,3 +138,24 @@ func SetDeploymentNodeSelector(deployment *appsv1.Deployment, nodeSelector map[s
 	deployment.Spec.Template.Spec.NodeSelector = nodeSelector
 	return nil
 }
+
+// SetDeploymentReplicas sets the desired replica count.
+func SetDeploymentReplicas(deployment *appsv1.Deployment, replicas int32) error {
+	if deployment == nil {
+		return errors.New("nil deployment")
+	}
+	if deployment.Spec.Replicas == nil {
+		deployment.Spec.Replicas = new(int32)
+	}
+	*deployment.Spec.Replicas = replicas
+	return nil
+}
+
+// SetDeploymentStrategy sets the deployment strategy.
+func SetDeploymentStrategy(deployment *appsv1.Deployment, strategy appsv1.DeploymentStrategy) error {
+	if deployment == nil {
+		return errors.New("nil deployment")
+	}
+	deployment.Spec.Strategy = strategy
+	return nil
+}

--- a/internal/k8s/deployment_test.go
+++ b/internal/k8s/deployment_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -153,5 +154,20 @@ func TestDeploymentFunctions(t *testing.T) {
 	}
 	if !reflect.DeepEqual(dep.Spec.Template.Spec.NodeSelector, ns) {
 		t.Errorf("node selector not set")
+	}
+
+	if err := SetDeploymentReplicas(dep, 3); err != nil {
+		t.Fatalf("SetDeploymentReplicas returned error: %v", err)
+	}
+	if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 3 {
+		t.Errorf("replicas not set")
+	}
+
+	strat := appsv1.DeploymentStrategy{Type: appsv1.RollingUpdateDeploymentStrategyType}
+	if err := SetDeploymentStrategy(dep, strat); err != nil {
+		t.Fatalf("SetDeploymentStrategy returned error: %v", err)
+	}
+	if dep.Spec.Strategy.Type != appsv1.RollingUpdateDeploymentStrategyType {
+		t.Errorf("strategy not set")
 	}
 }

--- a/internal/k8s/service.go
+++ b/internal/k8s/service.go
@@ -55,6 +55,33 @@ func SetServiceType(service *corev1.Service, type_ corev1.ServiceType) error {
 	return nil
 }
 
+// SetServiceClusterIP sets the clusterIP on the Service spec.
+func SetServiceClusterIP(service *corev1.Service, ip string) error {
+	if service == nil {
+		return errors.New("nil service")
+	}
+	service.Spec.ClusterIP = ip
+	return nil
+}
+
+// AddServiceExternalIP appends an external IP address to the Service spec.
+func AddServiceExternalIP(service *corev1.Service, ip string) error {
+	if service == nil {
+		return errors.New("nil service")
+	}
+	service.Spec.ExternalIPs = append(service.Spec.ExternalIPs, ip)
+	return nil
+}
+
+// SetServiceLoadBalancerIP sets the load balancer IP on the Service spec.
+func SetServiceLoadBalancerIP(service *corev1.Service, ip string) error {
+	if service == nil {
+		return errors.New("nil service")
+	}
+	service.Spec.LoadBalancerIP = ip
+	return nil
+}
+
 /*
    service.Spec.LoadBalancerIP
 

--- a/internal/k8s/service_test.go
+++ b/internal/k8s/service_test.go
@@ -58,6 +58,27 @@ func TestServiceFunctions(t *testing.T) {
 	if svc.Spec.LoadBalancerClass == nil || *svc.Spec.LoadBalancerClass != "lb-class" {
 		t.Errorf("load balancer class not set")
 	}
+
+	if err := SetServiceClusterIP(svc, "10.0.0.1"); err != nil {
+		t.Fatalf("SetServiceClusterIP returned error: %v", err)
+	}
+	if svc.Spec.ClusterIP != "10.0.0.1" {
+		t.Errorf("clusterIP not set")
+	}
+
+	if err := AddServiceExternalIP(svc, "192.168.1.2"); err != nil {
+		t.Fatalf("AddServiceExternalIP returned error: %v", err)
+	}
+	if len(svc.Spec.ExternalIPs) != 1 || svc.Spec.ExternalIPs[0] != "192.168.1.2" {
+		t.Errorf("external IP not added")
+	}
+
+	if err := SetServiceLoadBalancerIP(svc, "1.1.1.1"); err != nil {
+		t.Fatalf("SetServiceLoadBalancerIP returned error: %v", err)
+	}
+	if svc.Spec.LoadBalancerIP != "1.1.1.1" {
+		t.Errorf("loadBalancerIP not set")
+	}
 }
 
 func TestServiceMetadataFunctions(t *testing.T) {


### PR DESCRIPTION
## Summary
- add missing helpers for Deployment replicas/strategy
- add helper functions for common Service fields
- cover new helpers with tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6878b8e68bc0832fa1c6948c68be3e09