### PR TITLE
Add nil checks for mutators

### DIFF
--- a/internal/k8s/service.go
+++ b/internal/k8s/service.go
@@ -99,34 +99,58 @@ func SetServiceExternalTrafficPolicy(service *corev1.Service, trafficPolicy core
 	return nil
 }
 
-func SetServiceSessionAffinity(service *corev1.Service, affinity corev1.ServiceAffinity) {
+func SetServiceSessionAffinity(service *corev1.Service, affinity corev1.ServiceAffinity) error {
+	if service == nil {
+		return errors.New("nil service")
+	}
 	service.Spec.SessionAffinity = affinity
+	return nil
 }
 
-func SetServiceLoadBalancerClass(service *corev1.Service, class string) {
+func SetServiceLoadBalancerClass(service *corev1.Service, class string) error {
+	if service == nil {
+		return errors.New("nil service")
+	}
 	service.Spec.LoadBalancerClass = &class
+	return nil
 }
 
-func AddServiceLabel(svc *corev1.Service, key, value string) {
+func AddServiceLabel(svc *corev1.Service, key, value string) error {
+	if svc == nil {
+		return errors.New("nil service")
+	}
 	if svc.Labels == nil {
 		svc.Labels = make(map[string]string)
 	}
 	svc.Labels[key] = value
+	return nil
 }
 
-func AddServiceAnnotation(svc *corev1.Service, key, value string) {
+func AddServiceAnnotation(svc *corev1.Service, key, value string) error {
+	if svc == nil {
+		return errors.New("nil service")
+	}
 	if svc.Annotations == nil {
 		svc.Annotations = make(map[string]string)
 	}
 	svc.Annotations[key] = value
+	return nil
 }
 
-func SetServiceLabels(svc *corev1.Service, labels map[string]string) {
+func SetServiceLabels(svc *corev1.Service, labels map[string]string) error {
+	if svc == nil {
+		return errors.New("nil service")
+	}
 	svc.Labels = labels
+	return nil
 }
 
-func SetServiceAnnotations(svc *corev1.Service, anns map[string]string) {
+func SetServiceAnnotations(svc *corev1.Service, anns map[string]string) error {
+	if svc == nil {
+		return errors.New("nil service")
+	}
 	svc.Annotations = anns
+	return nil
 }
 
 func SetServicePublishNotReadyAddresses(svc *corev1.Service, publish bool) error {

--- a/internal/k8s/service_test.go
+++ b/internal/k8s/service_test.go
@@ -49,14 +49,24 @@ func TestServiceFunctions(t *testing.T) {
 		t.Errorf("external traffic policy not set")
 	}
 
-	SetServiceSessionAffinity(svc, corev1.ServiceAffinityClientIP)
+	if err := SetServiceSessionAffinity(svc, corev1.ServiceAffinityClientIP); err != nil {
+		t.Fatalf("SetServiceSessionAffinity returned error: %v", err)
+	}
 	if svc.Spec.SessionAffinity != corev1.ServiceAffinityClientIP {
 		t.Errorf("session affinity not set")
 	}
+	if err := SetServiceSessionAffinity(nil, corev1.ServiceAffinityClientIP); err == nil {
+		t.Errorf("expected error when service nil")
+	}
 
-	SetServiceLoadBalancerClass(svc, "lb-class")
+	if err := SetServiceLoadBalancerClass(svc, "lb-class"); err != nil {
+		t.Fatalf("SetServiceLoadBalancerClass returned error: %v", err)
+	}
 	if svc.Spec.LoadBalancerClass == nil || *svc.Spec.LoadBalancerClass != "lb-class" {
 		t.Errorf("load balancer class not set")
+	}
+	if err := SetServiceLoadBalancerClass(nil, "x"); err == nil {
+		t.Errorf("expected error when service nil")
 	}
 
 	if err := SetServiceClusterIP(svc, "10.0.0.1"); err != nil {
@@ -136,25 +146,47 @@ func TestServiceFunctions(t *testing.T) {
 func TestServiceMetadataFunctions(t *testing.T) {
 	svc := CreateService("svc", "ns")
 
-	AddServiceLabel(svc, "k", "v")
+	if err := AddServiceLabel(svc, "k", "v"); err != nil {
+		t.Fatalf("AddServiceLabel returned error: %v", err)
+	}
 	if svc.Labels["k"] != "v" {
 		t.Errorf("label not added")
 	}
 
-	AddServiceAnnotation(svc, "a", "b")
+	if err := AddServiceAnnotation(svc, "a", "b"); err != nil {
+		t.Fatalf("AddServiceAnnotation returned error: %v", err)
+	}
 	if svc.Annotations["a"] != "b" {
 		t.Errorf("annotation not added")
 	}
 
 	labels := map[string]string{"x": "y"}
-	SetServiceLabels(svc, labels)
+	if err := SetServiceLabels(svc, labels); err != nil {
+		t.Fatalf("SetServiceLabels returned error: %v", err)
+	}
 	if !reflect.DeepEqual(svc.Labels, labels) {
 		t.Errorf("labels not set")
 	}
 
 	anns := map[string]string{"c": "d"}
-	SetServiceAnnotations(svc, anns)
+	if err := SetServiceAnnotations(svc, anns); err != nil {
+		t.Fatalf("SetServiceAnnotations returned error: %v", err)
+	}
 	if !reflect.DeepEqual(svc.Annotations, anns) {
 		t.Errorf("annotations not set")
+	}
+
+	// nil service cases
+	if err := AddServiceLabel(nil, "k", "v"); err == nil {
+		t.Errorf("expected error when service nil")
+	}
+	if err := AddServiceAnnotation(nil, "k", "v"); err == nil {
+		t.Errorf("expected error when service nil")
+	}
+	if err := SetServiceLabels(nil, nil); err == nil {
+		t.Errorf("expected error when service nil")
+	}
+	if err := SetServiceAnnotations(nil, nil); err == nil {
+		t.Errorf("expected error when service nil")
 	}
 }

--- a/internal/metallb/bfdprofile.go
+++ b/internal/metallb/bfdprofile.go
@@ -1,6 +1,8 @@
 package metallb
 
 import (
+	"errors"
+
 	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -22,21 +24,37 @@ func CreateBFDProfile(name, namespace string, spec metallbv1beta1.BFDProfileSpec
 }
 
 // SetBFDProfileDetectMultiplier sets the detect multiplier on the BFDProfile spec.
-func SetBFDProfileDetectMultiplier(obj *metallbv1beta1.BFDProfile, mult uint32) {
+func SetBFDProfileDetectMultiplier(obj *metallbv1beta1.BFDProfile, mult uint32) error {
+	if obj == nil {
+		return errors.New("nil BFDProfile")
+	}
 	obj.Spec.DetectMultiplier = &mult
+	return nil
 }
 
 // SetBFDProfileEchoInterval sets the echo interval on the BFDProfile spec.
-func SetBFDProfileEchoInterval(obj *metallbv1beta1.BFDProfile, interval uint32) {
+func SetBFDProfileEchoInterval(obj *metallbv1beta1.BFDProfile, interval uint32) error {
+	if obj == nil {
+		return errors.New("nil BFDProfile")
+	}
 	obj.Spec.EchoInterval = &interval
+	return nil
 }
 
 // SetBFDProfileEchoMode sets the echo mode on the BFDProfile spec.
-func SetBFDProfileEchoMode(obj *metallbv1beta1.BFDProfile, mode bool) {
+func SetBFDProfileEchoMode(obj *metallbv1beta1.BFDProfile, mode bool) error {
+	if obj == nil {
+		return errors.New("nil BFDProfile")
+	}
 	obj.Spec.EchoMode = &mode
+	return nil
 }
 
 // SetBFDProfilePassiveMode sets the passive mode on the BFDProfile spec.
-func SetBFDProfilePassiveMode(obj *metallbv1beta1.BFDProfile, mode bool) {
+func SetBFDProfilePassiveMode(obj *metallbv1beta1.BFDProfile, mode bool) error {
+	if obj == nil {
+		return errors.New("nil BFDProfile")
+	}
 	obj.Spec.PassiveMode = &mode
+	return nil
 }

--- a/internal/metallb/bfdprofile_test.go
+++ b/internal/metallb/bfdprofile_test.go
@@ -15,10 +15,18 @@ func TestCreateBFDProfile(t *testing.T) {
 
 func TestBFDProfileHelpers(t *testing.T) {
 	p := CreateBFDProfile("prof", "ns", metallbv1beta1.BFDProfileSpec{})
-	SetBFDProfileDetectMultiplier(p, 2)
-	SetBFDProfileEchoInterval(p, 50)
-	SetBFDProfileEchoMode(p, true)
-	SetBFDProfilePassiveMode(p, true)
+	if err := SetBFDProfileDetectMultiplier(p, 2); err != nil {
+		t.Fatalf("SetBFDProfileDetectMultiplier returned error: %v", err)
+	}
+	if err := SetBFDProfileEchoInterval(p, 50); err != nil {
+		t.Fatalf("SetBFDProfileEchoInterval returned error: %v", err)
+	}
+	if err := SetBFDProfileEchoMode(p, true); err != nil {
+		t.Fatalf("SetBFDProfileEchoMode returned error: %v", err)
+	}
+	if err := SetBFDProfilePassiveMode(p, true); err != nil {
+		t.Fatalf("SetBFDProfilePassiveMode returned error: %v", err)
+	}
 
 	if p.Spec.DetectMultiplier == nil || *p.Spec.DetectMultiplier != 2 {
 		t.Errorf("detect multiplier not set")
@@ -31,5 +39,18 @@ func TestBFDProfileHelpers(t *testing.T) {
 	}
 	if p.Spec.PassiveMode == nil || !*p.Spec.PassiveMode {
 		t.Errorf("passive mode not set")
+	}
+
+	if err := SetBFDProfileDetectMultiplier(nil, 1); err == nil {
+		t.Errorf("expected error when profile nil")
+	}
+	if err := SetBFDProfileEchoInterval(nil, 1); err == nil {
+		t.Errorf("expected error when profile nil")
+	}
+	if err := SetBFDProfileEchoMode(nil, true); err == nil {
+		t.Errorf("expected error when profile nil")
+	}
+	if err := SetBFDProfilePassiveMode(nil, true); err == nil {
+		t.Errorf("expected error when profile nil")
 	}
 }

--- a/internal/metallb/bgpadvertisement.go
+++ b/internal/metallb/bgpadvertisement.go
@@ -1,6 +1,8 @@
 package metallb
 
 import (
+	"errors"
+
 	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -22,26 +24,46 @@ func CreateBGPAdvertisement(name, namespace string, spec metallbv1beta1.BGPAdver
 }
 
 // AddBGPAdvertisementIPAddressPool appends an IPAddressPool name to the BGPAdvertisement spec.
-func AddBGPAdvertisementIPAddressPool(obj *metallbv1beta1.BGPAdvertisement, pool string) {
+func AddBGPAdvertisementIPAddressPool(obj *metallbv1beta1.BGPAdvertisement, pool string) error {
+	if obj == nil {
+		return errors.New("nil BGPAdvertisement")
+	}
 	obj.Spec.IPAddressPools = append(obj.Spec.IPAddressPools, pool)
+	return nil
 }
 
 // AddBGPAdvertisementNodeSelector appends a node selector to the BGPAdvertisement spec.
-func AddBGPAdvertisementNodeSelector(obj *metallbv1beta1.BGPAdvertisement, sel metav1.LabelSelector) {
+func AddBGPAdvertisementNodeSelector(obj *metallbv1beta1.BGPAdvertisement, sel metav1.LabelSelector) error {
+	if obj == nil {
+		return errors.New("nil BGPAdvertisement")
+	}
 	obj.Spec.NodeSelectors = append(obj.Spec.NodeSelectors, sel)
+	return nil
 }
 
 // AddBGPAdvertisementCommunity appends a BGP community to the BGPAdvertisement spec.
-func AddBGPAdvertisementCommunity(obj *metallbv1beta1.BGPAdvertisement, c string) {
+func AddBGPAdvertisementCommunity(obj *metallbv1beta1.BGPAdvertisement, c string) error {
+	if obj == nil {
+		return errors.New("nil BGPAdvertisement")
+	}
 	obj.Spec.Communities = append(obj.Spec.Communities, c)
+	return nil
 }
 
 // AddBGPAdvertisementPeer appends a peer name to the BGPAdvertisement spec.
-func AddBGPAdvertisementPeer(obj *metallbv1beta1.BGPAdvertisement, peer string) {
+func AddBGPAdvertisementPeer(obj *metallbv1beta1.BGPAdvertisement, peer string) error {
+	if obj == nil {
+		return errors.New("nil BGPAdvertisement")
+	}
 	obj.Spec.Peers = append(obj.Spec.Peers, peer)
+	return nil
 }
 
 // SetBGPAdvertisementLocalPref sets the localPref value on the BGPAdvertisement spec.
-func SetBGPAdvertisementLocalPref(obj *metallbv1beta1.BGPAdvertisement, pref uint32) {
+func SetBGPAdvertisementLocalPref(obj *metallbv1beta1.BGPAdvertisement, pref uint32) error {
+	if obj == nil {
+		return errors.New("nil BGPAdvertisement")
+	}
 	obj.Spec.LocalPref = pref
+	return nil
 }

--- a/internal/metallb/bgpadvertisement_test.go
+++ b/internal/metallb/bgpadvertisement_test.go
@@ -22,11 +22,21 @@ func TestCreateBGPAdvertisement(t *testing.T) {
 
 func TestBGPAdvertisementHelpers(t *testing.T) {
 	adv := CreateBGPAdvertisement("adv", "ns", metallbv1beta1.BGPAdvertisementSpec{})
-	AddBGPAdvertisementIPAddressPool(adv, "pool")
-	AddBGPAdvertisementNodeSelector(adv, metav1.LabelSelector{MatchLabels: map[string]string{"node": "1"}})
-	AddBGPAdvertisementCommunity(adv, "64512:1")
-	AddBGPAdvertisementPeer(adv, "peer1")
-	SetBGPAdvertisementLocalPref(adv, 200)
+	if err := AddBGPAdvertisementIPAddressPool(adv, "pool"); err != nil {
+		t.Fatalf("AddBGPAdvertisementIPAddressPool returned error: %v", err)
+	}
+	if err := AddBGPAdvertisementNodeSelector(adv, metav1.LabelSelector{MatchLabels: map[string]string{"node": "1"}}); err != nil {
+		t.Fatalf("AddBGPAdvertisementNodeSelector returned error: %v", err)
+	}
+	if err := AddBGPAdvertisementCommunity(adv, "64512:1"); err != nil {
+		t.Fatalf("AddBGPAdvertisementCommunity returned error: %v", err)
+	}
+	if err := AddBGPAdvertisementPeer(adv, "peer1"); err != nil {
+		t.Fatalf("AddBGPAdvertisementPeer returned error: %v", err)
+	}
+	if err := SetBGPAdvertisementLocalPref(adv, 200); err != nil {
+		t.Fatalf("SetBGPAdvertisementLocalPref returned error: %v", err)
+	}
 
 	if len(adv.Spec.IPAddressPools) != 1 || adv.Spec.IPAddressPools[0] != "pool" {
 		t.Errorf("pool not added")
@@ -42,5 +52,21 @@ func TestBGPAdvertisementHelpers(t *testing.T) {
 	}
 	if adv.Spec.LocalPref != 200 {
 		t.Errorf("localpref not set")
+	}
+
+	if err := AddBGPAdvertisementIPAddressPool(nil, "x"); err == nil {
+		t.Errorf("expected error when adv nil")
+	}
+	if err := AddBGPAdvertisementNodeSelector(nil, metav1.LabelSelector{}); err == nil {
+		t.Errorf("expected error when adv nil")
+	}
+	if err := AddBGPAdvertisementCommunity(nil, "c"); err == nil {
+		t.Errorf("expected error when adv nil")
+	}
+	if err := AddBGPAdvertisementPeer(nil, "p"); err == nil {
+		t.Errorf("expected error when adv nil")
+	}
+	if err := SetBGPAdvertisementLocalPref(nil, 1); err == nil {
+		t.Errorf("expected error when adv nil")
 	}
 }

--- a/internal/metallb/bgppeer.go
+++ b/internal/metallb/bgppeer.go
@@ -1,6 +1,8 @@
 package metallb
 
 import (
+	"errors"
+
 	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -22,46 +24,82 @@ func CreateBGPPeer(name, namespace string, spec metallbv1beta1.BGPPeerSpec) *met
 }
 
 // AddBGPPeerNodeSelector appends a node selector to the BGPPeer spec.
-func AddBGPPeerNodeSelector(obj *metallbv1beta1.BGPPeer, sel metallbv1beta1.NodeSelector) {
+func AddBGPPeerNodeSelector(obj *metallbv1beta1.BGPPeer, sel metallbv1beta1.NodeSelector) error {
+	if obj == nil {
+		return errors.New("nil BGPPeer")
+	}
 	obj.Spec.NodeSelectors = append(obj.Spec.NodeSelectors, sel)
+	return nil
 }
 
 // SetBGPPeerPort sets the peer port on the BGPPeer spec.
-func SetBGPPeerPort(obj *metallbv1beta1.BGPPeer, port uint16) {
+func SetBGPPeerPort(obj *metallbv1beta1.BGPPeer, port uint16) error {
+	if obj == nil {
+		return errors.New("nil BGPPeer")
+	}
 	obj.Spec.Port = port
+	return nil
 }
 
 // SetBGPPeerHoldTime sets the hold time on the BGPPeer spec.
-func SetBGPPeerHoldTime(obj *metallbv1beta1.BGPPeer, d metav1.Duration) {
+func SetBGPPeerHoldTime(obj *metallbv1beta1.BGPPeer, d metav1.Duration) error {
+	if obj == nil {
+		return errors.New("nil BGPPeer")
+	}
 	obj.Spec.HoldTime = d
+	return nil
 }
 
 // SetBGPPeerKeepaliveTime sets the keepalive time on the BGPPeer spec.
-func SetBGPPeerKeepaliveTime(obj *metallbv1beta1.BGPPeer, d metav1.Duration) {
+func SetBGPPeerKeepaliveTime(obj *metallbv1beta1.BGPPeer, d metav1.Duration) error {
+	if obj == nil {
+		return errors.New("nil BGPPeer")
+	}
 	obj.Spec.KeepaliveTime = d
+	return nil
 }
 
 // SetBGPPeerSrcAddress sets the source address on the BGPPeer spec.
-func SetBGPPeerSrcAddress(obj *metallbv1beta1.BGPPeer, addr string) {
+func SetBGPPeerSrcAddress(obj *metallbv1beta1.BGPPeer, addr string) error {
+	if obj == nil {
+		return errors.New("nil BGPPeer")
+	}
 	obj.Spec.SrcAddress = addr
+	return nil
 }
 
 // SetBGPPeerRouterID sets the router ID on the BGPPeer spec.
-func SetBGPPeerRouterID(obj *metallbv1beta1.BGPPeer, id string) {
+func SetBGPPeerRouterID(obj *metallbv1beta1.BGPPeer, id string) error {
+	if obj == nil {
+		return errors.New("nil BGPPeer")
+	}
 	obj.Spec.RouterID = id
+	return nil
 }
 
 // SetBGPPeerEBGPMultiHop sets the eBGP multi-hop flag on the BGPPeer spec.
-func SetBGPPeerEBGPMultiHop(obj *metallbv1beta1.BGPPeer, multi bool) {
+func SetBGPPeerEBGPMultiHop(obj *metallbv1beta1.BGPPeer, multi bool) error {
+	if obj == nil {
+		return errors.New("nil BGPPeer")
+	}
 	obj.Spec.EBGPMultiHop = multi
+	return nil
 }
 
 // SetBGPPeerPassword sets the password on the BGPPeer spec.
-func SetBGPPeerPassword(obj *metallbv1beta1.BGPPeer, pw string) {
+func SetBGPPeerPassword(obj *metallbv1beta1.BGPPeer, pw string) error {
+	if obj == nil {
+		return errors.New("nil BGPPeer")
+	}
 	obj.Spec.Password = pw
+	return nil
 }
 
 // SetBGPPeerBFDProfile sets the BFD profile name on the BGPPeer spec.
-func SetBGPPeerBFDProfile(obj *metallbv1beta1.BGPPeer, profile string) {
+func SetBGPPeerBFDProfile(obj *metallbv1beta1.BGPPeer, profile string) error {
+	if obj == nil {
+		return errors.New("nil BGPPeer")
+	}
 	obj.Spec.BFDProfile = profile
+	return nil
 }

--- a/internal/metallb/bgppeer_test.go
+++ b/internal/metallb/bgppeer_test.go
@@ -19,15 +19,33 @@ func TestCreateBGPPeer(t *testing.T) {
 
 func TestBGPPeerHelpers(t *testing.T) {
 	p := CreateBGPPeer("peer", "ns", metallbv1beta1.BGPPeerSpec{})
-	AddBGPPeerNodeSelector(p, metallbv1beta1.NodeSelector{MatchLabels: map[string]string{"disktype": "ssd"}})
-	SetBGPPeerPort(p, 179)
-	SetBGPPeerHoldTime(p, metav1.Duration{})
-	SetBGPPeerKeepaliveTime(p, metav1.Duration{})
-	SetBGPPeerSrcAddress(p, "1.1.1.2")
-	SetBGPPeerRouterID(p, "2.2.2.2")
-	SetBGPPeerEBGPMultiHop(p, true)
-	SetBGPPeerPassword(p, "pw")
-	SetBGPPeerBFDProfile(p, "profile")
+	if err := AddBGPPeerNodeSelector(p, metallbv1beta1.NodeSelector{MatchLabels: map[string]string{"disktype": "ssd"}}); err != nil {
+		t.Fatalf("AddBGPPeerNodeSelector returned error: %v", err)
+	}
+	if err := SetBGPPeerPort(p, 179); err != nil {
+		t.Fatalf("SetBGPPeerPort returned error: %v", err)
+	}
+	if err := SetBGPPeerHoldTime(p, metav1.Duration{}); err != nil {
+		t.Fatalf("SetBGPPeerHoldTime returned error: %v", err)
+	}
+	if err := SetBGPPeerKeepaliveTime(p, metav1.Duration{}); err != nil {
+		t.Fatalf("SetBGPPeerKeepaliveTime returned error: %v", err)
+	}
+	if err := SetBGPPeerSrcAddress(p, "1.1.1.2"); err != nil {
+		t.Fatalf("SetBGPPeerSrcAddress returned error: %v", err)
+	}
+	if err := SetBGPPeerRouterID(p, "2.2.2.2"); err != nil {
+		t.Fatalf("SetBGPPeerRouterID returned error: %v", err)
+	}
+	if err := SetBGPPeerEBGPMultiHop(p, true); err != nil {
+		t.Fatalf("SetBGPPeerEBGPMultiHop returned error: %v", err)
+	}
+	if err := SetBGPPeerPassword(p, "pw"); err != nil {
+		t.Fatalf("SetBGPPeerPassword returned error: %v", err)
+	}
+	if err := SetBGPPeerBFDProfile(p, "profile"); err != nil {
+		t.Fatalf("SetBGPPeerBFDProfile returned error: %v", err)
+	}
 
 	if len(p.Spec.NodeSelectors) != 1 || p.Spec.NodeSelectors[0].MatchLabels["disktype"] != "ssd" {
 		t.Errorf("node selector not added")
@@ -49,5 +67,33 @@ func TestBGPPeerHelpers(t *testing.T) {
 	}
 	if p.Spec.BFDProfile != "profile" {
 		t.Errorf("bfd profile not set")
+	}
+
+	if err := AddBGPPeerNodeSelector(nil, metallbv1beta1.NodeSelector{}); err == nil {
+		t.Errorf("expected error when peer nil")
+	}
+	if err := SetBGPPeerPort(nil, 1); err == nil {
+		t.Errorf("expected error when peer nil")
+	}
+	if err := SetBGPPeerHoldTime(nil, metav1.Duration{}); err == nil {
+		t.Errorf("expected error when peer nil")
+	}
+	if err := SetBGPPeerKeepaliveTime(nil, metav1.Duration{}); err == nil {
+		t.Errorf("expected error when peer nil")
+	}
+	if err := SetBGPPeerSrcAddress(nil, ""); err == nil {
+		t.Errorf("expected error when peer nil")
+	}
+	if err := SetBGPPeerRouterID(nil, ""); err == nil {
+		t.Errorf("expected error when peer nil")
+	}
+	if err := SetBGPPeerEBGPMultiHop(nil, false); err == nil {
+		t.Errorf("expected error when peer nil")
+	}
+	if err := SetBGPPeerPassword(nil, ""); err == nil {
+		t.Errorf("expected error when peer nil")
+	}
+	if err := SetBGPPeerBFDProfile(nil, ""); err == nil {
+		t.Errorf("expected error when peer nil")
 	}
 }

--- a/internal/metallb/ipaddresspool.go
+++ b/internal/metallb/ipaddresspool.go
@@ -1,6 +1,8 @@
 package metallb
 
 import (
+	"errors"
+
 	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -22,21 +24,37 @@ func CreateIPAddressPool(name, namespace string, spec metallbv1beta1.IPAddressPo
 }
 
 // AddIPAddressPoolAddress adds an address range to the IPAddressPool spec.
-func AddIPAddressPoolAddress(obj *metallbv1beta1.IPAddressPool, addr string) {
+func AddIPAddressPoolAddress(obj *metallbv1beta1.IPAddressPool, addr string) error {
+	if obj == nil {
+		return errors.New("nil IPAddressPool")
+	}
 	obj.Spec.Addresses = append(obj.Spec.Addresses, addr)
+	return nil
 }
 
 // SetIPAddressPoolAutoAssign sets the autoAssign flag on the IPAddressPool spec.
-func SetIPAddressPoolAutoAssign(obj *metallbv1beta1.IPAddressPool, auto bool) {
+func SetIPAddressPoolAutoAssign(obj *metallbv1beta1.IPAddressPool, auto bool) error {
+	if obj == nil {
+		return errors.New("nil IPAddressPool")
+	}
 	obj.Spec.AutoAssign = &auto
+	return nil
 }
 
 // SetIPAddressPoolAvoidBuggyIPs sets the avoidBuggyIPs flag on the IPAddressPool spec.
-func SetIPAddressPoolAvoidBuggyIPs(obj *metallbv1beta1.IPAddressPool, avoid bool) {
+func SetIPAddressPoolAvoidBuggyIPs(obj *metallbv1beta1.IPAddressPool, avoid bool) error {
+	if obj == nil {
+		return errors.New("nil IPAddressPool")
+	}
 	obj.Spec.AvoidBuggyIPs = avoid
+	return nil
 }
 
 // SetIPAddressPoolAllocateTo sets the allocation policy on the IPAddressPool spec.
-func SetIPAddressPoolAllocateTo(obj *metallbv1beta1.IPAddressPool, alloc *metallbv1beta1.ServiceAllocation) {
+func SetIPAddressPoolAllocateTo(obj *metallbv1beta1.IPAddressPool, alloc *metallbv1beta1.ServiceAllocation) error {
+	if obj == nil {
+		return errors.New("nil IPAddressPool")
+	}
 	obj.Spec.AllocateTo = alloc
+	return nil
 }

--- a/internal/metallb/ipaddresspool_test.go
+++ b/internal/metallb/ipaddresspool_test.go
@@ -21,10 +21,18 @@ func TestCreateIPAddressPool(t *testing.T) {
 
 func TestIPAddressPoolHelpers(t *testing.T) {
 	pool := CreateIPAddressPool("pool", "ns", metallbv1beta1.IPAddressPoolSpec{})
-	AddIPAddressPoolAddress(pool, "10.0.0.1")
-	SetIPAddressPoolAutoAssign(pool, false)
-	SetIPAddressPoolAvoidBuggyIPs(pool, true)
-	SetIPAddressPoolAllocateTo(pool, &metallbv1beta1.ServiceAllocation{Priority: 1})
+	if err := AddIPAddressPoolAddress(pool, "10.0.0.1"); err != nil {
+		t.Fatalf("AddIPAddressPoolAddress returned error: %v", err)
+	}
+	if err := SetIPAddressPoolAutoAssign(pool, false); err != nil {
+		t.Fatalf("SetIPAddressPoolAutoAssign returned error: %v", err)
+	}
+	if err := SetIPAddressPoolAvoidBuggyIPs(pool, true); err != nil {
+		t.Fatalf("SetIPAddressPoolAvoidBuggyIPs returned error: %v", err)
+	}
+	if err := SetIPAddressPoolAllocateTo(pool, &metallbv1beta1.ServiceAllocation{Priority: 1}); err != nil {
+		t.Fatalf("SetIPAddressPoolAllocateTo returned error: %v", err)
+	}
 
 	if len(pool.Spec.Addresses) != 1 || pool.Spec.Addresses[0] != "10.0.0.1" {
 		t.Errorf("address not added")
@@ -37,5 +45,18 @@ func TestIPAddressPoolHelpers(t *testing.T) {
 	}
 	if pool.Spec.AllocateTo == nil || pool.Spec.AllocateTo.Priority != 1 {
 		t.Errorf("allocateTo not set")
+	}
+
+	if err := AddIPAddressPoolAddress(nil, "x"); err == nil {
+		t.Errorf("expected error when pool nil")
+	}
+	if err := SetIPAddressPoolAutoAssign(nil, true); err == nil {
+		t.Errorf("expected error when pool nil")
+	}
+	if err := SetIPAddressPoolAvoidBuggyIPs(nil, true); err == nil {
+		t.Errorf("expected error when pool nil")
+	}
+	if err := SetIPAddressPoolAllocateTo(nil, nil); err == nil {
+		t.Errorf("expected error when pool nil")
 	}
 }

--- a/internal/metallb/l2advertisement.go
+++ b/internal/metallb/l2advertisement.go
@@ -1,6 +1,8 @@
 package metallb
 
 import (
+	"errors"
+
 	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -22,16 +24,28 @@ func CreateL2Advertisement(name, namespace string, spec metallbv1beta1.L2Adverti
 }
 
 // AddL2AdvertisementIPAddressPool appends an IPAddressPool reference to the L2Advertisement spec.
-func AddL2AdvertisementIPAddressPool(obj *metallbv1beta1.L2Advertisement, pool string) {
+func AddL2AdvertisementIPAddressPool(obj *metallbv1beta1.L2Advertisement, pool string) error {
+	if obj == nil {
+		return errors.New("nil L2Advertisement")
+	}
 	obj.Spec.IPAddressPools = append(obj.Spec.IPAddressPools, pool)
+	return nil
 }
 
 // AddL2AdvertisementNodeSelector appends a node selector to the L2Advertisement spec.
-func AddL2AdvertisementNodeSelector(obj *metallbv1beta1.L2Advertisement, sel metav1.LabelSelector) {
+func AddL2AdvertisementNodeSelector(obj *metallbv1beta1.L2Advertisement, sel metav1.LabelSelector) error {
+	if obj == nil {
+		return errors.New("nil L2Advertisement")
+	}
 	obj.Spec.NodeSelectors = append(obj.Spec.NodeSelectors, sel)
+	return nil
 }
 
 // AddL2AdvertisementInterface appends a network interface name to the L2Advertisement spec.
-func AddL2AdvertisementInterface(obj *metallbv1beta1.L2Advertisement, iface string) {
+func AddL2AdvertisementInterface(obj *metallbv1beta1.L2Advertisement, iface string) error {
+	if obj == nil {
+		return errors.New("nil L2Advertisement")
+	}
 	obj.Spec.Interfaces = append(obj.Spec.Interfaces, iface)
+	return nil
 }

--- a/internal/metallb/l2advertisement_test.go
+++ b/internal/metallb/l2advertisement_test.go
@@ -16,9 +16,15 @@ func TestCreateL2Advertisement(t *testing.T) {
 
 func TestL2AdvertisementHelpers(t *testing.T) {
 	adv := CreateL2Advertisement("adv", "ns", metallbv1beta1.L2AdvertisementSpec{})
-	AddL2AdvertisementIPAddressPool(adv, "pool")
-	AddL2AdvertisementNodeSelector(adv, metav1.LabelSelector{MatchLabels: map[string]string{"role": "lb"}})
-	AddL2AdvertisementInterface(adv, "eth0")
+	if err := AddL2AdvertisementIPAddressPool(adv, "pool"); err != nil {
+		t.Fatalf("AddL2AdvertisementIPAddressPool returned error: %v", err)
+	}
+	if err := AddL2AdvertisementNodeSelector(adv, metav1.LabelSelector{MatchLabels: map[string]string{"role": "lb"}}); err != nil {
+		t.Fatalf("AddL2AdvertisementNodeSelector returned error: %v", err)
+	}
+	if err := AddL2AdvertisementInterface(adv, "eth0"); err != nil {
+		t.Fatalf("AddL2AdvertisementInterface returned error: %v", err)
+	}
 
 	if len(adv.Spec.IPAddressPools) != 1 || adv.Spec.IPAddressPools[0] != "pool" {
 		t.Errorf("pool not added")
@@ -28,5 +34,15 @@ func TestL2AdvertisementHelpers(t *testing.T) {
 	}
 	if len(adv.Spec.Interfaces) != 1 || adv.Spec.Interfaces[0] != "eth0" {
 		t.Errorf("interface not added")
+	}
+
+	if err := AddL2AdvertisementIPAddressPool(nil, "x"); err == nil {
+		t.Errorf("expected error when adv nil")
+	}
+	if err := AddL2AdvertisementNodeSelector(nil, metav1.LabelSelector{}); err == nil {
+		t.Errorf("expected error when adv nil")
+	}
+	if err := AddL2AdvertisementInterface(nil, "x"); err == nil {
+		t.Errorf("expected error when adv nil")
 	}
 }


### PR DESCRIPTION
## Summary
- return errors when Service mutators receive a nil object
- add nil handling to all MetalLB helper functions
- test nil cases for Service and MetalLB helpers

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6878ce7985e0832fbb6a7854aeff43d3