### PR TITLE
Move patch engine to dedicated module

### DIFF
--- a/cmd/kure/main.go
+++ b/cmd/kure/main.go
@@ -8,8 +8,8 @@ import (
 
 	"k8s.io/cli-runtime/pkg/printers"
 
-	"github.com/go-kure/kure/pkg/appsets"
 	"github.com/go-kure/kure/pkg/cluster"
+	"github.com/go-kure/kure/pkg/patch"
 )
 
 func runCluster(args []string) error {
@@ -56,7 +56,7 @@ func runPatch(args []string) error {
 	if basePath == "" || patchPath == "" {
 		return fmt.Errorf("--base and --patch are required")
 	}
-	objs, err := appsets.ApplyPatch(basePath, patchPath)
+	objs, err := patch.ApplyPatch(basePath, patchPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/kure/main_test.go
+++ b/cmd/kure/main_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/go-kure/kure/pkg/appsets"
+	"github.com/go-kure/kure/pkg/patch"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"os"
 	"path/filepath"
@@ -33,17 +33,17 @@ metadata:
 data:
   foo: bar
 `
-	patch := `- target: demo
+	patchYAML := `- target: demo
   patch:
     data.foo: baz
     metadata.labels.env: prod
 `
 	basePath := writeTempFile(t, base)
-	patchPath := writeTempFile(t, patch)
+	patchPath := writeTempFile(t, patchYAML)
 
-	objs, err := appsets.ApplyPatch(basePath, patchPath)
+	objs, err := patch.ApplyPatch(basePath, patchPath)
 	if err != nil {
-		t.Fatalf("appsets.ApplyPatch: %v", err)
+		t.Fatalf("patch.ApplyPatch: %v", err)
 	}
 	if len(objs) != 1 {
 		t.Fatalf("expected 1 object, got %d", len(objs))
@@ -100,4 +100,3 @@ func TestRunClusterMissingConfig(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 }
-

--- a/pkg/patch/PATCH_ENGINE_DESIGN.md
+++ b/pkg/patch/PATCH_ENGINE_DESIGN.md
@@ -1,8 +1,8 @@
-# Kure `appsets` Module — Purpose and Design
+# Kure `patch` Module — Purpose and Design
 
 ## Purpose
 
-The `appsets` module provides the **core abstraction layer** for loading, representing, and mutating Kubernetes resources using **structured patches** — without templates, overlays, or DSLs.
+The `patch` module provides the **core abstraction layer** for loading, representing, and mutating Kubernetes resources using **structured patches** — without templates, overlays, or DSLs.
 
 It enables tools like **Crane** and **Kur8** to declaratively define resource configurations and safe modifications using **pure YAML** and **Go-native data structures**. Patches themselves modify an existing **base resource**, which must be provided when a patchable set is created, either loaded from YAML or passed directly as an object.
 

--- a/pkg/patch/apply.go
+++ b/pkg/patch/apply.go
@@ -1,4 +1,4 @@
-package appsets
+package patch
 
 import (
 	"io"

--- a/pkg/patch/apply_test.go
+++ b/pkg/patch/apply_test.go
@@ -1,4 +1,4 @@
-package appsets
+package patch
 
 import (
 	"os"

--- a/pkg/patch/doc.go
+++ b/pkg/patch/doc.go
@@ -1,4 +1,4 @@
-// Package appsets provides core structures and helpers for loading,
+// Package patch provides core structures and helpers for loading,
 // patching, and managing sets of Kubernetes resources and declarative patch instructions.
 //
 // This package defines the low-level model used internally by Kure to support
@@ -7,7 +7,7 @@
 //
 // ## Core Concepts
 //
-// The appsets package revolves around the PatchableAppSet, which holds:
+// The patch package revolves around the PatchableAppSet, which holds:
 //
 //   - A set of Kubernetes resources, loaded as *unstructured.Unstructured
 //   - A set of declarative patch instructions, using a concise single-line syntax
@@ -85,4 +85,4 @@
 // - Cluster-wide configuration influence
 //
 // This package is designed for use by higher-level tools like Wharf, Crane, or Kur8.
-package appsets
+package patch

--- a/pkg/patch/loader.go
+++ b/pkg/patch/loader.go
@@ -1,4 +1,4 @@
-package appsets
+package patch
 
 import (
 	"fmt"

--- a/pkg/patch/op.go
+++ b/pkg/patch/op.go
@@ -1,4 +1,4 @@
-package appsets
+package patch
 
 import (
 	"errors"

--- a/pkg/patch/set.go
+++ b/pkg/patch/set.go
@@ -1,4 +1,4 @@
-package appsets
+package patch
 
 import (
 	"fmt"

--- a/pkg/patch/set_test.go
+++ b/pkg/patch/set_test.go
@@ -1,4 +1,4 @@
-package appsets
+package patch
 
 import (
 	"io"


### PR DESCRIPTION
## Summary
- relocate patch engine implementation from `pkg/appsets` to `pkg/patch`
- rename references to new `patch` package
- keep design docs in new location

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6880df801d3c832fa6025b5fb53c8d7e