### PR TITLE
Add CLI patching support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ API reference documentation is available at
 `k8s`, `fluxcd`, `certmanager`, and `metallb` are located under the
 `internal/` directory and include helpers for constructing related
 resources.
+## Patching manifests
+
+The `kure` CLI can patch a base manifest using a file of patch operations. Example files are located in `examples/patch`:
+
+```bash
+kure patch --base examples/patch/base-config.yaml --patch examples/patch/patch.yaml
+```
+
+The command reads the base resource(s) and applies the patches, printing the resulting YAML to stdout.
+
 
 ## License
 

--- a/examples/patch/base-config.yaml
+++ b/examples/patch/base-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo-config
+data:
+  foo: bar

--- a/examples/patch/base-deploy.yaml
+++ b/examples/patch/base-deploy.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-deploy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo
+  template:
+    metadata:
+      labels:
+        app: demo
+    spec:
+      containers:
+      - name: main
+        image: myapp:v1

--- a/examples/patch/patch.yaml
+++ b/examples/patch/patch.yaml
@@ -1,0 +1,8 @@
+- target: demo-config
+  patch:
+    data.foo: qux
+    metadata.labels.env: prod
+- target: demo-deploy
+  patch:
+    spec.replicas: 3
+    spec.template.spec.containers[0].image: myapp:v2

--- a/pkg/cmd/kure/main.go
+++ b/pkg/cmd/kure/main.go
@@ -2,33 +2,103 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"io"
 	"log"
+	"os"
+	"path/filepath"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/cli-runtime/pkg/printers"
+
+	"github.com/go-kure/kure/pkg/appsets"
 	"github.com/go-kure/kure/pkg/cluster"
 )
 
-func main() {
-	var configPath string
-	var manifestsPath string
-	var fluxPath string
-
-	flag.StringVar(&configPath, "config", "", "Path to cluster config YAML file")
-	flag.StringVar(&manifestsPath, "manifests", "manifests", "Output path for Kubernetes manifests")
-	flag.StringVar(&fluxPath, "flux", "flux", "Output path for FluxCD resources")
-	flag.Parse()
-
-	if configPath == "" {
-		log.Fatalf("Error: --config path is required")
+func runCluster(args []string) error {
+	fs := flag.NewFlagSet("cluster", flag.ExitOnError)
+	var configPath, manifestsPath, fluxPath string
+	fs.StringVar(&configPath, "config", "", "Path to cluster config YAML file")
+	fs.StringVar(&manifestsPath, "manifests", "manifests", "Output path for Kubernetes manifests")
+	fs.StringVar(&fluxPath, "flux", "flux", "Output path for FluxCD resources")
+	if err := fs.Parse(args); err != nil {
+		return err
 	}
-
+	if configPath == "" {
+		return fmt.Errorf("--config path is required")
+	}
 	cfg, err := cluster.LoadClusterConfigFromYAML(configPath)
 	if err != nil {
-		log.Fatalf("Failed to load cluster config: %v", err)
+		return fmt.Errorf("failed to load cluster config: %w", err)
 	}
-
 	if err := cluster.WriteCluster(*cfg, manifestsPath, fluxPath); err != nil {
-		log.Fatalf("Failed to write cluster files: %v", err)
+		return fmt.Errorf("failed to write cluster files: %w", err)
 	}
-
 	log.Println("Cluster generated successfully.")
+	return nil
+}
+
+func applyPatch(basePath, patchPath string) ([]*unstructured.Unstructured, error) {
+	baseFile, err := os.Open(filepath.Clean(basePath))
+	if err != nil {
+		return nil, err
+	}
+	defer baseFile.Close()
+	patchFile, err := os.Open(filepath.Clean(patchPath))
+	if err != nil {
+		return nil, err
+	}
+	defer patchFile.Close()
+	set, err := appsets.LoadPatchableAppSet([]io.Reader{baseFile}, patchFile)
+	if err != nil {
+		return nil, err
+	}
+	resources, err := set.Resolve()
+	if err != nil {
+		return nil, err
+	}
+	var patched []*unstructured.Unstructured
+	for _, r := range resources {
+		if err := r.Apply(); err != nil {
+			return nil, err
+		}
+		patched = append(patched, r.Base)
+	}
+	return patched, nil
+}
+
+func runPatch(args []string) error {
+	fs := flag.NewFlagSet("patch", flag.ExitOnError)
+	var basePath, patchPath string
+	fs.StringVar(&basePath, "base", "", "Path to base YAML file")
+	fs.StringVar(&patchPath, "patch", "", "Path to patch file")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if basePath == "" || patchPath == "" {
+		return fmt.Errorf("--base and --patch are required")
+	}
+	objs, err := applyPatch(basePath, patchPath)
+	if err != nil {
+		return err
+	}
+	y := printers.YAMLPrinter{}
+	for _, obj := range objs {
+		if err := y.PrintObj(obj, os.Stdout); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "patch" {
+		if err := runPatch(os.Args[2:]); err != nil {
+			log.Fatalf("patch error: %v", err)
+		}
+		return
+	}
+	if err := runCluster(os.Args[1:]); err != nil {
+		log.Fatalf("cluster error: %v", err)
+	}
 }

--- a/pkg/cmd/kure/main_test.go
+++ b/pkg/cmd/kure/main_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"os"
+	"testing"
+)
+
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "file-*.yaml")
+	if err != nil {
+		t.Fatalf("temp create: %v", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return f.Name()
+}
+
+func TestApplyPatch(t *testing.T) {
+	base := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo
+  labels:
+    app: demo
+data:
+  foo: bar
+`
+	patch := `- target: demo
+  patch:
+    data.foo: baz
+    metadata.labels.env: prod
+`
+	basePath := writeTempFile(t, base)
+	patchPath := writeTempFile(t, patch)
+
+	objs, err := applyPatch(basePath, patchPath)
+	if err != nil {
+		t.Fatalf("applyPatch: %v", err)
+	}
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objs))
+	}
+	labels, found, err := unstructured.NestedStringMap(objs[0].Object, "metadata", "labels")
+	if err != nil || !found {
+		t.Fatalf("labels missing")
+	}
+	if labels["env"] != "prod" {
+		t.Fatalf("patch not applied: %+v", labels)
+	}
+}
+
+func TestRunPatchMissingArgs(t *testing.T) {
+	err := runPatch([]string{})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- extend the `kure` CLI with a `patch` command
- add example base manifests and patches under `examples/patch`
- document patching usage in the README
- provide tests for the new patching logic

## Testing
- `go fmt ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687fa93bf1c0832fa6a767f981ce3df1