### PR TITLE
Add YAML IO helper package

### DIFF
--- a/cmd/kure/main_test.go
+++ b/cmd/kure/main_test.go
@@ -64,37 +64,9 @@ func TestRunPatchMissingArgs(t *testing.T) {
 	}
 }
 
-<<<<<<< HEAD
 func TestRunClusterMissingConfig(t *testing.T) {
 	if err := runCluster([]string{}); err == nil {
 		t.Fatalf("expected error")
-	}
-}
-
-func TestRunCluster(t *testing.T) {
-	cfg := `name: demo
-interval: 5m
-sourceRef: flux-system
-appGroups:
-- name: apps
-  namespace: default
-  apps:
-  - name: myapp
-`
-	cfgPath := writeTempFile(t, cfg)
-	out := t.TempDir()
-	manifests := filepath.Join(out, "manifests")
-	flux := filepath.Join(out, "flux")
-
-	err := runCluster([]string{"--config", cfgPath, "--manifests", manifests, "--flux", flux})
-	if err != nil {
-		t.Fatalf("runCluster: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(manifests, "clusters", "demo")); err != nil {
-		t.Fatalf("manifests not written: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(flux, "clusters", "demo")); err != nil {
-		t.Fatalf("flux not written: %v", err)
 	}
 }
 
@@ -126,11 +98,5 @@ appGroups:
 	exp := filepath.Join(flux, "clusters", "demo", "flux-system", "kustomization-flux-system.yaml")
 	if _, err := os.Stat(exp); err != nil {
 		t.Fatalf("expected file not written: %v", err)
-	}
-}
-
-func TestRunClusterMissingConfig(t *testing.T) {
-	if err := runCluster([]string{}); err == nil {
-		t.Fatalf("expected error")
 	}
 }

--- a/pkg/kio/doc.go
+++ b/pkg/kio/doc.go
@@ -1,0 +1,6 @@
+// Package kio provides helper functions for marshalling and unmarshalling
+// objects to and from YAML as well as reading and writing YAML files.
+//
+// The functions operate on io.Reader and io.Writer to integrate with the
+// standard library I/O interfaces.
+package kio

--- a/pkg/kio/yaml.go
+++ b/pkg/kio/yaml.go
@@ -1,0 +1,70 @@
+package kio
+
+import (
+	"bytes"
+	"io"
+	"os"
+
+	"sigs.k8s.io/yaml"
+)
+
+// Buffer is a simple in-memory buffer that implements io.Reader and io.Writer
+// and can marshal and unmarshal YAML representations of objects.
+type Buffer struct {
+	bytes.Buffer
+}
+
+// Marshal writes the YAML representation of obj to the buffer.
+func (b *Buffer) Marshal(obj interface{}) error {
+	b.Reset()
+	data, err := yaml.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	_, err = b.Write(data)
+	return err
+}
+
+// Unmarshal parses the buffer contents as YAML into obj.
+func (b *Buffer) Unmarshal(obj interface{}) error {
+	return yaml.Unmarshal(b.Bytes(), obj)
+}
+
+// Marshal writes the YAML representation of obj to w.
+func Marshal(w io.Writer, obj interface{}) error {
+	data, err := yaml.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+// Unmarshal reads YAML from r into obj.
+func Unmarshal(r io.Reader, obj interface{}) error {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	return yaml.Unmarshal(data, obj)
+}
+
+// SaveFile marshals obj as YAML and writes it to the given file path.
+func SaveFile(path string, obj interface{}) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return Marshal(f, obj)
+}
+
+// LoadFile reads YAML from the given path and unmarshals it into obj.
+func LoadFile(path string, obj interface{}) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return Unmarshal(f, obj)
+}

--- a/pkg/kio/yaml_test.go
+++ b/pkg/kio/yaml_test.go
@@ -1,0 +1,43 @@
+package kio
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+type demo struct {
+	Name string `yaml:"name"`
+	Age  int    `yaml:"age"`
+}
+
+func TestBufferMarshalUnmarshal(t *testing.T) {
+	b := &Buffer{}
+	in := demo{Name: "test", Age: 5}
+	if err := b.Marshal(in); err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out demo
+	if err := b.Unmarshal(&out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round trip mismatch: %#v != %#v", in, out)
+	}
+}
+
+func TestSaveLoadFile(t *testing.T) {
+	d := demo{Name: "file", Age: 8}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demo.yaml")
+	if err := SaveFile(path, d); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	var out demo
+	if err := LoadFile(path, &out); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !reflect.DeepEqual(d, out) {
+		t.Fatalf("file round trip mismatch: %#v != %#v", d, out)
+	}
+}


### PR DESCRIPTION
## Summary
- add `kio` package for reading/writing YAML
- provide buffer type implementing io.Reader and io.Writer
- update CLI tests to clean merge markers

## Testing
- `go test ./pkg/...`
- `go test ./cmd/...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6880ef492ce0832f90356e09ae8dd884