### PR TITLE
Introduce AppSet utilities

### DIFF
--- a/pkg/cluster/add.go
+++ b/pkg/cluster/add.go
@@ -1,0 +1,30 @@
+package cluster
+
+import (
+	"github.com/go-kure/kure/pkg/api"
+	"github.com/go-kure/kure/pkg/cluster/appset"
+	"github.com/go-kure/kure/pkg/layout"
+)
+
+// AddAppSet converts the provided AppSet into layout structures and appends
+// them to the manifest and Flux layout slices.
+func AddAppSet(manifests *[]*layout.ManifestLayout, fluxes *[]*layout.FluxLayout, as *appset.AppSet, filePer api.FileExportMode) error {
+	if err := as.Validate(); err != nil {
+		return err
+	}
+
+	ml := &layout.ManifestLayout{
+		Name:      as.Name,
+		Namespace: as.Namespace,
+		FilePer:   filePer,
+		Resources: as.Resources,
+	}
+	fl := &layout.FluxLayout{
+		Name:     as.Name,
+		Manifest: ml,
+	}
+
+	*manifests = append(*manifests, ml)
+	*fluxes = append(*fluxes, fl)
+	return nil
+}

--- a/pkg/cluster/appset/appset.go
+++ b/pkg/cluster/appset/appset.go
@@ -1,0 +1,136 @@
+package appset
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// AppSet represents a unit of deployment, typically the resources that
+// are reconciled by a single Flux Kustomization.
+type AppSet struct {
+	// Name identifies the application set.
+	Name string
+	// Namespace is the target namespace for the resources. It may be empty
+	// for cluster scoped objects.
+	Namespace string
+	// Resources holds the Kubernetes objects that belong to the application.
+	Resources []client.Object
+	// Labels are common labels that should be applied to each resource.
+	Labels map[string]string
+}
+
+// New constructs an AppSet with the given name, resources and labels.
+// It returns an error if validation fails.
+func New(name string, resources []client.Object, labels map[string]string) (*AppSet, error) {
+	a := &AppSet{Name: name, Namespace: "", Resources: resources, Labels: labels}
+	if err := a.Validate(); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+// Validate performs basic sanity checks on the AppSet.
+func (a *AppSet) Validate() error {
+	if a == nil {
+		return fmt.Errorf("nil AppSet")
+	}
+	if a.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	for i, r := range a.Resources {
+		if r == nil {
+			return fmt.Errorf("resource %d is nil", i)
+		}
+	}
+	return nil
+}
+
+// LabelRule defines a subset selection rule based on labels.
+type LabelRule struct {
+	// Name identifies the subset created from matching resources.
+	Name string
+	// Match specifies labels that must be present on a resource for it
+	// to belong to the subset.
+	Match map[string]string
+}
+
+func copyMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func labelsMatch(labels map[string]string, match map[string]string) bool {
+	for k, v := range match {
+		if labels[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// SplitByLabels divides the AppSet into new AppSets based on the provided
+// label rules. Resources matching a rule are placed into the corresponding
+// subset. Resources that do not match any rule remain in the original set.
+func (a *AppSet) SplitByLabels(rules []LabelRule) ([]*AppSet, error) {
+	if err := a.Validate(); err != nil {
+		return nil, err
+	}
+
+	subsets := make([]*AppSet, len(rules))
+	for i, r := range rules {
+		subsets[i] = &AppSet{
+			Name:      r.Name,
+			Namespace: a.Namespace,
+			Labels:    mergeLabels(a.Labels, r.Match),
+		}
+	}
+
+	var remaining []client.Object
+	for _, obj := range a.Resources {
+		matched := false
+		lbls := obj.GetLabels()
+		for i, r := range rules {
+			if labelsMatch(lbls, r.Match) {
+				subsets[i].Resources = append(subsets[i].Resources, obj)
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			remaining = append(remaining, obj)
+		}
+	}
+
+	// Filter out empty subsets
+	var result []*AppSet
+	for _, s := range subsets {
+		if len(s.Resources) > 0 {
+			result = append(result, s)
+		}
+	}
+
+	// Update current AppSet to hold remaining resources
+	a.Resources = remaining
+	if len(a.Resources) > 0 {
+		result = append(result, a)
+	}
+	return result, nil
+}
+
+func mergeLabels(base, add map[string]string) map[string]string {
+	out := copyMap(base)
+	for k, v := range add {
+		if out == nil {
+			out = map[string]string{}
+		}
+		out[k] = v
+	}
+	return out
+}

--- a/pkg/cluster/appset/appset_test.go
+++ b/pkg/cluster/appset/appset_test.go
@@ -1,0 +1,61 @@
+package appset
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestSplitByLabels(t *testing.T) {
+	r1 := &unstructured.Unstructured{}
+	r1.SetAPIVersion("v1")
+	r1.SetKind("ConfigMap")
+	r1.SetName("cm1")
+	r1.SetLabels(map[string]string{"env": "prod"})
+
+	r2 := &unstructured.Unstructured{}
+	r2.SetAPIVersion("v1")
+	r2.SetKind("ConfigMap")
+	r2.SetName("cm2")
+	r2.SetLabels(map[string]string{"env": "dev"})
+
+	r3 := &unstructured.Unstructured{}
+	r3.SetAPIVersion("v1")
+	r3.SetKind("ConfigMap")
+	r3.SetName("cm3")
+	r3.SetLabels(map[string]string{"env": "prod", "tier": "front"})
+
+	as, err := New("demo", []client.Object{r1, r2, r3}, map[string]string{"app": "demo"})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	rules := []LabelRule{
+		{Name: "prod", Match: map[string]string{"env": "prod"}},
+		{Name: "dev", Match: map[string]string{"env": "dev"}},
+	}
+
+	splits, err := as.SplitByLabels(rules)
+	if err != nil {
+		t.Fatalf("split: %v", err)
+	}
+
+	if len(splits) != 2 {
+		t.Fatalf("expected 2 splits got %d", len(splits))
+	}
+
+	if splits[0].Name != "prod" || len(splits[0].Resources) != 2 {
+		t.Fatalf("unexpected prod split")
+	}
+	if splits[1].Name != "dev" || len(splits[1].Resources) != 1 {
+		t.Fatalf("unexpected dev split")
+	}
+}
+
+func TestValidate(t *testing.T) {
+	as := &AppSet{Name: "", Resources: []client.Object{}}
+	if err := as.Validate(); err == nil {
+		t.Fatalf("expected validation error")
+	}
+}

--- a/pkg/cluster/appset/doc.go
+++ b/pkg/cluster/appset/doc.go
@@ -1,0 +1,7 @@
+// Package appset provides small helpers for grouping resources that make up
+// a single application or deployment unit.
+//
+// An AppSet can be used by the cluster package to add a collection of
+// Kubernetes resources, typically represented by a Flux Kustomization, to
+// a cluster layout.
+package appset


### PR DESCRIPTION
## Summary
- add new `appset` package to represent collections of application resources
- support splitting an AppSet based on label rules
- expose `cluster.AddAppSet` helper for converting AppSets into layouts
- test AppSet utilities

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6880faabd514832f8e484976595285d5