### PR TITLE
Add configurable Flux layout generation

### DIFF
--- a/pkg/cluster/layout/config.go
+++ b/pkg/cluster/layout/config.go
@@ -1,0 +1,58 @@
+package layout
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-kure/kure/pkg/api"
+)
+
+// ManifestFileNameFunc returns a file name for the given namespace, kind and resource name.
+type ManifestFileNameFunc func(namespace, kind, name string, mode api.FileExportMode) string
+
+// KustomizationFileNameFunc returns the file name for a Flux Kustomization manifest.
+type KustomizationFileNameFunc func(name string) string
+
+// LayoutConfig defines rules for generating a cluster layout.
+type LayoutConfig struct {
+	// ManifestsDir is the directory under which Kubernetes manifests are written.
+	ManifestsDir string
+	// FluxDir is the directory under which Flux manifests are written.
+	FluxDir string
+	// FilePer determines how resources are grouped into files when writing manifests.
+	FilePer api.FileExportMode
+	// ManifestFileName formats the file name for a resource manifest.
+	ManifestFileName ManifestFileNameFunc
+	// KustomizationFileName formats the file name for a Flux Kustomization.
+	KustomizationFileName KustomizationFileNameFunc
+}
+
+// DefaultLayoutConfig returns a configuration that matches the directory layout
+// expected by FluxCD when writing manifests and Kustomizations.
+func DefaultLayoutConfig() LayoutConfig {
+	return LayoutConfig{
+		ManifestsDir:          "clusters",
+		FluxDir:               "clusters",
+		FilePer:               api.FilePerResource,
+		ManifestFileName:      DefaultManifestFileName,
+		KustomizationFileName: DefaultKustomizationFileName,
+	}
+}
+
+// DefaultManifestFileName implements the standard file naming convention used
+// by Kure. It writes either one file per resource or groups by kind depending
+// on the FileExportMode.
+func DefaultManifestFileName(namespace, kind, name string, mode api.FileExportMode) string {
+	kind = strings.ToLower(kind)
+	switch mode {
+	case api.FilePerKind:
+		return fmt.Sprintf("%s-%s.yaml", namespace, kind)
+	default:
+		return fmt.Sprintf("%s-%s-%s.yaml", namespace, kind, name)
+	}
+}
+
+// DefaultKustomizationFileName returns the standard Flux Kustomization file name.
+func DefaultKustomizationFileName(name string) string {
+	return fmt.Sprintf("kustomization-%s.yaml", name)
+}

--- a/pkg/cluster/layout/doc.go
+++ b/pkg/cluster/layout/doc.go
@@ -1,0 +1,2 @@
+// Package layout defines helpers for generating cluster directory layouts.
+package layout

--- a/pkg/cluster/layout/generator.go
+++ b/pkg/cluster/layout/generator.go
@@ -1,0 +1,47 @@
+package layout
+
+import (
+	"github.com/go-kure/kure/pkg/api"
+	"github.com/go-kure/kure/pkg/bootstrap"
+	baselayout "github.com/go-kure/kure/pkg/layout"
+)
+
+// ClusterLayout groups the manifest and Flux layouts produced for a cluster.
+type ClusterLayout struct {
+	Manifests []*baselayout.ManifestLayout
+	Fluxes    []*baselayout.FluxLayout
+	Bootstrap *baselayout.FluxLayout
+}
+
+// FluxLayoutGenerator generates a cluster layout from a configuration and LayoutConfig.
+type FluxLayoutGenerator interface {
+	Generate(api.ClusterConfig, LayoutConfig) (*ClusterLayout, error)
+}
+
+// DefaultGenerator implements FluxLayoutGenerator using the current Kure behaviour.
+type DefaultGenerator struct{}
+
+// Generate builds ManifestLayout and FluxLayout trees from the given cluster configuration.
+func (DefaultGenerator) Generate(cfg api.ClusterConfig, lc LayoutConfig) (*ClusterLayout, error) {
+	var manifests []*baselayout.ManifestLayout
+	var fluxes []*baselayout.FluxLayout
+
+	for _, group := range cfg.AppGroups {
+		m, f, err := baselayout.NewAppGroup(group)
+		if err != nil {
+			return nil, err
+		}
+		if m.FilePer == "" {
+			m.FilePer = lc.FilePer
+		}
+		manifests = append(manifests, m)
+		fluxes = append(fluxes, f)
+	}
+
+	bs, err := bootstrap.NewFluxBootstrap(cfg.Name, cfg.SourceRef, cfg.Interval, "flux-system")
+	if err != nil {
+		return nil, err
+	}
+
+	return &ClusterLayout{Manifests: manifests, Fluxes: fluxes, Bootstrap: bs}, nil
+}

--- a/pkg/cluster/layout/write.go
+++ b/pkg/cluster/layout/write.go
@@ -1,0 +1,156 @@
+package layout
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	baselayout "github.com/go-kure/kure/pkg/layout"
+)
+
+// WriteManifest writes a ManifestLayout to disk using the provided configuration.
+func WriteManifest(basePath string, cfg LayoutConfig, ml *baselayout.ManifestLayout) error {
+	if cfg.ManifestFileName == nil {
+		cfg.ManifestFileName = DefaultManifestFileName
+	}
+	if cfg.ManifestsDir == "" {
+		cfg.ManifestsDir = "clusters"
+	}
+	mode := ml.FilePer
+	if mode == "" {
+		mode = cfg.FilePer
+	}
+
+	fullPath := filepath.Join(basePath, cfg.ManifestsDir, ml.FullRepoPath())
+	if err := os.MkdirAll(fullPath, 0755); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+
+	fileGroups := map[string][]client.Object{}
+	for _, obj := range ml.Resources {
+		ns := obj.GetNamespace()
+		if ns == "" {
+			ns = "cluster"
+		}
+		kind := strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind)
+		name := obj.GetName()
+		fileName := cfg.ManifestFileName(ns, kind, name, mode)
+		fileGroups[fileName] = append(fileGroups[fileName], obj)
+	}
+
+	for fileName, objs := range fileGroups {
+		f, err := os.Create(filepath.Join(fullPath, fileName))
+		if err != nil {
+			return err
+		}
+		for _, obj := range objs {
+			data, err := yaml.Marshal(obj)
+			if err != nil {
+				_ = f.Close()
+				return err
+			}
+			if _, err = f.Write(data); err != nil {
+				_ = f.Close()
+				return err
+			}
+			_, _ = f.Write([]byte("---"))
+		}
+		if err := f.Close(); err != nil {
+			return err
+		}
+	}
+
+	kustomPath := filepath.Join(fullPath, "kustomization.yaml")
+	kf, err := os.Create(kustomPath)
+	if err != nil {
+		return err
+	}
+	_, _ = kf.WriteString("resources: ")
+	for file := range fileGroups {
+		_, _ = kf.WriteString(fmt.Sprintf("  - %s ", file))
+	}
+
+	for _, child := range ml.Children {
+		_, _ = kf.WriteString(fmt.Sprintf("  - ../%s ", child.Name))
+	}
+
+	for _, child := range ml.Children {
+		if err := WriteManifest(basePath, cfg, child); err != nil {
+			_ = kf.Close()
+			return err
+		}
+	}
+
+	return kf.Close()
+}
+
+// WriteFlux writes a FluxLayout to disk using the provided configuration.
+func WriteFlux(basePath string, cfg LayoutConfig, fl *baselayout.FluxLayout) error {
+	if cfg.KustomizationFileName == nil {
+		cfg.KustomizationFileName = DefaultKustomizationFileName
+	}
+	if cfg.FluxDir == "" {
+		cfg.FluxDir = "clusters"
+	}
+
+	if fl.TargetPath == "" && fl.Manifest != nil {
+		fl.TargetPath = fl.Manifest.FullRepoPath()
+	}
+
+	dir := filepath.Join(basePath, cfg.FluxDir, fl.TargetPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	fileName := cfg.KustomizationFileName(fl.Name)
+	fullPath := filepath.Join(dir, fileName)
+
+	interval := fl.Interval
+	if interval == "" {
+		interval = "5m"
+	}
+	source := fl.SourceRef
+	if source == "" {
+		source = "flux-system"
+	}
+
+	pathSpec := "./" + filepath.ToSlash(fl.TargetPath)
+
+	kustom := map[string]interface{}{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata": map[string]string{
+			"name":      fl.Name,
+			"namespace": "flux-system",
+		},
+		"spec": map[string]interface{}{
+			"interval": interval,
+			"path":     pathSpec,
+			"prune":    true,
+			"sourceRef": map[string]string{
+				"kind":      "OCIRepository",
+				"name":      source,
+				"namespace": "flux-system",
+			},
+		},
+	}
+
+	if len(fl.DependsOn) > 0 {
+		var deps []map[string]string
+		for _, d := range fl.DependsOn {
+			deps = append(deps, map[string]string{"name": d})
+		}
+		kustom["spec"].(map[string]interface{})["dependsOn"] = deps
+	}
+
+	data, err := yaml.Marshal(kustom)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(fullPath, data, 0644)
+}

--- a/pkg/layout/flux_test.go
+++ b/pkg/layout/flux_test.go
@@ -1,0 +1,28 @@
+package layout_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	cllayout "github.com/go-kure/kure/pkg/cluster/layout"
+	"github.com/go-kure/kure/pkg/layout"
+)
+
+func TestFluxLayoutWriteWithConfig(t *testing.T) {
+	fl := &layout.FluxLayout{Name: "app", TargetPath: "demo/app"}
+
+	cfg := cllayout.DefaultLayoutConfig()
+	cfg.FluxDir = "flux"
+	cfg.KustomizationFileName = func(name string) string { return name + ".flux.yaml" }
+
+	dir := t.TempDir()
+	if err := cllayout.WriteFlux(dir, cfg, fl); err != nil {
+		t.Fatalf("write with config: %v", err)
+	}
+
+	expected := filepath.Join(dir, "flux", "demo", "app", "app.flux.yaml")
+	if _, err := os.Stat(expected); err != nil {
+		t.Fatalf("expected file not written: %v", err)
+	}
+}

--- a/pkg/layout/manifest_test.go
+++ b/pkg/layout/manifest_test.go
@@ -1,10 +1,12 @@
-package layout
+package layout_test
 
 import (
 	"os"
 	"path/filepath"
 	"testing"
 
+	cllayout "github.com/go-kure/kure/pkg/cluster/layout"
+	"github.com/go-kure/kure/pkg/layout"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -18,7 +20,7 @@ func TestManifestLayoutWrite(t *testing.T) {
 	obj.SetName("test")
 	obj.SetNamespace("default")
 
-	ml := &ManifestLayout{
+	ml := &layout.ManifestLayout{
 		Name:      "test",
 		Namespace: "default",
 		FilePer:   api.FilePerResource,
@@ -31,6 +33,36 @@ func TestManifestLayoutWrite(t *testing.T) {
 	}
 	path := filepath.Join(dir, "default", "test", "default-configmap-test.yaml")
 	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file not written: %v", err)
+	}
+}
+
+func TestManifestLayoutWriteWithConfig(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("v1")
+	obj.SetKind("ConfigMap")
+	obj.SetName("demo")
+	obj.SetNamespace("demo")
+
+	ml := &layout.ManifestLayout{
+		Name:      "app",
+		Namespace: "demo",
+		Resources: []client.Object{obj},
+	}
+
+	cfg := cllayout.DefaultLayoutConfig()
+	cfg.ManifestsDir = "manifests"
+	cfg.ManifestFileName = func(ns, kind, name string, _ api.FileExportMode) string {
+		return ns + "_" + kind + "_" + name + ".yml"
+	}
+
+	dir := t.TempDir()
+	if err := cllayout.WriteManifest(dir, cfg, ml); err != nil {
+		t.Fatalf("write with config: %v", err)
+	}
+
+	expected := filepath.Join(dir, "manifests", "demo", "app", "demo_configmap_demo.yml")
+	if _, err := os.Stat(expected); err != nil {
 		t.Fatalf("expected file not written: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- add `LayoutConfig` and default implementation in new `pkg/cluster/layout`
- implement `FluxLayoutGenerator` interface
- provide helper writers for manifests and Flux kustomizations
- add tests demonstrating custom output naming

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6880faacd7e4832f9b360400d12e053f