### PR TITLE
Fix doc comments for fluxcd helpers

### DIFF
--- a/internal/fluxcd/notification.go
+++ b/internal/fluxcd/notification.go
@@ -75,6 +75,7 @@ func SetProviderSuspend(provider *notificationv1beta2.Provider, suspend bool) {
 }
 
 // Alert helpers
+
 // CreateAlert returns a new Alert object configured with the given name,
 // namespace and specification.
 func CreateAlert(name, namespace string, spec notificationv1beta2.AlertSpec) *notificationv1beta2.Alert {
@@ -136,6 +137,7 @@ func SetAlertSuspend(alert *notificationv1beta2.Alert, suspend bool) {
 }
 
 // Receiver helpers
+
 // CreateReceiver returns a new Receiver object configured with the given name,
 // namespace and specification.
 func CreateReceiver(name, namespace string, spec notificationv1beta2.ReceiverSpec) *notificationv1beta2.Receiver {

--- a/internal/fluxcd/source.go
+++ b/internal/fluxcd/source.go
@@ -92,6 +92,7 @@ func CreateHelmChart(name, namespace string, spec sourcev1.HelmChartSpec) *sourc
 }
 
 // GitRepository helpers
+
 // SetGitRepositoryURL sets the repository clone URL.
 func SetGitRepositoryURL(gr *sourcev1.GitRepository, url string) {
 	gr.Spec.URL = url
@@ -153,6 +154,7 @@ func AddGitRepositoryInclude(gr *sourcev1.GitRepository, include sourcev1.GitRep
 }
 
 // HelmRepository helpers
+
 // SetHelmRepositoryURL sets the repository URL.
 func SetHelmRepositoryURL(hr *sourcev1.HelmRepository, url string) {
 	hr.Spec.URL = url
@@ -209,6 +211,7 @@ func SetHelmRepositoryProvider(hr *sourcev1.HelmRepository, provider string) {
 }
 
 // Bucket helpers
+
 // SetBucketProvider sets the cloud provider for the bucket.
 func SetBucketProvider(b *sourcev1.Bucket, provider string) {
 	b.Spec.Provider = provider
@@ -280,6 +283,7 @@ func SetBucketSuspend(b *sourcev1.Bucket, suspend bool) {
 }
 
 // HelmChart helpers
+
 // SetHelmChartChart sets the chart name on the HelmChart.
 func SetHelmChartChart(hc *sourcev1.HelmChart, chart string) {
 	hc.Spec.Chart = chart
@@ -331,6 +335,7 @@ func SetHelmChartVerify(hc *sourcev1.HelmChart, verify *sourcev1.OCIRepositoryVe
 }
 
 // OCIRepository helpers
+
 // SetOCIRepositoryURL sets the container registry URL.
 func SetOCIRepositoryURL(or *sourcev1beta2.OCIRepository, url string) {
 	or.Spec.URL = url


### PR DESCRIPTION
## Summary
- ensure exported helper comments follow Go conventions by separating group headers from doc comments

## Testing
- `go test ./...`
- `golint internal/fluxcd/source.go internal/fluxcd/notification.go | head`

------
https://chatgpt.com/codex/tasks/task_e_6878d50acad0832f94990708dfc3c97e