### PR TITLE
Refactor CLI to use subcommands

### DIFF
--- a/cmd/kure/main.go
+++ b/cmd/kure/main.go
@@ -16,12 +16,17 @@ import (
 )
 
 func runCluster(args []string) error {
-	fs := flag.NewFlagSet("cluster", flag.ExitOnError)
+	fs := flag.NewFlagSet("cluster", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), "Usage of cluster:")
+		fs.PrintDefaults()
+	}
 	var configPath, manifestsPath, fluxPath string
 	fs.StringVar(&configPath, "config", "", "Path to cluster config YAML file")
 	fs.StringVar(&manifestsPath, "manifests", "manifests", "Output path for Kubernetes manifests")
 	fs.StringVar(&fluxPath, "flux", "flux", "Output path for FluxCD resources")
 	if err := fs.Parse(args); err != nil {
+		fs.Usage()
 		return err
 	}
 	if configPath == "" {
@@ -68,11 +73,16 @@ func applyPatch(basePath, patchPath string) ([]*unstructured.Unstructured, error
 }
 
 func runPatch(args []string) error {
-	fs := flag.NewFlagSet("patch", flag.ExitOnError)
+	fs := flag.NewFlagSet("patch", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), "Usage of patch:")
+		fs.PrintDefaults()
+	}
 	var basePath, patchPath string
 	fs.StringVar(&basePath, "base", "", "Path to base YAML file")
 	fs.StringVar(&patchPath, "patch", "", "Path to patch file")
 	if err := fs.Parse(args); err != nil {
+		fs.Usage()
 		return err
 	}
 	if basePath == "" || patchPath == "" {
@@ -92,13 +102,25 @@ func runPatch(args []string) error {
 }
 
 func main() {
-	if len(os.Args) > 1 && os.Args[1] == "patch" {
-		if err := runPatch(os.Args[2:]); err != nil {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "expected 'cluster' or 'patch' subcommands")
+		os.Exit(1)
+	}
+
+	cmd := os.Args[1]
+	args := os.Args[2:]
+
+	switch cmd {
+	case "cluster":
+		if err := runCluster(args); err != nil {
+			log.Fatalf("cluster error: %v", err)
+		}
+	case "patch":
+		if err := runPatch(args); err != nil {
 			log.Fatalf("patch error: %v", err)
 		}
-		return
-	}
-	if err := runCluster(os.Args[1:]); err != nil {
-		log.Fatalf("cluster error: %v", err)
+	default:
+		fmt.Fprintln(os.Stderr, "expected 'cluster' or 'patch' subcommands")
+		os.Exit(1)
 	}
 }

--- a/cmd/kure/main_test.go
+++ b/cmd/kure/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -59,5 +60,38 @@ func TestRunPatchMissingArgs(t *testing.T) {
 	err := runPatch([]string{})
 	if err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestRunClusterMissingConfig(t *testing.T) {
+	if err := runCluster([]string{}); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestRunCluster(t *testing.T) {
+	cfg := `name: demo
+interval: 5m
+sourceRef: flux-system
+appGroups:
+- name: apps
+  namespace: default
+  apps:
+  - name: myapp
+`
+	cfgPath := writeTempFile(t, cfg)
+	out := t.TempDir()
+	manifests := filepath.Join(out, "manifests")
+	flux := filepath.Join(out, "flux")
+
+	err := runCluster([]string{"--config", cfgPath, "--manifests", manifests, "--flux", flux})
+	if err != nil {
+		t.Fatalf("runCluster: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(manifests, "clusters", "demo")); err != nil {
+		t.Fatalf("manifests not written: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(flux, "clusters", "demo")); err != nil {
+		t.Fatalf("flux not written: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- add dedicated `cluster` and `patch` subcommands
- handle flag parsing errors gracefully and show usage
- test both subcommands

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687fb758e9d8832fa1bb1decb1607338