### PR TITLE
Fix error handling when printing YAML

### DIFF
--- a/main.go
+++ b/main.go
@@ -353,8 +353,6 @@ func main() {
 	}
 
 	for _, obj := range objects {
-		if err := y.PrintObj(obj, os.Stdout); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to print YAML: %v\n", err)
-		}
+		logError("failed to print YAML", y.PrintObj(obj, os.Stdout))
 	}
 }


### PR DESCRIPTION
## Summary
- use `logError` in main.go when printing objects as YAML

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6878ee07992c832f8870450d34526d84