### PR TITLE
Enhance k8s helpers

### DIFF
--- a/internal/k8s/container.go
+++ b/internal/k8s/container.go
@@ -161,3 +161,18 @@ func SetContainerStdinOnce(container *corev1.Container, once bool) {
 func SetContainerTTY(container *corev1.Container, tty bool) {
 	container.TTY = tty
 }
+
+// SetContainerImage sets the image on the container.
+func SetContainerImage(container *corev1.Container, image string) {
+	container.Image = image
+}
+
+// SetContainerCommand replaces the command slice on the container.
+func SetContainerCommand(container *corev1.Container, command []string) {
+	container.Command = command
+}
+
+// SetContainerArgs replaces the args slice on the container.
+func SetContainerArgs(container *corev1.Container, args []string) {
+	container.Args = args
+}

--- a/internal/k8s/container_test.go
+++ b/internal/k8s/container_test.go
@@ -582,3 +582,24 @@ func TestContainerMiscFunctions(t *testing.T) {
 		t.Errorf("tty not set")
 	}
 }
+
+func TestContainerSetters(t *testing.T) {
+	c := &corev1.Container{}
+
+	SetContainerImage(c, "nginx")
+	if c.Image != "nginx" {
+		t.Errorf("image not set")
+	}
+
+	cmd := []string{"/bin/sh"}
+	SetContainerCommand(c, cmd)
+	if !reflect.DeepEqual(c.Command, cmd) {
+		t.Errorf("command not set")
+	}
+
+	args := []string{"-c", "echo"}
+	SetContainerArgs(c, args)
+	if !reflect.DeepEqual(c.Args, args) {
+		t.Errorf("args not set")
+	}
+}

--- a/internal/k8s/daemonset.go
+++ b/internal/k8s/daemonset.go
@@ -150,3 +150,12 @@ func SetDaemonSetUpdateStrategy(ds *appsv1.DaemonSet, strat appsv1.DaemonSetUpda
 	ds.Spec.UpdateStrategy = strat
 	return nil
 }
+
+// SetDaemonSetRevisionHistoryLimit sets the revision history limit.
+func SetDaemonSetRevisionHistoryLimit(ds *appsv1.DaemonSet, limit *int32) error {
+	if ds == nil {
+		return errors.New("nil daemonset")
+	}
+	ds.Spec.RevisionHistoryLimit = limit
+	return nil
+}

--- a/internal/k8s/daemonset_test.go
+++ b/internal/k8s/daemonset_test.go
@@ -158,4 +158,12 @@ func TestDaemonSetFunctions(t *testing.T) {
 	if ds.Spec.UpdateStrategy.Type != appsv1.RollingUpdateDaemonSetStrategyType {
 		t.Errorf("update strategy not set")
 	}
+
+	rhl := int32(3)
+	if err := SetDaemonSetRevisionHistoryLimit(ds, &rhl); err != nil {
+		t.Fatalf("SetDaemonSetRevisionHistoryLimit returned error: %v", err)
+	}
+	if ds.Spec.RevisionHistoryLimit == nil || *ds.Spec.RevisionHistoryLimit != 3 {
+		t.Errorf("revision history limit not set")
+	}
 }

--- a/internal/k8s/deployment.go
+++ b/internal/k8s/deployment.go
@@ -159,3 +159,30 @@ func SetDeploymentStrategy(deployment *appsv1.Deployment, strategy appsv1.Deploy
 	deployment.Spec.Strategy = strategy
 	return nil
 }
+
+// SetDeploymentRevisionHistoryLimit sets the revision history limit.
+func SetDeploymentRevisionHistoryLimit(deployment *appsv1.Deployment, limit int32) error {
+	if deployment == nil {
+		return errors.New("nil deployment")
+	}
+	deployment.Spec.RevisionHistoryLimit = &limit
+	return nil
+}
+
+// SetDeploymentMinReadySeconds sets the minimum ready seconds.
+func SetDeploymentMinReadySeconds(deployment *appsv1.Deployment, secs int32) error {
+	if deployment == nil {
+		return errors.New("nil deployment")
+	}
+	deployment.Spec.MinReadySeconds = secs
+	return nil
+}
+
+// SetDeploymentProgressDeadlineSeconds sets the progress deadline seconds.
+func SetDeploymentProgressDeadlineSeconds(deployment *appsv1.Deployment, secs int32) error {
+	if deployment == nil {
+		return errors.New("nil deployment")
+	}
+	deployment.Spec.ProgressDeadlineSeconds = &secs
+	return nil
+}

--- a/internal/k8s/deployment_test.go
+++ b/internal/k8s/deployment_test.go
@@ -170,4 +170,25 @@ func TestDeploymentFunctions(t *testing.T) {
 	if dep.Spec.Strategy.Type != appsv1.RollingUpdateDeploymentStrategyType {
 		t.Errorf("strategy not set")
 	}
+
+	if err := SetDeploymentRevisionHistoryLimit(dep, 5); err != nil {
+		t.Fatalf("SetDeploymentRevisionHistoryLimit returned error: %v", err)
+	}
+	if dep.Spec.RevisionHistoryLimit == nil || *dep.Spec.RevisionHistoryLimit != 5 {
+		t.Errorf("revision history limit not set")
+	}
+
+	if err := SetDeploymentMinReadySeconds(dep, 10); err != nil {
+		t.Fatalf("SetDeploymentMinReadySeconds returned error: %v", err)
+	}
+	if dep.Spec.MinReadySeconds != 10 {
+		t.Errorf("min ready seconds not set")
+	}
+
+	if err := SetDeploymentProgressDeadlineSeconds(dep, 60); err != nil {
+		t.Fatalf("SetDeploymentProgressDeadlineSeconds returned error: %v", err)
+	}
+	if dep.Spec.ProgressDeadlineSeconds == nil || *dep.Spec.ProgressDeadlineSeconds != 60 {
+		t.Errorf("progress deadline seconds not set")
+	}
 }

--- a/internal/k8s/job.go
+++ b/internal/k8s/job.go
@@ -165,6 +165,15 @@ func SetJobTTLSecondsAfterFinished(job *batchv1.Job, ttl int32) error {
 	return nil
 }
 
+// SetJobActiveDeadlineSeconds sets the active deadline seconds for the job.
+func SetJobActiveDeadlineSeconds(job *batchv1.Job, secs *int64) error {
+	if job == nil {
+		return errors.New("nil job")
+	}
+	job.Spec.ActiveDeadlineSeconds = secs
+	return nil
+}
+
 func CreateCronJob(name, namespace, schedule string) *batchv1.CronJob {
 	obj := &batchv1.CronJob{
 		TypeMeta: metav1.TypeMeta{
@@ -340,5 +349,14 @@ func SetCronJobStartingDeadlineSeconds(cron *batchv1.CronJob, sec int64) error {
 		return errors.New("nil cronjob")
 	}
 	cron.Spec.StartingDeadlineSeconds = &sec
+	return nil
+}
+
+// SetCronJobTimeZone sets the time zone field.
+func SetCronJobTimeZone(cron *batchv1.CronJob, tz *string) error {
+	if cron == nil {
+		return errors.New("nil cronjob")
+	}
+	cron.Spec.TimeZone = tz
 	return nil
 }

--- a/internal/k8s/job_test.go
+++ b/internal/k8s/job_test.go
@@ -134,6 +134,14 @@ func TestJobFunctions(t *testing.T) {
 	if job.Spec.TTLSecondsAfterFinished == nil || *job.Spec.TTLSecondsAfterFinished != 30 {
 		t.Errorf("ttl not set")
 	}
+
+	ad := int64(100)
+	if err := SetJobActiveDeadlineSeconds(job, &ad); err != nil {
+		t.Fatalf("SetJobActiveDeadlineSeconds returned error: %v", err)
+	}
+	if job.Spec.ActiveDeadlineSeconds == nil || *job.Spec.ActiveDeadlineSeconds != 100 {
+		t.Errorf("active deadline not set")
+	}
 }
 
 func TestCreateCronJob(t *testing.T) {
@@ -274,5 +282,13 @@ func TestCronJobFunctions(t *testing.T) {
 	}
 	if cj.Spec.StartingDeadlineSeconds == nil || *cj.Spec.StartingDeadlineSeconds != 60 {
 		t.Errorf("deadline not set")
+	}
+
+	tz := "UTC"
+	if err := SetCronJobTimeZone(cj, &tz); err != nil {
+		t.Fatalf("SetCronJobTimeZone returned error: %v", err)
+	}
+	if cj.Spec.TimeZone == nil || *cj.Spec.TimeZone != "UTC" {
+		t.Errorf("timezone not set")
 	}
 }

--- a/internal/k8s/pod.go
+++ b/internal/k8s/pod.go
@@ -144,6 +144,15 @@ func SetPodNodeSelector(pod *corev1.Pod, nodeSelector map[string]string) error {
 	return nil
 }
 
+// SetPodPriorityClassName sets the priority class name.
+func SetPodPriorityClassName(pod *corev1.Pod, class string) error {
+	if pod == nil {
+		return errors.New("nil pod")
+	}
+	pod.Spec.PriorityClassName = class
+	return nil
+}
+
 // SetPodHostNetwork configures host networking for the Pod.
 func SetPodHostNetwork(pod *corev1.Pod, hostNetwork bool) error {
 	if pod == nil {

--- a/internal/k8s/pod_test.go
+++ b/internal/k8s/pod_test.go
@@ -184,3 +184,13 @@ func TestPodFunctions(t *testing.T) {
 		t.Errorf("scheduler name not set")
 	}
 }
+
+func TestSetPodPriorityClassName(t *testing.T) {
+	pod := CreatePod("p", "ns")
+	if err := SetPodPriorityClassName(pod, "high"); err != nil {
+		t.Fatalf("SetPodPriorityClassName returned error: %v", err)
+	}
+	if pod.Spec.PriorityClassName != "high" {
+		t.Errorf("priority class name not set")
+	}
+}

--- a/internal/k8s/service.go
+++ b/internal/k8s/service.go
@@ -184,3 +184,30 @@ func SetServiceAllocateLoadBalancerNodePorts(svc *corev1.Service, allocate bool)
 	svc.Spec.AllocateLoadBalancerNodePorts = &allocate
 	return nil
 }
+
+// SetServiceExternalName sets the externalName field for ExternalName services.
+func SetServiceExternalName(svc *corev1.Service, name string) error {
+	if svc == nil {
+		return errors.New("nil service")
+	}
+	svc.Spec.ExternalName = name
+	return nil
+}
+
+// SetServiceHealthCheckNodePort sets the healthCheckNodePort field for LoadBalancer services.
+func SetServiceHealthCheckNodePort(svc *corev1.Service, port int32) error {
+	if svc == nil {
+		return errors.New("nil service")
+	}
+	svc.Spec.HealthCheckNodePort = port
+	return nil
+}
+
+// SetServiceSessionAffinityConfig configures the session affinity options.
+func SetServiceSessionAffinityConfig(svc *corev1.Service, cfg *corev1.SessionAffinityConfig) error {
+	if svc == nil {
+		return errors.New("nil service")
+	}
+	svc.Spec.SessionAffinityConfig = cfg
+	return nil
+}

--- a/internal/k8s/service_test.go
+++ b/internal/k8s/service_test.go
@@ -131,6 +131,28 @@ func TestServiceFunctions(t *testing.T) {
 	if svc.Spec.AllocateLoadBalancerNodePorts == nil || *svc.Spec.AllocateLoadBalancerNodePorts {
 		t.Errorf("allocate LB node ports not set")
 	}
+
+	if err := SetServiceExternalName(svc, "example.com"); err != nil {
+		t.Fatalf("SetServiceExternalName returned error: %v", err)
+	}
+	if svc.Spec.ExternalName != "example.com" {
+		t.Errorf("external name not set")
+	}
+
+	if err := SetServiceHealthCheckNodePort(svc, 30000); err != nil {
+		t.Fatalf("SetServiceHealthCheckNodePort returned error: %v", err)
+	}
+	if svc.Spec.HealthCheckNodePort != 30000 {
+		t.Errorf("health check node port not set")
+	}
+
+	cfg := &corev1.SessionAffinityConfig{ClientIP: &corev1.ClientIPConfig{TimeoutSeconds: new(int32)}}
+	if err := SetServiceSessionAffinityConfig(svc, cfg); err != nil {
+		t.Fatalf("SetServiceSessionAffinityConfig returned error: %v", err)
+	}
+	if svc.Spec.SessionAffinityConfig != cfg {
+		t.Errorf("session affinity config not set")
+	}
 }
 
 func TestServiceMetadataFunctions(t *testing.T) {

--- a/internal/k8s/statefulset.go
+++ b/internal/k8s/statefulset.go
@@ -193,3 +193,21 @@ func SetStatefulSetPodManagementPolicy(sts *appsv1.StatefulSet, policy appsv1.Po
 	sts.Spec.PodManagementPolicy = policy
 	return nil
 }
+
+// SetStatefulSetRevisionHistoryLimit sets the revision history limit.
+func SetStatefulSetRevisionHistoryLimit(sts *appsv1.StatefulSet, limit *int32) error {
+	if sts == nil {
+		return errors.New("nil statefulset")
+	}
+	sts.Spec.RevisionHistoryLimit = limit
+	return nil
+}
+
+// SetStatefulSetMinReadySeconds sets the minimum ready seconds.
+func SetStatefulSetMinReadySeconds(sts *appsv1.StatefulSet, secs int32) error {
+	if sts == nil {
+		return errors.New("nil statefulset")
+	}
+	sts.Spec.MinReadySeconds = secs
+	return nil
+}

--- a/internal/k8s/statefulset_test.go
+++ b/internal/k8s/statefulset_test.go
@@ -187,4 +187,19 @@ func TestStatefulSetFunctions(t *testing.T) {
 	if sts.Spec.PodManagementPolicy != appsv1.ParallelPodManagement {
 		t.Errorf("pod management policy not set")
 	}
+
+	rhl := int32(4)
+	if err := SetStatefulSetRevisionHistoryLimit(sts, &rhl); err != nil {
+		t.Fatalf("SetStatefulSetRevisionHistoryLimit returned error: %v", err)
+	}
+	if sts.Spec.RevisionHistoryLimit == nil || *sts.Spec.RevisionHistoryLimit != 4 {
+		t.Errorf("revision history limit not set")
+	}
+
+	if err := SetStatefulSetMinReadySeconds(sts, 5); err != nil {
+		t.Fatalf("SetStatefulSetMinReadySeconds returned error: %v", err)
+	}
+	if sts.Spec.MinReadySeconds != 5 {
+		t.Errorf("min ready seconds not set")
+	}
 }


### PR DESCRIPTION
## Summary
- add setters for container image, command and args
- allow configuring pod priority class
- extend Service helpers for external name, healthcheck and affinity config
- support revision/history configuration for deployments, daemonsets and statefulsets
- add active deadline for jobs and timezone for cronjobs
- update unit tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6878cdf87538832faa200b3adfb64adf