### PR TITLE
Add PodSpec helper API

### DIFF
--- a/internal/k8s/podspec.go
+++ b/internal/k8s/podspec.go
@@ -1,0 +1,229 @@
+package k8s
+
+import (
+	"errors"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// CreatePodSpec returns a PodSpec initialized with sensible defaults.
+func CreatePodSpec() *corev1.PodSpec {
+	obj := corev1.PodSpec{
+		Containers:                    []corev1.Container{},
+		InitContainers:                []corev1.Container{},
+		Volumes:                       []corev1.Volume{},
+		RestartPolicy:                 corev1.RestartPolicyAlways,
+		TerminationGracePeriodSeconds: new(int64),
+		SecurityContext:               &corev1.PodSecurityContext{},
+		ImagePullSecrets:              []corev1.LocalObjectReference{},
+		ServiceAccountName:            "",
+		NodeSelector:                  map[string]string{},
+		Affinity:                      &corev1.Affinity{},
+		Tolerations:                   []corev1.Toleration{},
+	}
+	return &obj
+}
+
+// AddPodSpecContainer appends a container to the PodSpec.
+func AddPodSpecContainer(spec *corev1.PodSpec, container *corev1.Container) error {
+	if spec == nil || container == nil {
+		return errors.New("nil spec or container")
+	}
+	spec.Containers = append(spec.Containers, *container)
+	return nil
+}
+
+// AddPodSpecInitContainer appends an init container to the PodSpec.
+func AddPodSpecInitContainer(spec *corev1.PodSpec, container *corev1.Container) error {
+	if spec == nil || container == nil {
+		return errors.New("nil spec or container")
+	}
+	spec.InitContainers = append(spec.InitContainers, *container)
+	return nil
+}
+
+// AddPodSpecEphemeralContainer appends an ephemeral container to the PodSpec.
+func AddPodSpecEphemeralContainer(spec *corev1.PodSpec, container *corev1.EphemeralContainer) error {
+	if spec == nil || container == nil {
+		return errors.New("nil spec or container")
+	}
+	spec.EphemeralContainers = append(spec.EphemeralContainers, *container)
+	return nil
+}
+
+// AddPodSpecVolume appends a volume to the PodSpec.
+func AddPodSpecVolume(spec *corev1.PodSpec, volume *corev1.Volume) error {
+	if spec == nil || volume == nil {
+		return errors.New("nil spec or volume")
+	}
+	spec.Volumes = append(spec.Volumes, *volume)
+	return nil
+}
+
+// AddPodSpecImagePullSecret appends an image pull secret to the PodSpec.
+func AddPodSpecImagePullSecret(spec *corev1.PodSpec, secret *corev1.LocalObjectReference) error {
+	if spec == nil || secret == nil {
+		return errors.New("nil spec or secret")
+	}
+	spec.ImagePullSecrets = append(spec.ImagePullSecrets, *secret)
+	return nil
+}
+
+// AddPodSpecToleration appends a toleration to the PodSpec.
+func AddPodSpecToleration(spec *corev1.PodSpec, toleration *corev1.Toleration) error {
+	if spec == nil || toleration == nil {
+		return errors.New("nil spec or toleration")
+	}
+	spec.Tolerations = append(spec.Tolerations, *toleration)
+	return nil
+}
+
+// AddPodSpecTopologySpreadConstraints appends a topology spread constraint if provided.
+func AddPodSpecTopologySpreadConstraints(spec *corev1.PodSpec, constraint *corev1.TopologySpreadConstraint) error {
+	if spec == nil {
+		return errors.New("nil spec")
+	}
+	if constraint == nil {
+		return nil
+	}
+	spec.TopologySpreadConstraints = append(spec.TopologySpreadConstraints, *constraint)
+	return nil
+}
+
+// SetPodSpecServiceAccountName sets the service account name.
+func SetPodSpecServiceAccountName(spec *corev1.PodSpec, name string) error {
+	if spec == nil {
+		return errors.New("nil spec")
+	}
+	spec.ServiceAccountName = name
+	return nil
+}
+
+// SetPodSpecSecurityContext sets the security context for the PodSpec.
+func SetPodSpecSecurityContext(spec *corev1.PodSpec, sc *corev1.PodSecurityContext) error {
+	if spec == nil {
+		return errors.New("nil spec")
+	}
+	spec.SecurityContext = sc
+	return nil
+}
+
+// SetPodSpecAffinity assigns affinity rules to the PodSpec.
+func SetPodSpecAffinity(spec *corev1.PodSpec, aff *corev1.Affinity) error {
+	if spec == nil {
+		return errors.New("nil spec")
+	}
+	spec.Affinity = aff
+	return nil
+}
+
+// SetPodSpecNodeSelector sets the node selector map.
+func SetPodSpecNodeSelector(spec *corev1.PodSpec, selector map[string]string) error {
+	if spec == nil {
+		return errors.New("nil spec")
+	}
+	spec.NodeSelector = selector
+	return nil
+}
+
+// SetPodSpecPriorityClassName sets the priority class name.
+func SetPodSpecPriorityClassName(spec *corev1.PodSpec, class string) error {
+	if spec == nil {
+		return errors.New("nil spec")
+	}
+	spec.PriorityClassName = class
+	return nil
+}
+
+// SetPodSpecHostNetwork configures host networking.
+func SetPodSpecHostNetwork(spec *corev1.PodSpec, hostNetwork bool) error {
+	if spec == nil {
+		return errors.New("nil spec")
+	}
+	spec.HostNetwork = hostNetwork
+	return nil
+}
+
+// SetPodSpecHostPID configures host PID namespace usage.
+func SetPodSpecHostPID(spec *corev1.PodSpec, hostPID bool) error {
+	if spec == nil {
+		return errors.New("nil spec")
+	}
+	spec.HostPID = hostPID
+	return nil
+}
+
+// SetPodSpecHostIPC configures host IPC namespace usage.
+func SetPodSpecHostIPC(spec *corev1.PodSpec, hostIPC bool) error {
+	if spec == nil {
+		return errors.New("nil spec")
+	}
+	spec.HostIPC = hostIPC
+	return nil
+}
+
+// SetPodSpecDNSPolicy sets the DNS policy.
+func SetPodSpecDNSPolicy(spec *corev1.PodSpec, policy corev1.DNSPolicy) error {
+	if spec == nil {
+		return errors.New("nil spec")
+	}
+	spec.DNSPolicy = policy
+	return nil
+}
+
+// SetPodSpecDNSConfig sets the DNS config.
+func SetPodSpecDNSConfig(spec *corev1.PodSpec, cfg *corev1.PodDNSConfig) error {
+	if spec == nil {
+		return errors.New("nil spec")
+	}
+	spec.DNSConfig = cfg
+	return nil
+}
+
+// SetPodSpecHostname sets the hostname.
+func SetPodSpecHostname(spec *corev1.PodSpec, hostname string) error {
+	if spec == nil {
+		return errors.New("nil spec")
+	}
+	spec.Hostname = hostname
+	return nil
+}
+
+// SetPodSpecSubdomain sets the subdomain.
+func SetPodSpecSubdomain(spec *corev1.PodSpec, subdomain string) error {
+	if spec == nil {
+		return errors.New("nil spec")
+	}
+	spec.Subdomain = subdomain
+	return nil
+}
+
+// SetPodSpecRestartPolicy sets the restart policy.
+func SetPodSpecRestartPolicy(spec *corev1.PodSpec, policy corev1.RestartPolicy) error {
+	if spec == nil {
+		return errors.New("nil spec")
+	}
+	spec.RestartPolicy = policy
+	return nil
+}
+
+// SetPodSpecTerminationGracePeriod sets the termination grace period seconds.
+func SetPodSpecTerminationGracePeriod(spec *corev1.PodSpec, secs int64) error {
+	if spec == nil {
+		return errors.New("nil spec")
+	}
+	if spec.TerminationGracePeriodSeconds == nil {
+		spec.TerminationGracePeriodSeconds = new(int64)
+	}
+	*spec.TerminationGracePeriodSeconds = secs
+	return nil
+}
+
+// SetPodSpecSchedulerName sets the scheduler name.
+func SetPodSpecSchedulerName(spec *corev1.PodSpec, scheduler string) error {
+	if spec == nil {
+		return errors.New("nil spec")
+	}
+	spec.SchedulerName = scheduler
+	return nil
+}

--- a/internal/k8s/podspec_test.go
+++ b/internal/k8s/podspec_test.go
@@ -1,0 +1,192 @@
+package k8s
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCreatePodSpec(t *testing.T) {
+	spec := CreatePodSpec()
+
+	if spec.RestartPolicy != corev1.RestartPolicyAlways {
+		t.Errorf("unexpected restart policy %v", spec.RestartPolicy)
+	}
+	if spec.TerminationGracePeriodSeconds == nil {
+		t.Errorf("expected TerminationGracePeriodSeconds to be set")
+	}
+	if len(spec.Containers) != 0 {
+		t.Errorf("expected no containers")
+	}
+}
+
+func TestPodSpecFunctions(t *testing.T) {
+	spec := CreatePodSpec()
+
+	c := corev1.Container{Name: "c"}
+	if err := AddPodSpecContainer(spec, &c); err != nil {
+		t.Fatalf("AddPodSpecContainer returned error: %v", err)
+	}
+	if len(spec.Containers) != 1 || spec.Containers[0].Name != "c" {
+		t.Errorf("container not added")
+	}
+
+	ic := corev1.Container{Name: "init"}
+	if err := AddPodSpecInitContainer(spec, &ic); err != nil {
+		t.Fatalf("AddPodSpecInitContainer returned error: %v", err)
+	}
+	if len(spec.InitContainers) != 1 {
+		t.Errorf("init container not added")
+	}
+
+	ec := corev1.EphemeralContainer{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "debug"}}
+	if err := AddPodSpecEphemeralContainer(spec, &ec); err != nil {
+		t.Fatalf("AddPodSpecEphemeralContainer returned error: %v", err)
+	}
+	if len(spec.EphemeralContainers) != 1 {
+		t.Errorf("ephemeral container not added")
+	}
+
+	v := corev1.Volume{Name: "vol"}
+	if err := AddPodSpecVolume(spec, &v); err != nil {
+		t.Fatalf("AddPodSpecVolume returned error: %v", err)
+	}
+	if len(spec.Volumes) != 1 {
+		t.Errorf("volume not added")
+	}
+
+	sec := corev1.LocalObjectReference{Name: "pull"}
+	if err := AddPodSpecImagePullSecret(spec, &sec); err != nil {
+		t.Fatalf("AddPodSpecImagePullSecret returned error: %v", err)
+	}
+	if len(spec.ImagePullSecrets) != 1 {
+		t.Errorf("pull secret not added")
+	}
+
+	tol := corev1.Toleration{Key: "k"}
+	if err := AddPodSpecToleration(spec, &tol); err != nil {
+		t.Fatalf("AddPodSpecToleration returned error: %v", err)
+	}
+	if len(spec.Tolerations) != 1 {
+		t.Errorf("toleration not added")
+	}
+
+	tsc := corev1.TopologySpreadConstraint{MaxSkew: 1, TopologyKey: "zone", WhenUnsatisfiable: corev1.DoNotSchedule, LabelSelector: &metav1.LabelSelector{}}
+	if err := AddPodSpecTopologySpreadConstraints(spec, &tsc); err != nil {
+		t.Fatalf("AddPodSpecTopologySpreadConstraints returned error: %v", err)
+	}
+	if len(spec.TopologySpreadConstraints) != 1 {
+		t.Errorf("topology constraint not added")
+	}
+
+	if err := SetPodSpecServiceAccountName(spec, "sa"); err != nil {
+		t.Fatalf("SetPodSpecServiceAccountName returned error: %v", err)
+	}
+	if spec.ServiceAccountName != "sa" {
+		t.Errorf("service account not set")
+	}
+
+	sc := &corev1.PodSecurityContext{}
+	if err := SetPodSpecSecurityContext(spec, sc); err != nil {
+		t.Fatalf("SetPodSpecSecurityContext returned error: %v", err)
+	}
+	if spec.SecurityContext != sc {
+		t.Errorf("security context not set")
+	}
+
+	aff := &corev1.Affinity{}
+	if err := SetPodSpecAffinity(spec, aff); err != nil {
+		t.Fatalf("SetPodSpecAffinity returned error: %v", err)
+	}
+	if spec.Affinity != aff {
+		t.Errorf("affinity not set")
+	}
+
+	sel := map[string]string{"role": "db"}
+	if err := SetPodSpecNodeSelector(spec, sel); err != nil {
+		t.Fatalf("SetPodSpecNodeSelector returned error: %v", err)
+	}
+	if !reflect.DeepEqual(spec.NodeSelector, sel) {
+		t.Errorf("node selector not set")
+	}
+
+	if err := SetPodSpecPriorityClassName(spec, "high"); err != nil {
+		t.Fatalf("SetPodSpecPriorityClassName returned error: %v", err)
+	}
+	if spec.PriorityClassName != "high" {
+		t.Errorf("priority class name not set")
+	}
+
+	if err := SetPodSpecHostNetwork(spec, true); err != nil {
+		t.Fatalf("SetPodSpecHostNetwork returned error: %v", err)
+	}
+	if !spec.HostNetwork {
+		t.Errorf("host network not set")
+	}
+
+	if err := SetPodSpecHostPID(spec, true); err != nil {
+		t.Fatalf("SetPodSpecHostPID returned error: %v", err)
+	}
+	if !spec.HostPID {
+		t.Errorf("host pid not set")
+	}
+
+	if err := SetPodSpecHostIPC(spec, true); err != nil {
+		t.Fatalf("SetPodSpecHostIPC returned error: %v", err)
+	}
+	if !spec.HostIPC {
+		t.Errorf("host ipc not set")
+	}
+
+	if err := SetPodSpecDNSPolicy(spec, corev1.DNSClusterFirstWithHostNet); err != nil {
+		t.Fatalf("SetPodSpecDNSPolicy returned error: %v", err)
+	}
+	if spec.DNSPolicy != corev1.DNSClusterFirstWithHostNet {
+		t.Errorf("dns policy not set")
+	}
+
+	dnsCfg := &corev1.PodDNSConfig{Nameservers: []string{"8.8.8.8"}}
+	if err := SetPodSpecDNSConfig(spec, dnsCfg); err != nil {
+		t.Fatalf("SetPodSpecDNSConfig returned error: %v", err)
+	}
+	if spec.DNSConfig != dnsCfg {
+		t.Errorf("dns config not set")
+	}
+
+	if err := SetPodSpecHostname(spec, "myhost"); err != nil {
+		t.Fatalf("SetPodSpecHostname returned error: %v", err)
+	}
+	if spec.Hostname != "myhost" {
+		t.Errorf("hostname not set")
+	}
+
+	if err := SetPodSpecSubdomain(spec, "sub"); err != nil {
+		t.Fatalf("SetPodSpecSubdomain returned error: %v", err)
+	}
+	if spec.Subdomain != "sub" {
+		t.Errorf("subdomain not set")
+	}
+
+	if err := SetPodSpecRestartPolicy(spec, corev1.RestartPolicyOnFailure); err != nil {
+		t.Fatalf("SetPodSpecRestartPolicy returned error: %v", err)
+	}
+	if spec.RestartPolicy != corev1.RestartPolicyOnFailure {
+		t.Errorf("restart policy not set")
+	}
+
+	if err := SetPodSpecTerminationGracePeriod(spec, 15); err != nil {
+		t.Fatalf("SetPodSpecTerminationGracePeriod returned error: %v", err)
+	}
+	if spec.TerminationGracePeriodSeconds == nil || *spec.TerminationGracePeriodSeconds != 15 {
+		t.Errorf("termination grace period not set")
+	}
+
+	if err := SetPodSpecSchedulerName(spec, "sched"); err != nil {
+		t.Fatalf("SetPodSpecSchedulerName returned error: %v", err)
+	}
+	if spec.SchedulerName != "sched" {
+		t.Errorf("scheduler name not set")
+	}
+}


### PR DESCRIPTION
## Summary
- add `CreatePodSpec` and helpers for editing PodSpec fields
- test PodSpec helpers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6889e3220be4832f8b180cb12e633cdf