### PR TITLE
Implement ParsePatchPath parser

### DIFF
--- a/pkg/appsets/appsets.go
+++ b/pkg/appsets/appsets.go
@@ -1,228 +1,270 @@
 package appsets
 
 import (
-    "errors"
-    "fmt"
-    "regexp"
-    "strconv"
-    "strings"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
 
-    "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type PatchOp struct {
-    Op         string      `json:"op"`
-    Path       string      `json:"path"`
-    ParsedPath []PathPart  `json:"patsedpath,omitempty"`
-    Selector   string      `json:"selector,omitempty"`
-    Value      interface{} `json:"value"`
+	Op         string      `json:"op"`
+	Path       string      `json:"path"`
+	ParsedPath []PathPart  `json:"patsedpath,omitempty"`
+	Selector   string      `json:"selector,omitempty"`
+	Value      interface{} `json:"value"`
 }
 
 type ResourceWithPatches struct {
-    Name    string
-    Base    *unstructured.Unstructured
-    Patches []PatchOp
+	Name    string
+	Base    *unstructured.Unstructured
+	Patches []PatchOp
 }
 
 func (r *ResourceWithPatches) Apply() error {
-    for _, patch := range r.Patches {
-        if err := applyPatchOp(r.Base.Object, patch); err != nil {
-            return fmt.Errorf("failed to apply patch %v: %w", patch, err)
-        }
-    }
-    return nil
+	for _, patch := range r.Patches {
+		if err := applyPatchOp(r.Base.Object, patch); err != nil {
+			return fmt.Errorf("failed to apply patch %v: %w", patch, err)
+		}
+	}
+	return nil
 }
 
 func applyPatchOp(obj map[string]interface{}, op PatchOp) error {
-    switch op.Op {
-    case "replace":
-        return unstructured.SetNestedField(obj, op.Value, parsePath(op.Path)...)
-    case "append":
-        lst, found, err := unstructured.NestedSlice(obj, parsePath(op.Path)...)
-        if err != nil || !found {
-            return fmt.Errorf("path not found: %s", op.Path)
-        }
-        lst = append(lst, op.Value)
-        return unstructured.SetNestedSlice(obj, lst, parsePath(op.Path)...)
-    case "insertBefore", "insertAfter":
-        return applyListPatch(obj, op)
-    default:
-        return fmt.Errorf("unsupported op: %s", op.Op)
-    }
+	switch op.Op {
+	case "replace":
+		return unstructured.SetNestedField(obj, op.Value, parsePath(op.Path)...)
+	case "append":
+		lst, found, err := unstructured.NestedSlice(obj, parsePath(op.Path)...)
+		if err != nil || !found {
+			return fmt.Errorf("path not found: %s", op.Path)
+		}
+		lst = append(lst, op.Value)
+		return unstructured.SetNestedSlice(obj, lst, parsePath(op.Path)...)
+	case "insertBefore", "insertAfter":
+		return applyListPatch(obj, op)
+	default:
+		return fmt.Errorf("unsupported op: %s", op.Op)
+	}
 }
 
 func applyListPatch(obj map[string]interface{}, op PatchOp) error {
-    path := parsePath(op.Path)
-    lst, found, err := unstructured.NestedSlice(obj, path...)
-    if err != nil || !found {
-        return fmt.Errorf("path not found for list insert: %s", op.Path)
-    }
+	path := parsePath(op.Path)
+	lst, found, err := unstructured.NestedSlice(obj, path...)
+	if err != nil || !found {
+		return fmt.Errorf("path not found for list insert: %s", op.Path)
+	}
 
-    idx, err := resolveListIndex(lst, op.Selector)
-    if err != nil {
-        return err
-    }
+	idx, err := resolveListIndex(lst, op.Selector)
+	if err != nil {
+		return err
+	}
 
-    switch op.Op {
-    case "insertBefore":
-        lst = append(lst[:idx], append([]interface{}{op.Value}, lst[idx:]...)...)
-    case "insertAfter":
-        lst = append(lst[:idx+1], append([]interface{}{op.Value}, lst[idx+1:]...)...)
-    }
+	switch op.Op {
+	case "insertBefore":
+		lst = append(lst[:idx], append([]interface{}{op.Value}, lst[idx:]...)...)
+	case "insertAfter":
+		lst = append(lst[:idx+1], append([]interface{}{op.Value}, lst[idx+1:]...)...)
+	}
 
-    return unstructured.SetNestedSlice(obj, lst, path...)
+	return unstructured.SetNestedSlice(obj, lst, path...)
 }
 
 func resolveListIndex(list []interface{}, selector string) (int, error) {
-    if strings.Contains(selector, "=") {
-        parts := strings.SplitN(selector, "=", 2)
-        key, val := parts[0], parts[1]
-        for i, item := range list {
-            m, ok := item.(map[string]interface{})
-            if ok && fmt.Sprintf("%v", m[key]) == val {
-                return i, nil
-            }
-        }
-        return -1, errors.New("key match not found")
-    }
-    i, err := strconv.Atoi(selector)
-    if err != nil {
-        return -1, fmt.Errorf("invalid index: %s", selector)
-    }
-    if i < 0 {
-        i = len(list) + i
-    }
-    if i < 0 || i > len(list) {
-        return -1, fmt.Errorf("index out of bounds: %d", i)
-    }
-    return i, nil
+	if strings.Contains(selector, "=") {
+		parts := strings.SplitN(selector, "=", 2)
+		key, val := parts[0], parts[1]
+		for i, item := range list {
+			m, ok := item.(map[string]interface{})
+			if ok && fmt.Sprintf("%v", m[key]) == val {
+				return i, nil
+			}
+		}
+		return -1, errors.New("key match not found")
+	}
+	i, err := strconv.Atoi(selector)
+	if err != nil {
+		return -1, fmt.Errorf("invalid index: %s", selector)
+	}
+	if i < 0 {
+		i = len(list) + i
+	}
+	if i < 0 || i > len(list) {
+		return -1, fmt.Errorf("index out of bounds: %d", i)
+	}
+	return i, nil
 }
 
 func parsePath(path string) []string {
-    clean := strings.TrimPrefix(path, "/")
-    return strings.Split(clean, "/")
+	clean := strings.TrimPrefix(path, "/")
+	return strings.Split(clean, "/")
 }
 
 func ParsePatchLine(key string, value interface{}) (PatchOp, error) {
-    var op PatchOp
-    // Handle append shortcut
-    if strings.HasSuffix(key, "[-]") {
-        op.Op = "append"
-        op.Path = strings.TrimSuffix(key, "[-]")
-        op.Value = value
-        return op, nil
-    }
+	var op PatchOp
+	// Handle append shortcut
+	if strings.HasSuffix(key, "[-]") {
+		op.Op = "append"
+		op.Path = strings.TrimSuffix(key, "[-]")
+		op.Value = value
+		return op, nil
+	}
 
-    re := regexp.MustCompile(`(.*)\[(.*?)]$`)
-    matches := re.FindStringSubmatch(key)
-    if len(matches) == 3 {
-        path, sel := matches[1], matches[2]
-        switch {
-        case strings.HasPrefix(sel, "-="):
-            op.Op = "insertBefore"
-            op.Selector = strings.TrimPrefix(sel, "-=")
-        case strings.HasPrefix(sel, "+="):
-            op.Op = "insertAfter"
-            op.Selector = strings.TrimPrefix(sel, "+=")
-        default:
-            op.Op = "replace"
-            op.Selector = sel
-        }
-        op.Path = path
-        op.Value = value
-        return op, nil
-    }
+	re := regexp.MustCompile(`(.*)\[(.*?)]$`)
+	matches := re.FindStringSubmatch(key)
+	if len(matches) == 3 {
+		path, sel := matches[1], matches[2]
+		switch {
+		case strings.HasPrefix(sel, "-="):
+			op.Op = "insertBefore"
+			op.Selector = strings.TrimPrefix(sel, "-=")
+		case strings.HasPrefix(sel, "+="):
+			op.Op = "insertAfter"
+			op.Selector = strings.TrimPrefix(sel, "+=")
+		default:
+			op.Op = "replace"
+			op.Selector = sel
+		}
+		op.Path = path
+		op.Value = value
+		return op, nil
+	}
 
-    // Default: no selector, simple replace
-    op.Op = "replace"
-    op.Path = key
-    op.Value = value
-    return op, nil
+	// Default: no selector, simple replace
+	op.Op = "replace"
+	op.Path = key
+	op.Value = value
+	return op, nil
 }
 
 type PatchableAppSet struct {
-    Resources []*unstructured.Unstructured
-    Patches   []struct {
-        Target string
-        Patch  PatchOp
-    }
+	Resources []*unstructured.Unstructured
+	Patches   []struct {
+		Target string
+		Patch  PatchOp
+	}
 }
 
 func (s *PatchableAppSet) Resolve() ([]*ResourceWithPatches, error) {
-    out := make(map[string]*ResourceWithPatches)
-    for _, r := range s.Resources {
-        name := r.GetName()
-        out[name] = &ResourceWithPatches{
-            Name: name,
-            Base: r.DeepCopy(),
-        }
-    }
-    for _, p := range s.Patches {
-        if rw, ok := out[p.Target]; ok {
-            rw.Patches = append(rw.Patches, p.Patch)
-        } else {
-            return nil, fmt.Errorf("target not found: %s", p.Target)
-        }
-    }
-    var result []*ResourceWithPatches
-    for _, r := range out {
-        result = append(result, r)
-    }
-    return result, nil
+	out := make(map[string]*ResourceWithPatches)
+	for _, r := range s.Resources {
+		name := r.GetName()
+		out[name] = &ResourceWithPatches{
+			Name: name,
+			Base: r.DeepCopy(),
+		}
+	}
+	for _, p := range s.Patches {
+		if rw, ok := out[p.Target]; ok {
+			rw.Patches = append(rw.Patches, p.Patch)
+		} else {
+			return nil, fmt.Errorf("target not found: %s", p.Target)
+		}
+	}
+	var result []*ResourceWithPatches
+	for _, r := range out {
+		result = append(result, r)
+	}
+	return result, nil
 }
 
 func (p *PatchOp) ValidateAgainst(obj *unstructured.Unstructured) error {
-    path := parsePath(p.Path)
-    switch p.Op {
-    case "replace":
-        _, found, err := unstructured.NestedFieldNoCopy(obj.Object, path...)
-        if err != nil {
-            return err
-        }
-        if !found {
-            return fmt.Errorf("path not found for replace: %s", p.Path)
-        }
-    case "insertBefore", "insertAfter", "append":
-        _, found, err := unstructured.NestedSlice(obj.Object, path...)
-        if err != nil {
-            return err
-        }
-        if !found {
-            return fmt.Errorf("path not found for list op: %s", p.Path)
-        }
-    }
-    return nil
+	path := parsePath(p.Path)
+	switch p.Op {
+	case "replace":
+		_, found, err := unstructured.NestedFieldNoCopy(obj.Object, path...)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return fmt.Errorf("path not found for replace: %s", p.Path)
+		}
+	case "insertBefore", "insertAfter", "append":
+		_, found, err := unstructured.NestedSlice(obj.Object, path...)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return fmt.Errorf("path not found for list op: %s", p.Path)
+		}
+	}
+	return nil
 }
 
 type PathPart struct {
-    Field      string
-    MatchType  string // e.g. "", "index", "key"
-    MatchValue string
+	Field      string
+	MatchType  string // e.g. "", "index", "key"
+	MatchValue string
 }
 
 func (p *PatchOp) NormalizePath() error {
-    parsed, err := ParsePatchPath(p.Path)
-    if err != nil {
-        return fmt.Errorf("NormalizePath failed for %s: %w", p.Path, err)
-    }
-    p.ParsedPath = parsed
-    return nil
+	parsed, err := ParsePatchPath(p.Path)
+	if err != nil {
+		return fmt.Errorf("NormalizePath failed for %s: %w", p.Path, err)
+	}
+	p.ParsedPath = parsed
+	return nil
 }
 
 func InferPatchOp(path string) string {
-    if strings.Contains(path, "[+=]") || strings.Contains(path, "[+=name=") {
-        return "insertafter"
-    }
-    if strings.Contains(path, "[-=") {
-        return "insertbefore"
-    }
-    if strings.HasSuffix(path, "[-]") {
-        return "append"
-    }
-    return "replace"
+	if strings.Contains(path, "[+=]") || strings.Contains(path, "[+=name=") {
+		return "insertafter"
+	}
+	if strings.Contains(path, "[-=") {
+		return "insertbefore"
+	}
+	if strings.HasSuffix(path, "[-]") {
+		return "append"
+	}
+	return "replace"
 }
 
 func ParsePatchPath(path string) ([]PathPart, error) {
-    // Dummy logic: real parser needed for selectors
-    return []PathPart{{Field: path}}, nil
+	clean := strings.Trim(path, "/")
+	if clean == "" {
+		return nil, fmt.Errorf("empty path")
+	}
+
+	segments := strings.Split(clean, "/")
+	parts := make([]PathPart, 0, len(segments))
+
+	for _, seg := range segments {
+		if seg == "" {
+			return nil, fmt.Errorf("invalid empty segment in %q", path)
+		}
+
+		var part PathPart
+		idx := strings.IndexRune(seg, '[')
+		if idx == -1 {
+			part.Field = seg
+			parts = append(parts, part)
+			continue
+		}
+		if !strings.HasSuffix(seg, "]") || idx == 0 {
+			return nil, fmt.Errorf("malformed selector in segment %q", seg)
+		}
+
+		part.Field = seg[:idx]
+		sel := seg[idx+1 : len(seg)-1]
+		if sel == "" {
+			return nil, fmt.Errorf("empty selector in segment %q", seg)
+		}
+
+		if strings.Contains(sel, "=") {
+			part.MatchType = "key"
+			part.MatchValue = sel
+		} else {
+			if _, err := strconv.Atoi(sel); err != nil {
+				return nil, fmt.Errorf("invalid index %q in segment %q", sel, seg)
+			}
+			part.MatchType = "index"
+			part.MatchValue = sel
+		}
+		parts = append(parts, part)
+	}
+
+	return parts, nil
 }

--- a/pkg/appsets/appsets_test.go
+++ b/pkg/appsets/appsets_test.go
@@ -14,3 +14,44 @@ func TestParsePatchLine(t *testing.T) {
 		t.Fatalf("unexpected path %s", op.Path)
 	}
 }
+
+func TestParsePatchPath(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []PathPart
+	}{
+		{
+			in: "spec/template/spec/containers[0]/image",
+			want: []PathPart{
+				{Field: "spec"},
+				{Field: "template"},
+				{Field: "spec"},
+				{Field: "containers", MatchType: "index", MatchValue: "0"},
+				{Field: "image"},
+			},
+		},
+		{
+			in: "spec/containers[name=main]/image",
+			want: []PathPart{
+				{Field: "spec"},
+				{Field: "containers", MatchType: "key", MatchValue: "name=main"},
+				{Field: "image"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		got, err := ParsePatchPath(tc.in)
+		if err != nil {
+			t.Fatalf("ParsePatchPath error: %v", err)
+		}
+		if len(got) != len(tc.want) {
+			t.Fatalf("segments len mismatch for %s: got %d want %d", tc.in, len(got), len(tc.want))
+		}
+		for i, p := range got {
+			if p != tc.want[i] {
+				t.Fatalf("segment %d mismatch for %s: got %+v want %+v", i, tc.in, p, tc.want[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement selector parsing in `ParsePatchPath`
- add tests for parsing index and key selectors

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687e3f9301a4832fb56362de8d22edfd