### PR TITLE
Add cluster example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ kure patch --base examples/patch/base-config.yaml --patch examples/patch/patch.y
 
 The command reads the base resource(s) and applies the patches, printing the resulting YAML to stdout.
 
+## Cluster example
+
+The repository also provides an example for building a cluster configuration
+programmatically. Running the following command will print the generated YAML
+to stdout:
+
+```bash
+go run ./cmd/cluster
+```
+
+
 
 ## License
 

--- a/cmd/cluster/main.go
+++ b/cmd/cluster/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/go-kure/kure/pkg/api"
+	"github.com/go-kure/kure/pkg/cluster"
+	"github.com/go-kure/kure/pkg/kio"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func main() {
+	c := cluster.NewCluster("prod", "10m", "flux-system", &api.OCIRepositoryConfig{
+		Name:      "flux-system",
+		Namespace: "flux-system",
+		URL:       "oci://ghcr.io/my-org/flux-manifests",
+		Ref:       "main",
+		Interval:  "10m",
+	})
+	c.SetFilePer(api.FilePerResource)
+
+	app := api.AppDeploymentConfig{
+		Name:     "my-app",
+		Image:    "ghcr.io/my-org/my-app:v1",
+		Ports:    []int{80},
+		Replicas: ptr(2),
+		Ingress: &api.IngressConfig{
+			Host:   "my-app.example.com",
+			TLS:    true,
+			Issuer: "letsencrypt",
+		},
+	}
+
+	group := api.AppGroup{
+		Name:      "apps",
+		Namespace: "default",
+		Apps:      []api.AppDeploymentConfig{app},
+	}
+
+	c.AddAppSet(cluster.AppSet{AppGroup: group})
+
+	if err := kio.Marshal(os.Stdout, c); err != nil {
+		log.Fatalf("failed to marshal cluster: %v", err)
+	}
+}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -2,7 +2,7 @@ package cluster
 
 import (
 	"github.com/go-kure/kure/pkg/api"
-	"github.com/go-kure/kure/pkg/bootstrap"
+	"github.com/go-kure/kure/pkg/fluxcd"
 	"github.com/go-kure/kure/pkg/layout"
 )
 
@@ -60,7 +60,7 @@ func (c *Cluster) BuildLayout(r LayoutRules) ([]*layout.ManifestLayout, []*layou
 		fluxes = append(fluxes, flux)
 	}
 
-	bootstrapFlux, err := bootstrap.NewFluxBootstrap(c.Name, c.SourceRef, c.Interval, "flux-system")
+	bootstrapFlux, err := fluxcd.NewFluxBootstrap(c.Name, c.SourceRef, c.Interval, "flux-system")
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/cluster/layout/generator.go
+++ b/pkg/cluster/layout/generator.go
@@ -2,7 +2,7 @@ package layout
 
 import (
 	"github.com/go-kure/kure/pkg/api"
-	"github.com/go-kure/kure/pkg/bootstrap"
+	"github.com/go-kure/kure/pkg/fluxcd"
 	baselayout "github.com/go-kure/kure/pkg/layout"
 )
 
@@ -38,7 +38,7 @@ func (DefaultGenerator) Generate(cfg api.ClusterConfig, lc LayoutConfig) (*Clust
 		fluxes = append(fluxes, f)
 	}
 
-	bs, err := bootstrap.NewFluxBootstrap(cfg.Name, cfg.SourceRef, cfg.Interval, "flux-system")
+	bs, err := fluxcd.NewFluxBootstrap(cfg.Name, cfg.SourceRef, cfg.Interval, "flux-system")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/writer.go
+++ b/pkg/cluster/writer.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/go-kure/kure/pkg/bootstrap"
+	"github.com/go-kure/kure/pkg/fluxcd"
 )
 
 // WriteCluster writes the manifests and Flux layouts for the cluster to disk.
@@ -31,9 +31,9 @@ func WriteCluster(c *Cluster, manifestsBasePath, fluxBasePath string) error {
 	}
 
 	if c.OCIRepo != nil {
-		ocirepo := bootstrap.NewOCIRepositoryYAML(c.OCIRepo)
+		ocirepo := fluxcd.NewOCIRepositoryYAML(c.OCIRepo)
 		ocipath := filepath.Join(fluxBasePath, "clusters", c.Name, "flux-system", "ocirepository-"+c.Name+".yaml")
-		if err := bootstrap.WriteYAMLResource(ocipath, ocirepo); err != nil {
+		if err := fluxcd.WriteYAMLResource(ocipath, ocirepo); err != nil {
 			return fmt.Errorf("write OCI repo: %w", err)
 		}
 	}


### PR DESCRIPTION
## Summary
- add an example program under cmd/cluster that builds a Cluster and prints its YAML
- update Cluster utilities to use the fluxcd package
- mention the new cluster example in README

## Testing
- `go fmt ./...`
- `go test ./...`
- `go run ./cmd/cluster | head`


------
https://chatgpt.com/codex/tasks/task_e_688112bce890832f9d23d8e1dd1c1299