### PR TITLE
Add k8s helper coverage

### DIFF
--- a/internal/k8s/pod.go
+++ b/internal/k8s/pod.go
@@ -169,3 +169,46 @@ func SetPodDNSConfig(pod *corev1.Pod, dnsConfig *corev1.PodDNSConfig) error {
 	pod.Spec.DNSConfig = dnsConfig
 	return nil
 }
+
+func SetPodHostname(pod *corev1.Pod, hostname string) error {
+	if pod == nil {
+		return errors.New("nil pod")
+	}
+	pod.Spec.Hostname = hostname
+	return nil
+}
+
+func SetPodSubdomain(pod *corev1.Pod, subdomain string) error {
+	if pod == nil {
+		return errors.New("nil pod")
+	}
+	pod.Spec.Subdomain = subdomain
+	return nil
+}
+
+func SetPodRestartPolicy(pod *corev1.Pod, policy corev1.RestartPolicy) error {
+	if pod == nil {
+		return errors.New("nil pod")
+	}
+	pod.Spec.RestartPolicy = policy
+	return nil
+}
+
+func SetPodTerminationGracePeriod(pod *corev1.Pod, secs int64) error {
+	if pod == nil {
+		return errors.New("nil pod")
+	}
+	if pod.Spec.TerminationGracePeriodSeconds == nil {
+		pod.Spec.TerminationGracePeriodSeconds = new(int64)
+	}
+	*pod.Spec.TerminationGracePeriodSeconds = secs
+	return nil
+}
+
+func SetPodSchedulerName(pod *corev1.Pod, scheduler string) error {
+	if pod == nil {
+		return errors.New("nil pod")
+	}
+	pod.Spec.SchedulerName = scheduler
+	return nil
+}

--- a/internal/k8s/pod_test.go
+++ b/internal/k8s/pod_test.go
@@ -148,4 +148,39 @@ func TestPodFunctions(t *testing.T) {
 	if pod.Spec.DNSConfig != dnsCfg {
 		t.Errorf("dns config not set")
 	}
+
+	if err := SetPodHostname(pod, "myhost"); err != nil {
+		t.Fatalf("SetPodHostname returned error: %v", err)
+	}
+	if pod.Spec.Hostname != "myhost" {
+		t.Errorf("hostname not set")
+	}
+
+	if err := SetPodSubdomain(pod, "sub"); err != nil {
+		t.Fatalf("SetPodSubdomain returned error: %v", err)
+	}
+	if pod.Spec.Subdomain != "sub" {
+		t.Errorf("subdomain not set")
+	}
+
+	if err := SetPodRestartPolicy(pod, corev1.RestartPolicyOnFailure); err != nil {
+		t.Fatalf("SetPodRestartPolicy returned error: %v", err)
+	}
+	if pod.Spec.RestartPolicy != corev1.RestartPolicyOnFailure {
+		t.Errorf("restart policy not set")
+	}
+
+	if err := SetPodTerminationGracePeriod(pod, 15); err != nil {
+		t.Fatalf("SetPodTerminationGracePeriod returned error: %v", err)
+	}
+	if pod.Spec.TerminationGracePeriodSeconds == nil || *pod.Spec.TerminationGracePeriodSeconds != 15 {
+		t.Errorf("termination grace period not set")
+	}
+
+	if err := SetPodSchedulerName(pod, "sched"); err != nil {
+		t.Fatalf("SetPodSchedulerName returned error: %v", err)
+	}
+	if pod.Spec.SchedulerName != "sched" {
+		t.Errorf("scheduler name not set")
+	}
 }

--- a/internal/k8s/service.go
+++ b/internal/k8s/service.go
@@ -128,3 +128,59 @@ func SetServiceLabels(svc *corev1.Service, labels map[string]string) {
 func SetServiceAnnotations(svc *corev1.Service, anns map[string]string) {
 	svc.Annotations = anns
 }
+
+func SetServicePublishNotReadyAddresses(svc *corev1.Service, publish bool) error {
+	if svc == nil {
+		return errors.New("nil service")
+	}
+	svc.Spec.PublishNotReadyAddresses = publish
+	return nil
+}
+
+func AddServiceLoadBalancerSourceRange(svc *corev1.Service, cidr string) error {
+	if svc == nil {
+		return errors.New("nil service")
+	}
+	svc.Spec.LoadBalancerSourceRanges = append(svc.Spec.LoadBalancerSourceRanges, cidr)
+	return nil
+}
+
+func SetServiceLoadBalancerSourceRanges(svc *corev1.Service, ranges []string) error {
+	if svc == nil {
+		return errors.New("nil service")
+	}
+	svc.Spec.LoadBalancerSourceRanges = ranges
+	return nil
+}
+
+func SetServiceIPFamilies(svc *corev1.Service, fams []corev1.IPFamily) error {
+	if svc == nil {
+		return errors.New("nil service")
+	}
+	svc.Spec.IPFamilies = fams
+	return nil
+}
+
+func SetServiceIPFamilyPolicy(svc *corev1.Service, policy *corev1.IPFamilyPolicyType) error {
+	if svc == nil {
+		return errors.New("nil service")
+	}
+	svc.Spec.IPFamilyPolicy = policy
+	return nil
+}
+
+func SetServiceInternalTrafficPolicy(svc *corev1.Service, policy *corev1.ServiceInternalTrafficPolicyType) error {
+	if svc == nil {
+		return errors.New("nil service")
+	}
+	svc.Spec.InternalTrafficPolicy = policy
+	return nil
+}
+
+func SetServiceAllocateLoadBalancerNodePorts(svc *corev1.Service, allocate bool) error {
+	if svc == nil {
+		return errors.New("nil service")
+	}
+	svc.Spec.AllocateLoadBalancerNodePorts = &allocate
+	return nil
+}

--- a/internal/k8s/service_test.go
+++ b/internal/k8s/service_test.go
@@ -79,6 +79,58 @@ func TestServiceFunctions(t *testing.T) {
 	if svc.Spec.LoadBalancerIP != "1.1.1.1" {
 		t.Errorf("loadBalancerIP not set")
 	}
+
+	if err := SetServicePublishNotReadyAddresses(svc, true); err != nil {
+		t.Fatalf("SetServicePublishNotReadyAddresses returned error: %v", err)
+	}
+	if !svc.Spec.PublishNotReadyAddresses {
+		t.Errorf("publish not ready addresses not set")
+	}
+
+	if err := AddServiceLoadBalancerSourceRange(svc, "10.0.0.0/24"); err != nil {
+		t.Fatalf("AddServiceLoadBalancerSourceRange returned error: %v", err)
+	}
+	if len(svc.Spec.LoadBalancerSourceRanges) != 1 || svc.Spec.LoadBalancerSourceRanges[0] != "10.0.0.0/24" {
+		t.Errorf("source range not added")
+	}
+
+	ranges := []string{"10.0.1.0/24", "10.0.2.0/24"}
+	if err := SetServiceLoadBalancerSourceRanges(svc, ranges); err != nil {
+		t.Fatalf("SetServiceLoadBalancerSourceRanges returned error: %v", err)
+	}
+	if !reflect.DeepEqual(svc.Spec.LoadBalancerSourceRanges, ranges) {
+		t.Errorf("source ranges not set")
+	}
+
+	if err := SetServiceIPFamilies(svc, []corev1.IPFamily{corev1.IPv4Protocol}); err != nil {
+		t.Fatalf("SetServiceIPFamilies returned error: %v", err)
+	}
+	if len(svc.Spec.IPFamilies) != 1 || svc.Spec.IPFamilies[0] != corev1.IPv4Protocol {
+		t.Errorf("ip families not set")
+	}
+
+	policy := corev1.IPFamilyPolicyPreferDualStack
+	if err := SetServiceIPFamilyPolicy(svc, &policy); err != nil {
+		t.Fatalf("SetServiceIPFamilyPolicy returned error: %v", err)
+	}
+	if svc.Spec.IPFamilyPolicy == nil || *svc.Spec.IPFamilyPolicy != policy {
+		t.Errorf("ip family policy not set")
+	}
+
+	itp := corev1.ServiceInternalTrafficPolicyLocal
+	if err := SetServiceInternalTrafficPolicy(svc, &itp); err != nil {
+		t.Fatalf("SetServiceInternalTrafficPolicy returned error: %v", err)
+	}
+	if svc.Spec.InternalTrafficPolicy == nil || *svc.Spec.InternalTrafficPolicy != itp {
+		t.Errorf("internal traffic policy not set")
+	}
+
+	if err := SetServiceAllocateLoadBalancerNodePorts(svc, false); err != nil {
+		t.Fatalf("SetServiceAllocateLoadBalancerNodePorts returned error: %v", err)
+	}
+	if svc.Spec.AllocateLoadBalancerNodePorts == nil || *svc.Spec.AllocateLoadBalancerNodePorts {
+		t.Errorf("allocate LB node ports not set")
+	}
 }
 
 func TestServiceMetadataFunctions(t *testing.T) {

--- a/internal/k8s/serviceaccount.go
+++ b/internal/k8s/serviceaccount.go
@@ -46,6 +46,22 @@ func AddServiceAccountImagePullSecret(sa *corev1.ServiceAccount, secret corev1.L
 	return nil
 }
 
+func SetServiceAccountSecrets(sa *corev1.ServiceAccount, secrets []corev1.ObjectReference) error {
+	if sa == nil {
+		return errors.New("nil serviceaccount")
+	}
+	sa.Secrets = secrets
+	return nil
+}
+
+func SetServiceAccountImagePullSecrets(sa *corev1.ServiceAccount, secrets []corev1.LocalObjectReference) error {
+	if sa == nil {
+		return errors.New("nil serviceaccount")
+	}
+	sa.ImagePullSecrets = secrets
+	return nil
+}
+
 func SetServiceAccountAutomountToken(sa *corev1.ServiceAccount, automount bool) error {
 	if sa == nil {
 		return errors.New("nil serviceaccount")

--- a/internal/k8s/serviceaccount_test.go
+++ b/internal/k8s/serviceaccount_test.go
@@ -51,6 +51,28 @@ func TestAddServiceAccountImagePullSecret(t *testing.T) {
 	}
 }
 
+func TestSetServiceAccountSecrets(t *testing.T) {
+	sa := CreateServiceAccount("sa", "ns")
+	secrets := []corev1.ObjectReference{{Name: "a"}, {Name: "b"}}
+	if err := SetServiceAccountSecrets(sa, secrets); err != nil {
+		t.Fatalf("SetServiceAccountSecrets returned error: %v", err)
+	}
+	if !reflect.DeepEqual(sa.Secrets, secrets) {
+		t.Errorf("secrets not set")
+	}
+}
+
+func TestSetServiceAccountImagePullSecrets(t *testing.T) {
+	sa := CreateServiceAccount("sa", "ns")
+	pulls := []corev1.LocalObjectReference{{Name: "x"}, {Name: "y"}}
+	if err := SetServiceAccountImagePullSecrets(sa, pulls); err != nil {
+		t.Fatalf("SetServiceAccountImagePullSecrets returned error: %v", err)
+	}
+	if !reflect.DeepEqual(sa.ImagePullSecrets, pulls) {
+		t.Errorf("image pull secrets not set")
+	}
+}
+
 func TestSetServiceAccountAutomountToken(t *testing.T) {
 	sa := CreateServiceAccount("sa", "ns")
 	if err := SetServiceAccountAutomountToken(sa, true); err != nil {


### PR DESCRIPTION
## Summary
- add helper methods for extra k8s fields (service, pod, serviceaccount)
- extend tests for new helper functions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6878c7ae5168832f959f2d4a228e132d