### PR TITLE
Add base-resource support

### DIFF
--- a/pkg/appsets/design.md
+++ b/pkg/appsets/design.md
@@ -4,7 +4,7 @@
 
 The `appsets` module provides the **core abstraction layer** for loading, representing, and mutating Kubernetes resources using **structured patches** — without templates, overlays, or DSLs.
 
-It enables tools like **Crane** and **Kur8** to declaratively define resource configurations and safe modifications using **pure YAML** and **Go-native data structures**.
+It enables tools like **Crane** and **Kur8** to declaratively define resource configurations and safe modifications using **pure YAML** and **Go-native data structures**. Patches themselves modify an existing **base resource**, which must be provided when a patchable set is created, either loaded from YAML or passed directly as an object.
 
 This forms the foundation for Kure's deterministic, introspectable Kubernetes manifest generation pipeline.
 
@@ -28,6 +28,9 @@ This forms the foundation for Kure's deterministic, introspectable Kubernetes ma
    - All paths are parsed and normalized into `PathPart` structs.
    - Path syntax is explicitly validated before application.
 
+5. **Base resource required**:
+   - Each patch is applied on top of an existing object loaded from a file or provided programmatically.
+
 ---
 
 ## Core Types
@@ -42,6 +45,7 @@ This forms the foundation for Kure's deterministic, introspectable Kubernetes ma
 
 - `LoadResourcesFromMultiYAML(io.Reader)` — Load 1..n Kubernetes resources
 - `LoadPatchFile(io.Reader)` — Load simple or targeted patch syntax
+- `NewPatchableAppSet([]*unstructured.Unstructured, []PatchSpec)` — Create a patchable set from in-memory objects
 - `LoadPatchableAppSet([]io.Reader, io.Reader)` — Create a full working patchable set
 - `NormalizePath()` — Validate and parse patch paths before application
 

--- a/pkg/appsets/doc.go
+++ b/pkg/appsets/doc.go
@@ -11,6 +11,8 @@
 //
 //   - A set of Kubernetes resources, loaded as *unstructured.Unstructured
 //   - A set of declarative patch instructions, using a concise single-line syntax
+//   - Patches are always applied to a base resource that must be loaded or
+//     provided when the PatchableAppSet is created
 //
 // Patches are matched to target resources by name or kind.name unless a `target:`
 // field is explicitly specified.
@@ -63,9 +65,10 @@
 //
 // ## Main Functions
 //
-//	LoadPatchFile(r io.Reader) ([]PatchOp, error)
-//	LoadResourcesFromMultiYAML(r io.Reader) ([]*unstructured.Unstructured, error)
-//	LoadPatchableAppSet(resourceReaders []io.Reader, patchReader io.Reader) (*PatchableAppSet, error)
+//		LoadPatchFile(r io.Reader) ([]PatchOp, error)
+//		LoadResourcesFromMultiYAML(r io.Reader) ([]*unstructured.Unstructured, error)
+//	     NewPatchableAppSet(resources []*unstructured.Unstructured, patches []PatchSpec) (*PatchableAppSet, error)
+//	     LoadPatchableAppSet(resourceReaders []io.Reader, patchReader io.Reader) (*PatchableAppSet, error)
 //
 // These helpers allow loading resources and patches from YAML files or from programmatic input.
 //


### PR DESCRIPTION
## Summary
- describe base resource requirement in docs and design
- add `NewPatchableAppSet` for programmatic creation
- test creating patchable set from objects

## Testing
- `go test ./pkg/appsets -run TestNewPatchableAppSet -count=1`
- `go test ./pkg/...`

------
https://chatgpt.com/codex/tasks/task_e_687f97011808832fabf27e6d1eca5b6a