### PR TITLE
Implement delete operation and smart targeting

### DIFF
--- a/pkg/appsets/appsets_test.go
+++ b/pkg/appsets/appsets_test.go
@@ -1,16 +1,23 @@
 package appsets
 
-import "testing"
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
 
 func TestParsePatchLine(t *testing.T) {
-	op, err := ParsePatchLine("spec/template/spec/containers[+=name=main]", map[string]interface{}{"image": "nginx"})
+	op, err := ParsePatchLine("spec.template.spec.containers[+=name=main]", map[string]interface{}{"image": "nginx"})
 	if err != nil {
 		t.Fatalf("parse error: %v", err)
 	}
 	if op.Op != "insertAfter" || op.Selector != "name=main" {
 		t.Fatalf("unexpected op %+v", op)
 	}
-	if op.Path != "spec/template/spec/containers" {
+	if op.Path != "spec.template.spec.containers" {
 		t.Fatalf("unexpected path %s", op.Path)
 	}
 }
@@ -21,7 +28,7 @@ func TestParsePatchPath(t *testing.T) {
 		want []PathPart
 	}{
 		{
-			in: "spec/template/spec/containers[0]/image",
+			in: "spec.template.spec.containers[0].image",
 			want: []PathPart{
 				{Field: "spec"},
 				{Field: "template"},
@@ -31,7 +38,7 @@ func TestParsePatchPath(t *testing.T) {
 			},
 		},
 		{
-			in: "spec/containers[name=main]/image",
+			in: "spec.containers[name=main].image",
 			want: []PathPart{
 				{Field: "spec"},
 				{Field: "containers", MatchType: "key", MatchValue: "name=main"},
@@ -53,5 +60,73 @@ func TestParsePatchPath(t *testing.T) {
 				t.Fatalf("segment %d mismatch for %s: got %+v want %+v", i, tc.in, p, tc.want[i])
 			}
 		}
+	}
+}
+
+func TestDeleteOperation(t *testing.T) {
+	yamlStr := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo
+  labels:
+    app: demo
+`
+	var m map[string]interface{}
+	if err := yaml.Unmarshal([]byte(yamlStr), &m); err != nil {
+		t.Fatalf("yaml decode: %v", err)
+	}
+	obj := &unstructured.Unstructured{Object: m}
+	op, err := ParsePatchLine("metadata.labels.app[delete]", "")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := applyPatchOp(obj.Object, op); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	labels, _, _ := unstructured.NestedStringMap(obj.Object, "metadata", "labels")
+	if _, ok := labels["app"]; ok {
+		t.Fatalf("label not deleted")
+	}
+}
+
+func TestExplicitTargetAndSmart(t *testing.T) {
+	resYaml := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo
+data:
+  foo: bar
+`
+	var rm map[string]interface{}
+	if err := yaml.Unmarshal([]byte(resYaml), &rm); err != nil {
+		t.Fatalf("yaml decode: %v", err)
+	}
+	patchYaml := "- target: demo\n  patch:\n    data.foo: baz\n"
+	patches, err := LoadPatchFile(strings.NewReader(patchYaml))
+	if err != nil {
+		t.Fatalf("load patch: %v", err)
+	}
+	if len(patches) != 1 {
+		t.Fatalf("expected 1 patch")
+	}
+	set, err := LoadPatchableAppSet([]io.Reader{strings.NewReader(resYaml)}, strings.NewReader(patchYaml))
+	if err != nil {
+		t.Fatalf("LoadPatchableAppSet: %v", err)
+	}
+	resolved, err := set.Resolve()
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if len(resolved) != 1 || resolved[0].Name != "demo" {
+		t.Fatalf("unexpected resolve result")
+	}
+	if err := resolved[0].Apply(); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	val, _, _ := unstructured.NestedString(resolved[0].Base.Object, "data", "foo")
+	if val != "baz" {
+		t.Fatalf("patch not applied")
 	}
 }

--- a/pkg/appsets/design.md
+++ b/pkg/appsets/design.md
@@ -55,4 +55,5 @@ Supports expressive list modification syntax:
 spec.containers[3].image: nginx:latest        # replace
 spec.containers[+=name=web].image: sidecar:1  # insert after matching item
 spec.containers[-]: { name: debug }           # append
+metadata.labels[delete=app]: ""               # delete label
 

--- a/pkg/appsets/doc.go
+++ b/pkg/appsets/doc.go
@@ -27,10 +27,11 @@
 //
 //   - Targeted patch list:
 //
-//     - target: my-deployment
-//       patch:
-//         spec.replicas: 5
-//         spec.template.metadata.labels.foo: bar
+//   - target: my-deployment
+//     patch:
+//     spec.replicas: 5
+//     spec.template.metadata.labels.foo: bar
+//     metadata.labels[delete=app]: ""
 //
 // Supported path selectors include:
 //
@@ -44,27 +45,27 @@
 //
 // Patch operations are defined via the PatchOp struct:
 //
-//     type PatchOp struct {
-//         Path       string
-//         Value      interface{}
-//         Op         string // "replace", "add", "delete", "insertbefore", "insertafter"
-//         ParsedPath []PathPart
-//     }
+//	type PatchOp struct {
+//	    Path       string
+//	    Value      interface{}
+//	    Op         string // "replace", "delete", "insertbefore", "insertafter", "append"
+//	    ParsedPath []PathPart
+//	}
 //
 // Each patch is parsed and validated via NormalizePath() and mapped to a
 // list of field operations at runtime.
 //
 // ## Main Types
 //
-//     PatchableAppSet — Holds resources and patch operations
-//     PatchOp         — Describes a single patch instruction
-//     PathPart        — Parsed component of a patch path
+//	PatchableAppSet — Holds resources and patch operations
+//	PatchOp         — Describes a single patch instruction
+//	PathPart        — Parsed component of a patch path
 //
 // ## Main Functions
 //
-//     LoadPatchFile(r io.Reader) ([]PatchOp, error)
-//     LoadResourcesFromMultiYAML(r io.Reader) ([]*unstructured.Unstructured, error)
-//     LoadPatchableAppSet(resourceReaders []io.Reader, patchReader io.Reader) (*PatchableAppSet, error)
+//	LoadPatchFile(r io.Reader) ([]PatchOp, error)
+//	LoadResourcesFromMultiYAML(r io.Reader) ([]*unstructured.Unstructured, error)
+//	LoadPatchableAppSet(resourceReaders []io.Reader, patchReader io.Reader) (*PatchableAppSet, error)
 //
 // These helpers allow loading resources and patches from YAML files or from programmatic input.
 //
@@ -72,7 +73,7 @@
 //
 // Enable verbose patch resolution and loading by setting:
 //
-//     export KURE_DEBUG=1
+//	export KURE_DEBUG=1
 //
 // ## Future Extensions
 //
@@ -82,4 +83,3 @@
 //
 // This package is designed for use by higher-level tools like Wharf, Crane, or Kur8.
 package appsets
-

--- a/pkg/appsets/loader.go
+++ b/pkg/appsets/loader.go
@@ -1,156 +1,205 @@
 package appsets
 
 import (
-    "fmt"
-    "io"
-    "log"
-    "os"
-    "strings"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
 
-    "gopkg.in/yaml.v3"
-    "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type RawPatchMap map[string]interface{}
 
 type TargetedPatch struct {
-    Target string                 `yaml:"target"`
-    Patch  map[string]interface{} `yaml:"patch"`
+	Target string                 `yaml:"target"`
+	Patch  map[string]interface{} `yaml:"patch"`
+}
+
+// PatchSpec ties a parsed PatchOp to an optional explicit target.
+type PatchSpec struct {
+	Target string
+	Patch  PatchOp
 }
 
 var Debug = os.Getenv("KURE_DEBUG") == "1"
 
-func LoadPatchFile(r io.Reader) ([]PatchOp, error) {
-    dec := yaml.NewDecoder(r)
+func LoadPatchFile(r io.Reader) ([]PatchSpec, error) {
+	dec := yaml.NewDecoder(r)
 
-    var firstToken yaml.Node
-    if err := dec.Decode(&firstToken); err != nil {
-        return nil, fmt.Errorf("failed to read patch input: %w", err)
-    }
+	var firstToken yaml.Node
+	if err := dec.Decode(&firstToken); err != nil {
+		return nil, fmt.Errorf("failed to read patch input: %w", err)
+	}
+	if firstToken.Kind == yaml.DocumentNode && len(firstToken.Content) > 0 {
+		firstToken = *firstToken.Content[0]
+	}
 
-    var patches []PatchOp
+	var patches []PatchSpec
 
-    if firstToken.Kind == yaml.MappingNode {
-        var raw RawPatchMap
-        if err := firstToken.Decode(&raw); err != nil {
-            return nil, fmt.Errorf("invalid simple patch map: %w", err)
-        }
-        for k, v := range raw {
-            op, err := ParsePatchLine(k, v)
-            if err != nil {
-                return nil, fmt.Errorf("invalid patch line '%s': %w", k, err)
-            }
-            patches = append(patches, op)
-        }
-    } else if firstToken.Kind == yaml.SequenceNode {
-        var list []TargetedPatch
-        if err := firstToken.Decode(&list); err != nil {
-            return nil, fmt.Errorf("invalid patch list: %w", err)
-        }
-        for _, entry := range list {
-            for k, v := range entry.Patch {
-                op, err := ParsePatchLine(k, v)
-                if err != nil {
-                    return nil, fmt.Errorf("invalid patch line '%s': %w", k, err)
-                }
-                if err := op.NormalizePath(); err != nil {
-                    return nil, fmt.Errorf("invalid patch path syntax: %s: %w", op.Path, err)
-                }
-                if Debug {
-                    log.Printf("Targeted patch loaded: target=%s op=%s path=%s value=%v", entry.Target, op.Op, op.Path, op.Value)
-                }
-                patches = append(patches, op)
-            }
-        }
-    } else {
-        return nil, fmt.Errorf("unrecognized patch format")
-    }
+	if firstToken.Kind == yaml.MappingNode {
+		var raw RawPatchMap
+		if err := firstToken.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("invalid simple patch map: %w", err)
+		}
+		for k, v := range raw {
+			op, err := ParsePatchLine(k, v)
+			if err != nil {
+				return nil, fmt.Errorf("invalid patch line '%s': %w", k, err)
+			}
+			patches = append(patches, PatchSpec{Patch: op})
+		}
+	} else if firstToken.Kind == yaml.SequenceNode {
+		var list []TargetedPatch
+		if err := firstToken.Decode(&list); err != nil {
+			return nil, fmt.Errorf("invalid patch list: %w", err)
+		}
+		for _, entry := range list {
+			for k, v := range entry.Patch {
+				op, err := ParsePatchLine(k, v)
+				if err != nil {
+					return nil, fmt.Errorf("invalid patch line '%s': %w", k, err)
+				}
+				if err := op.NormalizePath(); err != nil {
+					return nil, fmt.Errorf("invalid patch path syntax: %s: %w", op.Path, err)
+				}
+				if Debug {
+					log.Printf("Targeted patch loaded: target=%s op=%s path=%s value=%v", entry.Target, op.Op, op.Path, op.Value)
+				}
+				patches = append(patches, PatchSpec{Target: entry.Target, Patch: op})
+			}
+		}
+	} else {
+		return nil, fmt.Errorf("unrecognized patch format")
+	}
 
-    return patches, nil
+	return patches, nil
 }
 
 func LoadResourcesFromMultiYAML(r io.Reader) ([]*unstructured.Unstructured, error) {
-    dec := yaml.NewDecoder(r)
-    var resources []*unstructured.Unstructured
-    for {
-        u := &unstructured.Unstructured{}
-        err := dec.Decode(u)
-        if err != nil {
-            if err == io.EOF {
-                break
-            }
-            return nil, fmt.Errorf("failed to decode resource document: %w", err)
-        }
-        if len(u.Object) > 0 {
-            if Debug {
-                log.Printf("Loaded resource: kind=%s name=%s", u.GetKind(), u.GetName())
-            }
-            resources = append(resources, u)
-        }
-    }
-    return resources, nil
+	dec := yaml.NewDecoder(r)
+	var resources []*unstructured.Unstructured
+	for {
+		var raw map[string]interface{}
+		err := dec.Decode(&raw)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("failed to decode resource document: %w", err)
+		}
+		if len(raw) > 0 {
+			u := &unstructured.Unstructured{Object: raw}
+			if Debug {
+				log.Printf("Loaded resource: kind=%s name=%s", u.GetKind(), u.GetName())
+			}
+			resources = append(resources, u)
+		}
+	}
+	return resources, nil
 }
 
 func LoadPatchableAppSet(resourceReaders []io.Reader, patchReader io.Reader) (*PatchableAppSet, error) {
-    var resources []*unstructured.Unstructured
-    for _, r := range resourceReaders {
-        rs, err := LoadResourcesFromMultiYAML(r)
-        if err != nil {
-            return nil, err
-        }
-        resources = append(resources, rs...)
-    }
+	var resources []*unstructured.Unstructured
+	for _, r := range resourceReaders {
+		rs, err := LoadResourcesFromMultiYAML(r)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, rs...)
+	}
 
-    patches, err := LoadPatchFile(patchReader)
-    if err != nil {
-        return nil, err
-    }
+	patches, err := LoadPatchFile(patchReader)
+	if err != nil {
+		return nil, err
+	}
 
-    var wrapped []struct {
-        Target string
-        Patch  PatchOp
-    }
+	var wrapped []struct {
+		Target string
+		Patch  PatchOp
+	}
 
-    for _, p := range patches {
-        if err := p.NormalizePath(); err != nil {
-            return nil, fmt.Errorf("invalid patch path syntax: %s: %w", p.Path, err)
-        }
+	for _, spec := range patches {
+		p := spec.Patch
+		if err := p.NormalizePath(); err != nil {
+			return nil, fmt.Errorf("invalid patch path syntax: %s: %w", p.Path, err)
+		}
 
-        target := resolvePatchTarget(resources, p.Path)
-        if target == "" {
-            return nil, fmt.Errorf("could not determine target resource for patch path: %s", p.Path)
-        }
+		var target string
+		var trimmed string
+		if spec.Target != "" {
+			if !resourceExists(resources, spec.Target) {
+				return nil, fmt.Errorf("explicit target not found: %s", spec.Target)
+			}
+			target = spec.Target
+		} else {
+			target, trimmed = resolvePatchTarget(resources, p.Path)
+			if target == "" {
+				cands := smartTarget(resources, p)
+				if len(cands) == 1 {
+					target = cands[0]
+				}
+			}
+		}
 
-        if Debug {
-            log.Printf("Patch resolved: target=%s op=%s path=%s value=%v", target, p.Op, p.Path, p.Value)
-        }
-        wrapped = append(wrapped, struct {
-            Target string
-            Patch  PatchOp
-        }{Target: target, Patch: p})
-    }
+		if target == "" {
+			return nil, fmt.Errorf("could not determine target resource for patch path: %s", p.Path)
+		}
 
-    return &PatchableAppSet{
-        Resources: resources,
-        Patches:   wrapped,
-    }, nil
+		if trimmed != "" {
+			p.Path = trimmed
+		}
+
+		if Debug {
+			log.Printf("Patch resolved: target=%s op=%s path=%s value=%v", target, p.Op, p.Path, p.Value)
+		}
+		wrapped = append(wrapped, struct {
+			Target string
+			Patch  PatchOp
+		}{Target: target, Patch: p})
+	}
+
+	return &PatchableAppSet{
+		Resources: resources,
+		Patches:   wrapped,
+	}, nil
 }
 
-func resolvePatchTarget(resources []*unstructured.Unstructured, path string) string {
-    pathParts := parsePath(path)
-    if len(pathParts) == 0 {
-        return ""
-    }
-    for _, r := range resources {
-        name := r.GetName()
-        if strings.EqualFold(name, pathParts[0]) {
-            return name
-        }
-        kind := strings.ToLower(r.GetKind())
-        composite := fmt.Sprintf("%s.%s", kind, name)
-        if strings.EqualFold(composite, pathParts[0]) {
-            return name
-        }
-    }
-    return ""
+func resolvePatchTarget(resources []*unstructured.Unstructured, path string) (string, string) {
+	pathParts := parsePath(path)
+	if len(pathParts) == 0 {
+		return "", ""
+	}
+	first := strings.ToLower(pathParts[0])
+	for _, r := range resources {
+		name := strings.ToLower(r.GetName())
+		kind := strings.ToLower(r.GetKind())
+		if first == name || first == fmt.Sprintf("%s.%s", kind, name) {
+			trimmed := strings.Join(pathParts[1:], ".")
+			return r.GetName(), trimmed
+		}
+	}
+	return "", ""
+}
+
+func resourceExists(resources []*unstructured.Unstructured, name string) bool {
+	for _, r := range resources {
+		if r.GetName() == name {
+			return true
+		}
+	}
+	return false
+}
+
+// smartTarget attempts to match a patch to a resource based on field presence.
+func smartTarget(resources []*unstructured.Unstructured, p PatchOp) []string {
+	var matches []string
+	for _, r := range resources {
+		if err := p.ValidateAgainst(r); err == nil {
+			matches = append(matches, r.GetName())
+		}
+	}
+	return matches
 }


### PR DESCRIPTION
## Summary
- support dot-separated paths in patch parsing
- implement delete list and field operations
- support explicit and smart patch targeting
- update loader YAML decoding logic
- extend tests for delete and targeting

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687f472342e8832fb9020dd4595ff1e2