### PR TITLE
Remove redundant import aliases

### DIFF
--- a/internal/fluxcd/notification.go
+++ b/internal/fluxcd/notification.go
@@ -1,7 +1,7 @@
 package fluxcd
 
 import (
-	v1 "github.com/fluxcd/notification-controller/api/v1"
+	"github.com/fluxcd/notification-controller/api/v1"
 	notificationv1beta2 "github.com/fluxcd/notification-controller/api/v1beta2"
 	"github.com/fluxcd/pkg/apis/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/fluxcd/notification_test.go
+++ b/internal/fluxcd/notification_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	v1 "github.com/fluxcd/notification-controller/api/v1"
+	"github.com/fluxcd/notification-controller/api/v1"
 	notificationv1beta2 "github.com/fluxcd/notification-controller/api/v1beta2"
 	"github.com/fluxcd/pkg/apis/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/fluxcd/resourcesetinputprovider.go
+++ b/internal/fluxcd/resourcesetinputprovider.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	fluxv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
-	meta "github.com/fluxcd/pkg/apis/meta"
+	"github.com/fluxcd/pkg/apis/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/internal/fluxcd/resourcesetinputprovider_test.go
+++ b/internal/fluxcd/resourcesetinputprovider_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	fluxv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
-	meta "github.com/fluxcd/pkg/apis/meta"
+	"github.com/fluxcd/pkg/apis/meta"
 )
 
 func TestCreateResourceSetInputProvider(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -36,9 +36,9 @@ import (
 
 	fluxv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
-	v1 "github.com/fluxcd/notification-controller/api/v1"
+	"github.com/fluxcd/notification-controller/api/v1"
 	notificationv1beta2 "github.com/fluxcd/notification-controller/api/v1beta2"
-	meta "github.com/fluxcd/pkg/apis/meta"
+	"github.com/fluxcd/pkg/apis/meta"
 	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 )
 


### PR DESCRIPTION
## Summary
- drop unnecessary import aliases that matched the package name

## Testing
- `go test ./... -run TestNonExistent -count=0`

------
https://chatgpt.com/codex/tasks/task_e_6878c8567568832fb80b5f110e95f3cf