### PR TITLE
Refactor podspec helpers

### DIFF
--- a/internal/k8s/daemonset.go
+++ b/internal/k8s/daemonset.go
@@ -29,19 +29,7 @@ func CreateDaemonSet(name, namespace string) *appsv1.DaemonSet {
 			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
-				Spec: corev1.PodSpec{
-					Containers:                    []corev1.Container{},
-					InitContainers:                []corev1.Container{},
-					Volumes:                       []corev1.Volume{},
-					RestartPolicy:                 corev1.RestartPolicyAlways,
-					TerminationGracePeriodSeconds: new(int64),
-					SecurityContext:               &corev1.PodSecurityContext{},
-					ImagePullSecrets:              []corev1.LocalObjectReference{},
-					ServiceAccountName:            "",
-					NodeSelector:                  map[string]string{},
-					Affinity:                      &corev1.Affinity{},
-					Tolerations:                   []corev1.Toleration{},
-				},
+				Spec:       corev1.PodSpec{},
 			},
 			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{},
 		},
@@ -49,49 +37,53 @@ func CreateDaemonSet(name, namespace string) *appsv1.DaemonSet {
 	return obj
 }
 
+// SetDaemonSetPodSpec assigns a PodSpec to the DaemonSet template.
+func SetDaemonSetPodSpec(ds *appsv1.DaemonSet, spec *corev1.PodSpec) error {
+	if ds == nil || spec == nil {
+		return errors.New("nil daemonset or spec")
+	}
+	ds.Spec.Template.Spec = *spec
+	return nil
+}
+
 // AddDaemonSetContainer appends a container to the DaemonSet pod template.
 func AddDaemonSetContainer(ds *appsv1.DaemonSet, c *corev1.Container) error {
-	if ds == nil || c == nil {
-		return errors.New("nil daemonset or container")
+	if ds == nil {
+		return errors.New("nil daemonset")
 	}
-	ds.Spec.Template.Spec.Containers = append(ds.Spec.Template.Spec.Containers, *c)
-	return nil
+	return AddPodSpecContainer(&ds.Spec.Template.Spec, c)
 }
 
 // AddDaemonSetInitContainer appends an init container to the pod template.
 func AddDaemonSetInitContainer(ds *appsv1.DaemonSet, c *corev1.Container) error {
-	if ds == nil || c == nil {
-		return errors.New("nil daemonset or container")
+	if ds == nil {
+		return errors.New("nil daemonset")
 	}
-	ds.Spec.Template.Spec.InitContainers = append(ds.Spec.Template.Spec.InitContainers, *c)
-	return nil
+	return AddPodSpecInitContainer(&ds.Spec.Template.Spec, c)
 }
 
 // AddDaemonSetVolume appends a volume to the pod template.
 func AddDaemonSetVolume(ds *appsv1.DaemonSet, v *corev1.Volume) error {
-	if ds == nil || v == nil {
-		return errors.New("nil daemonset or volume")
+	if ds == nil {
+		return errors.New("nil daemonset")
 	}
-	ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes, *v)
-	return nil
+	return AddPodSpecVolume(&ds.Spec.Template.Spec, v)
 }
 
 // AddDaemonSetImagePullSecret appends an image pull secret to the pod template.
 func AddDaemonSetImagePullSecret(ds *appsv1.DaemonSet, s *corev1.LocalObjectReference) error {
-	if ds == nil || s == nil {
-		return errors.New("nil daemonset or secret")
+	if ds == nil {
+		return errors.New("nil daemonset")
 	}
-	ds.Spec.Template.Spec.ImagePullSecrets = append(ds.Spec.Template.Spec.ImagePullSecrets, *s)
-	return nil
+	return AddPodSpecImagePullSecret(&ds.Spec.Template.Spec, s)
 }
 
 // AddDaemonSetToleration appends a toleration to the pod template.
 func AddDaemonSetToleration(ds *appsv1.DaemonSet, t *corev1.Toleration) error {
-	if ds == nil || t == nil {
-		return errors.New("nil daemonset or toleration")
+	if ds == nil {
+		return errors.New("nil daemonset")
 	}
-	ds.Spec.Template.Spec.Tolerations = append(ds.Spec.Template.Spec.Tolerations, *t)
-	return nil
+	return AddPodSpecToleration(&ds.Spec.Template.Spec, t)
 }
 
 // AddDaemonSetTopologySpreadConstraints appends a topology spread constraint if not nil.
@@ -99,11 +91,7 @@ func AddDaemonSetTopologySpreadConstraints(ds *appsv1.DaemonSet, c *corev1.Topol
 	if ds == nil {
 		return errors.New("nil daemonset")
 	}
-	if c == nil {
-		return nil
-	}
-	ds.Spec.Template.Spec.TopologySpreadConstraints = append(ds.Spec.Template.Spec.TopologySpreadConstraints, *c)
-	return nil
+	return AddPodSpecTopologySpreadConstraints(&ds.Spec.Template.Spec, c)
 }
 
 // SetDaemonSetServiceAccountName sets the service account name.
@@ -111,8 +99,7 @@ func SetDaemonSetServiceAccountName(ds *appsv1.DaemonSet, name string) error {
 	if ds == nil {
 		return errors.New("nil daemonset")
 	}
-	ds.Spec.Template.Spec.ServiceAccountName = name
-	return nil
+	return SetPodSpecServiceAccountName(&ds.Spec.Template.Spec, name)
 }
 
 // SetDaemonSetSecurityContext sets the pod security context.
@@ -120,8 +107,7 @@ func SetDaemonSetSecurityContext(ds *appsv1.DaemonSet, sc *corev1.PodSecurityCon
 	if ds == nil {
 		return errors.New("nil daemonset")
 	}
-	ds.Spec.Template.Spec.SecurityContext = sc
-	return nil
+	return SetPodSpecSecurityContext(&ds.Spec.Template.Spec, sc)
 }
 
 // SetDaemonSetAffinity sets the pod affinity rules.
@@ -129,8 +115,7 @@ func SetDaemonSetAffinity(ds *appsv1.DaemonSet, aff *corev1.Affinity) error {
 	if ds == nil {
 		return errors.New("nil daemonset")
 	}
-	ds.Spec.Template.Spec.Affinity = aff
-	return nil
+	return SetPodSpecAffinity(&ds.Spec.Template.Spec, aff)
 }
 
 // SetDaemonSetNodeSelector sets the node selector.
@@ -138,8 +123,7 @@ func SetDaemonSetNodeSelector(ds *appsv1.DaemonSet, ns map[string]string) error 
 	if ds == nil {
 		return errors.New("nil daemonset")
 	}
-	ds.Spec.Template.Spec.NodeSelector = ns
-	return nil
+	return SetPodSpecNodeSelector(&ds.Spec.Template.Spec, ns)
 }
 
 // SetDaemonSetUpdateStrategy sets the update strategy.

--- a/internal/k8s/deployment.go
+++ b/internal/k8s/deployment.go
@@ -37,106 +37,90 @@ func CreateDeployment(name string, namespace string) *appsv1.Deployment {
 						"app": name,
 					},
 				},
-				Spec: corev1.PodSpec{
-					Containers:                    []corev1.Container{},
-					InitContainers:                []corev1.Container{},
-					Volumes:                       []corev1.Volume{},
-					RestartPolicy:                 corev1.RestartPolicyAlways,
-					TerminationGracePeriodSeconds: new(int64),
-					SecurityContext:               &corev1.PodSecurityContext{},
-					ImagePullSecrets:              []corev1.LocalObjectReference{},
-					ServiceAccountName:            "",
-					NodeSelector:                  map[string]string{},
-					Affinity:                      &corev1.Affinity{},
-					Tolerations:                   []corev1.Toleration{},
-				},
+				Spec: corev1.PodSpec{},
 			},
 		},
 	}
 	return obj
 }
 
-func AddDeploymentContainer(deployment *appsv1.Deployment, container *corev1.Container) error {
-	if deployment == nil || container == nil {
-		return errors.New("nil deployment or container")
+// SetDeploymentPodSpec assigns a PodSpec to the Deployment template.
+func SetDeploymentPodSpec(dep *appsv1.Deployment, spec *corev1.PodSpec) error {
+	if dep == nil || spec == nil {
+		return errors.New("nil deployment or spec")
 	}
-	deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, *container)
+	dep.Spec.Template.Spec = *spec
 	return nil
+}
+
+func AddDeploymentContainer(deployment *appsv1.Deployment, container *corev1.Container) error {
+	if deployment == nil {
+		return errors.New("nil deployment")
+	}
+	return AddPodSpecContainer(&deployment.Spec.Template.Spec, container)
 }
 
 func AddDeploymentInitContainer(deployment *appsv1.Deployment, container *corev1.Container) error {
-	if deployment == nil || container == nil {
-		return errors.New("nil deployment or container")
+	if deployment == nil {
+		return errors.New("nil deployment")
 	}
-	deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers, *container)
-	return nil
+	return AddPodSpecInitContainer(&deployment.Spec.Template.Spec, container)
 }
 
 func AddDeploymentVolume(deployment *appsv1.Deployment, volume *corev1.Volume) error {
-	if deployment == nil || volume == nil {
-		return errors.New("nil deployment or volume")
+	if deployment == nil {
+		return errors.New("nil deployment")
 	}
-	deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, *volume)
-	return nil
+	return AddPodSpecVolume(&deployment.Spec.Template.Spec, volume)
 }
 
 func AddDeploymentImagePullSecret(deployment *appsv1.Deployment, imagePullSecret *corev1.LocalObjectReference) error {
-	if deployment == nil || imagePullSecret == nil {
-		return errors.New("nil deployment or imagePullSecret")
+	if deployment == nil {
+		return errors.New("nil deployment")
 	}
-	deployment.Spec.Template.Spec.ImagePullSecrets = append(deployment.Spec.Template.Spec.ImagePullSecrets, *imagePullSecret)
-	return nil
+	return AddPodSpecImagePullSecret(&deployment.Spec.Template.Spec, imagePullSecret)
 }
 
 func AddDeploymentToleration(deployment *appsv1.Deployment, toleration *corev1.Toleration) error {
-	if deployment == nil || toleration == nil {
-		return errors.New("nil deployment or toleration")
+	if deployment == nil {
+		return errors.New("nil deployment")
 	}
-	deployment.Spec.Template.Spec.Tolerations = append(deployment.Spec.Template.Spec.Tolerations, *toleration)
-	return nil
+	return AddPodSpecToleration(&deployment.Spec.Template.Spec, toleration)
 }
 
 func AddDeploymentTopologySpreadConstraints(deployment *appsv1.Deployment, topologySpreadConstraint *corev1.TopologySpreadConstraint) error {
 	if deployment == nil {
 		return errors.New("nil deployment")
 	}
-	if topologySpreadConstraint == nil {
-		return nil
-	}
-	deployment.Spec.Template.Spec.TopologySpreadConstraints = append(deployment.Spec.Template.Spec.TopologySpreadConstraints, *topologySpreadConstraint)
-	return nil
+	return AddPodSpecTopologySpreadConstraints(&deployment.Spec.Template.Spec, topologySpreadConstraint)
 }
 
 func SetDeploymentServiceAccountName(deployment *appsv1.Deployment, serviceAccountName string) error {
 	if deployment == nil {
 		return errors.New("nil deployment")
 	}
-	deployment.Spec.Template.Spec.ServiceAccountName = serviceAccountName
-	return nil
+	return SetPodSpecServiceAccountName(&deployment.Spec.Template.Spec, serviceAccountName)
 }
 
 func SetDeploymentSecurityContext(deployment *appsv1.Deployment, securityContext *corev1.PodSecurityContext) error {
 	if deployment == nil {
 		return errors.New("nil deployment")
 	}
-	deployment.Spec.Template.Spec.SecurityContext = securityContext
-	return nil
+	return SetPodSpecSecurityContext(&deployment.Spec.Template.Spec, securityContext)
 }
 
 func SetDeploymentAffinity(deployment *appsv1.Deployment, affinity *corev1.Affinity) error {
 	if deployment == nil {
 		return errors.New("nil deployment")
 	}
-	deployment.Spec.Template.Spec.Affinity = affinity
-	return nil
+	return SetPodSpecAffinity(&deployment.Spec.Template.Spec, affinity)
 }
 
 func SetDeploymentNodeSelector(deployment *appsv1.Deployment, nodeSelector map[string]string) error {
 	if deployment == nil {
 		return errors.New("nil deployment")
 	}
-	deployment.Spec.Template.Spec.NodeSelector = nodeSelector
-	return nil
+	return SetPodSpecNodeSelector(&deployment.Spec.Template.Spec, nodeSelector)
 }
 
 // SetDeploymentReplicas sets the desired replica count.

--- a/internal/k8s/job.go
+++ b/internal/k8s/job.go
@@ -31,106 +31,90 @@ func CreateJob(name, namespace string) *batchv1.Job {
 						"app": name,
 					},
 				},
-				Spec: corev1.PodSpec{
-					Containers:                    []corev1.Container{},
-					InitContainers:                []corev1.Container{},
-					Volumes:                       []corev1.Volume{},
-					RestartPolicy:                 corev1.RestartPolicyNever,
-					TerminationGracePeriodSeconds: new(int64),
-					SecurityContext:               &corev1.PodSecurityContext{},
-					ImagePullSecrets:              []corev1.LocalObjectReference{},
-					ServiceAccountName:            "",
-					NodeSelector:                  map[string]string{},
-					Affinity:                      &corev1.Affinity{},
-					Tolerations:                   []corev1.Toleration{},
-				},
+				Spec: corev1.PodSpec{},
 			},
 		},
 	}
 	return obj
 }
 
-func AddJobContainer(job *batchv1.Job, container *corev1.Container) error {
-	if job == nil || container == nil {
-		return errors.New("nil job or container")
+// SetJobPodSpec assigns a PodSpec to the Job template.
+func SetJobPodSpec(job *batchv1.Job, spec *corev1.PodSpec) error {
+	if job == nil || spec == nil {
+		return errors.New("nil job or spec")
 	}
-	job.Spec.Template.Spec.Containers = append(job.Spec.Template.Spec.Containers, *container)
+	job.Spec.Template.Spec = *spec
 	return nil
+}
+
+func AddJobContainer(job *batchv1.Job, container *corev1.Container) error {
+	if job == nil {
+		return errors.New("nil job")
+	}
+	return AddPodSpecContainer(&job.Spec.Template.Spec, container)
 }
 
 func AddJobInitContainer(job *batchv1.Job, container *corev1.Container) error {
-	if job == nil || container == nil {
-		return errors.New("nil job or container")
+	if job == nil {
+		return errors.New("nil job")
 	}
-	job.Spec.Template.Spec.InitContainers = append(job.Spec.Template.Spec.InitContainers, *container)
-	return nil
+	return AddPodSpecInitContainer(&job.Spec.Template.Spec, container)
 }
 
 func AddJobVolume(job *batchv1.Job, volume *corev1.Volume) error {
-	if job == nil || volume == nil {
-		return errors.New("nil job or volume")
+	if job == nil {
+		return errors.New("nil job")
 	}
-	job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, *volume)
-	return nil
+	return AddPodSpecVolume(&job.Spec.Template.Spec, volume)
 }
 
 func AddJobImagePullSecret(job *batchv1.Job, secret *corev1.LocalObjectReference) error {
-	if job == nil || secret == nil {
-		return errors.New("nil job or secret")
+	if job == nil {
+		return errors.New("nil job")
 	}
-	job.Spec.Template.Spec.ImagePullSecrets = append(job.Spec.Template.Spec.ImagePullSecrets, *secret)
-	return nil
+	return AddPodSpecImagePullSecret(&job.Spec.Template.Spec, secret)
 }
 
 func AddJobToleration(job *batchv1.Job, toleration *corev1.Toleration) error {
-	if job == nil || toleration == nil {
-		return errors.New("nil job or toleration")
+	if job == nil {
+		return errors.New("nil job")
 	}
-	job.Spec.Template.Spec.Tolerations = append(job.Spec.Template.Spec.Tolerations, *toleration)
-	return nil
+	return AddPodSpecToleration(&job.Spec.Template.Spec, toleration)
 }
 
 func AddJobTopologySpreadConstraint(job *batchv1.Job, constraint *corev1.TopologySpreadConstraint) error {
 	if job == nil {
 		return errors.New("nil job")
 	}
-	if constraint == nil {
-		return nil
-	}
-	job.Spec.Template.Spec.TopologySpreadConstraints = append(job.Spec.Template.Spec.TopologySpreadConstraints, *constraint)
-	return nil
+	return AddPodSpecTopologySpreadConstraints(&job.Spec.Template.Spec, constraint)
 }
 
 func SetJobServiceAccountName(job *batchv1.Job, name string) error {
 	if job == nil {
 		return errors.New("nil job")
 	}
-	job.Spec.Template.Spec.ServiceAccountName = name
-	return nil
+	return SetPodSpecServiceAccountName(&job.Spec.Template.Spec, name)
 }
 
 func SetJobSecurityContext(job *batchv1.Job, sc *corev1.PodSecurityContext) error {
 	if job == nil {
 		return errors.New("nil job")
 	}
-	job.Spec.Template.Spec.SecurityContext = sc
-	return nil
+	return SetPodSpecSecurityContext(&job.Spec.Template.Spec, sc)
 }
 
 func SetJobAffinity(job *batchv1.Job, aff *corev1.Affinity) error {
 	if job == nil {
 		return errors.New("nil job")
 	}
-	job.Spec.Template.Spec.Affinity = aff
-	return nil
+	return SetPodSpecAffinity(&job.Spec.Template.Spec, aff)
 }
 
 func SetJobNodeSelector(job *batchv1.Job, selector map[string]string) error {
 	if job == nil {
 		return errors.New("nil job")
 	}
-	job.Spec.Template.Spec.NodeSelector = selector
-	return nil
+	return SetPodSpecNodeSelector(&job.Spec.Template.Spec, selector)
 }
 
 func SetJobCompletions(job *batchv1.Job, completions int32) error {
@@ -200,19 +184,7 @@ func CreateCronJob(name, namespace, schedule string) *batchv1.CronJob {
 								"app": name,
 							},
 						},
-						Spec: corev1.PodSpec{
-							Containers:                    []corev1.Container{},
-							InitContainers:                []corev1.Container{},
-							Volumes:                       []corev1.Volume{},
-							RestartPolicy:                 corev1.RestartPolicyNever,
-							TerminationGracePeriodSeconds: new(int64),
-							SecurityContext:               &corev1.PodSecurityContext{},
-							ImagePullSecrets:              []corev1.LocalObjectReference{},
-							ServiceAccountName:            "",
-							NodeSelector:                  map[string]string{},
-							Affinity:                      &corev1.Affinity{},
-							Tolerations:                   []corev1.Toleration{},
-						},
+						Spec: corev1.PodSpec{},
 					},
 				},
 			},
@@ -221,87 +193,83 @@ func CreateCronJob(name, namespace, schedule string) *batchv1.CronJob {
 	return obj
 }
 
-func AddCronJobContainer(cron *batchv1.CronJob, container *corev1.Container) error {
-	if cron == nil || container == nil {
-		return errors.New("nil cronjob or container")
+// SetCronJobPodSpec assigns a PodSpec to the CronJob template.
+func SetCronJobPodSpec(cron *batchv1.CronJob, spec *corev1.PodSpec) error {
+	if cron == nil || spec == nil {
+		return errors.New("nil cronjob or spec")
 	}
-	cron.Spec.JobTemplate.Spec.Template.Spec.Containers = append(cron.Spec.JobTemplate.Spec.Template.Spec.Containers, *container)
+	cron.Spec.JobTemplate.Spec.Template.Spec = *spec
 	return nil
+}
+
+func AddCronJobContainer(cron *batchv1.CronJob, container *corev1.Container) error {
+	if cron == nil {
+		return errors.New("nil cronjob")
+	}
+	return AddPodSpecContainer(&cron.Spec.JobTemplate.Spec.Template.Spec, container)
 }
 
 func AddCronJobInitContainer(cron *batchv1.CronJob, container *corev1.Container) error {
-	if cron == nil || container == nil {
-		return errors.New("nil cronjob or container")
+	if cron == nil {
+		return errors.New("nil cronjob")
 	}
-	cron.Spec.JobTemplate.Spec.Template.Spec.InitContainers = append(cron.Spec.JobTemplate.Spec.Template.Spec.InitContainers, *container)
-	return nil
+	return AddPodSpecInitContainer(&cron.Spec.JobTemplate.Spec.Template.Spec, container)
 }
 
 func AddCronJobVolume(cron *batchv1.CronJob, volume *corev1.Volume) error {
-	if cron == nil || volume == nil {
-		return errors.New("nil cronjob or volume")
+	if cron == nil {
+		return errors.New("nil cronjob")
 	}
-	cron.Spec.JobTemplate.Spec.Template.Spec.Volumes = append(cron.Spec.JobTemplate.Spec.Template.Spec.Volumes, *volume)
-	return nil
+	return AddPodSpecVolume(&cron.Spec.JobTemplate.Spec.Template.Spec, volume)
 }
 
 func AddCronJobImagePullSecret(cron *batchv1.CronJob, secret *corev1.LocalObjectReference) error {
-	if cron == nil || secret == nil {
-		return errors.New("nil cronjob or secret")
+	if cron == nil {
+		return errors.New("nil cronjob")
 	}
-	cron.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets = append(cron.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets, *secret)
-	return nil
+	return AddPodSpecImagePullSecret(&cron.Spec.JobTemplate.Spec.Template.Spec, secret)
 }
 
 func AddCronJobToleration(cron *batchv1.CronJob, toleration *corev1.Toleration) error {
-	if cron == nil || toleration == nil {
-		return errors.New("nil cronjob or toleration")
+	if cron == nil {
+		return errors.New("nil cronjob")
 	}
-	cron.Spec.JobTemplate.Spec.Template.Spec.Tolerations = append(cron.Spec.JobTemplate.Spec.Template.Spec.Tolerations, *toleration)
-	return nil
+	return AddPodSpecToleration(&cron.Spec.JobTemplate.Spec.Template.Spec, toleration)
 }
 
 func AddCronJobTopologySpreadConstraint(cron *batchv1.CronJob, constraint *corev1.TopologySpreadConstraint) error {
 	if cron == nil {
 		return errors.New("nil cronjob")
 	}
-	if constraint == nil {
-		return nil
-	}
-	cron.Spec.JobTemplate.Spec.Template.Spec.TopologySpreadConstraints = append(cron.Spec.JobTemplate.Spec.Template.Spec.TopologySpreadConstraints, *constraint)
-	return nil
+	return AddPodSpecTopologySpreadConstraints(&cron.Spec.JobTemplate.Spec.Template.Spec, constraint)
 }
 
 func SetCronJobServiceAccountName(cron *batchv1.CronJob, name string) error {
 	if cron == nil {
 		return errors.New("nil cronjob")
 	}
-	cron.Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName = name
-	return nil
+	return SetPodSpecServiceAccountName(&cron.Spec.JobTemplate.Spec.Template.Spec, name)
 }
 
 func SetCronJobSecurityContext(cron *batchv1.CronJob, sc *corev1.PodSecurityContext) error {
 	if cron == nil {
 		return errors.New("nil cronjob")
 	}
-	cron.Spec.JobTemplate.Spec.Template.Spec.SecurityContext = sc
-	return nil
+	return SetPodSpecSecurityContext(&cron.Spec.JobTemplate.Spec.Template.Spec, sc)
 }
 
 func SetCronJobAffinity(cron *batchv1.CronJob, aff *corev1.Affinity) error {
 	if cron == nil {
 		return errors.New("nil cronjob")
 	}
-	cron.Spec.JobTemplate.Spec.Template.Spec.Affinity = aff
-	return nil
+	return SetPodSpecAffinity(&cron.Spec.JobTemplate.Spec.Template.Spec, aff)
 }
 
 func SetCronJobNodeSelector(cron *batchv1.CronJob, selector map[string]string) error {
 	if cron == nil {
 		return errors.New("nil cronjob")
 	}
-	cron.Spec.JobTemplate.Spec.Template.Spec.NodeSelector = selector
-	return nil
+	return SetPodSpecNodeSelector(&cron.Spec.JobTemplate.Spec.Template.Spec, selector)
 }
 
 func SetCronJobSchedule(cron *batchv1.CronJob, schedule string) error {

--- a/internal/k8s/job_test.go
+++ b/internal/k8s/job_test.go
@@ -17,7 +17,7 @@ func TestCreateJob(t *testing.T) {
 	if job.Kind != "Job" {
 		t.Errorf("unexpected kind %q", job.Kind)
 	}
-	if job.Spec.Template.Spec.RestartPolicy != corev1.RestartPolicyNever {
+	if job.Spec.Template.Spec.RestartPolicy != "" {
 		t.Errorf("unexpected restart policy %v", job.Spec.Template.Spec.RestartPolicy)
 	}
 	if len(job.Spec.Template.Spec.Containers) != 0 {
@@ -155,7 +155,7 @@ func TestCreateCronJob(t *testing.T) {
 	if cj.Spec.Schedule != "* * * * *" {
 		t.Errorf("schedule not set")
 	}
-	if cj.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy != corev1.RestartPolicyNever {
+	if cj.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy != "" {
 		t.Errorf("unexpected restart policy")
 	}
 }

--- a/internal/k8s/pod.go
+++ b/internal/k8s/pod.go
@@ -25,75 +25,66 @@ func CreatePod(name string, namespace string) *corev1.Pod {
 				"app": name,
 			},
 		},
-		Spec: corev1.PodSpec{
-			Containers:                    []corev1.Container{},
-			InitContainers:                []corev1.Container{},
-			Volumes:                       []corev1.Volume{},
-			RestartPolicy:                 corev1.RestartPolicyAlways,
-			TerminationGracePeriodSeconds: new(int64),
-			SecurityContext:               &corev1.PodSecurityContext{},
-			ImagePullSecrets:              []corev1.LocalObjectReference{},
-			ServiceAccountName:            "",
-			NodeSelector:                  map[string]string{},
-			Affinity:                      &corev1.Affinity{},
-			Tolerations:                   []corev1.Toleration{},
-		},
+		Spec: corev1.PodSpec{},
 	}
 	return &obj
 }
 
+// SetPodSpec assigns a pod spec to the Pod.
+func SetPodSpec(pod *corev1.Pod, spec *corev1.PodSpec) error {
+	if pod == nil || spec == nil {
+		return errors.New("nil pod or spec")
+	}
+	pod.Spec = *spec
+	return nil
+}
+
 // AddPodContainer appends a container to the Pod spec.
 func AddPodContainer(pod *corev1.Pod, container *corev1.Container) error {
-	if pod == nil || container == nil {
-		return errors.New("nil pod or container")
+	if pod == nil {
+		return errors.New("nil pod")
 	}
-	pod.Spec.Containers = append(pod.Spec.Containers, *container)
-	return nil
+	return AddPodSpecContainer(&pod.Spec, container)
 }
 
 // AddPodInitContainer appends an init container to the Pod spec.
 func AddPodInitContainer(pod *corev1.Pod, container *corev1.Container) error {
-	if pod == nil || container == nil {
-		return errors.New("nil pod or container")
+	if pod == nil {
+		return errors.New("nil pod")
 	}
-	pod.Spec.InitContainers = append(pod.Spec.InitContainers, *container)
-	return nil
+	return AddPodSpecInitContainer(&pod.Spec, container)
 }
 
 // AddPodEphemeralContainer appends an ephemeral container to the Pod spec.
 func AddPodEphemeralContainer(pod *corev1.Pod, container *corev1.EphemeralContainer) error {
-	if pod == nil || container == nil {
-		return errors.New("nil pod or container")
+	if pod == nil {
+		return errors.New("nil pod")
 	}
-	pod.Spec.EphemeralContainers = append(pod.Spec.EphemeralContainers, *container)
-	return nil
+	return AddPodSpecEphemeralContainer(&pod.Spec, container)
 }
 
 // AddPodVolume appends a volume to the Pod spec.
 func AddPodVolume(pod *corev1.Pod, volume *corev1.Volume) error {
-	if pod == nil || volume == nil {
-		return errors.New("nil pod or volume")
+	if pod == nil {
+		return errors.New("nil pod")
 	}
-	pod.Spec.Volumes = append(pod.Spec.Volumes, *volume)
-	return nil
+	return AddPodSpecVolume(&pod.Spec, volume)
 }
 
 // AddPodImagePullSecret appends an image pull secret to the Pod spec.
 func AddPodImagePullSecret(pod *corev1.Pod, imagePullSecret *corev1.LocalObjectReference) error {
-	if pod == nil || imagePullSecret == nil {
-		return errors.New("nil pod or imagePullSecret")
+	if pod == nil {
+		return errors.New("nil pod")
 	}
-	pod.Spec.ImagePullSecrets = append(pod.Spec.ImagePullSecrets, *imagePullSecret)
-	return nil
+	return AddPodSpecImagePullSecret(&pod.Spec, imagePullSecret)
 }
 
 // AddPodToleration appends a toleration to the Pod spec.
 func AddPodToleration(pod *corev1.Pod, toleration *corev1.Toleration) error {
-	if pod == nil || toleration == nil {
-		return errors.New("nil pod or toleration")
+	if pod == nil {
+		return errors.New("nil pod")
 	}
-	pod.Spec.Tolerations = append(pod.Spec.Tolerations, *toleration)
-	return nil
+	return AddPodSpecToleration(&pod.Spec, toleration)
 }
 
 // AddPodTopologySpreadConstraints appends a topology spread constraint if provided.
@@ -101,11 +92,7 @@ func AddPodTopologySpreadConstraints(pod *corev1.Pod, topologySpreadConstraint *
 	if pod == nil {
 		return errors.New("nil pod")
 	}
-	if topologySpreadConstraint == nil {
-		return nil
-	}
-	pod.Spec.TopologySpreadConstraints = append(pod.Spec.TopologySpreadConstraints, *topologySpreadConstraint)
-	return nil
+	return AddPodSpecTopologySpreadConstraints(&pod.Spec, topologySpreadConstraint)
 }
 
 // SetPodServiceAccountName sets the service account used by the Pod.
@@ -113,8 +100,7 @@ func SetPodServiceAccountName(pod *corev1.Pod, serviceAccountName string) error 
 	if pod == nil {
 		return errors.New("nil pod")
 	}
-	pod.Spec.ServiceAccountName = serviceAccountName
-	return nil
+	return SetPodSpecServiceAccountName(&pod.Spec, serviceAccountName)
 }
 
 // SetPodSecurityContext sets the pod-level security context.
@@ -122,8 +108,7 @@ func SetPodSecurityContext(pod *corev1.Pod, securityContext *corev1.PodSecurityC
 	if pod == nil {
 		return errors.New("nil pod")
 	}
-	pod.Spec.SecurityContext = securityContext
-	return nil
+	return SetPodSpecSecurityContext(&pod.Spec, securityContext)
 }
 
 // SetPodAffinity assigns affinity rules to the Pod.
@@ -131,8 +116,7 @@ func SetPodAffinity(pod *corev1.Pod, affinity *corev1.Affinity) error {
 	if pod == nil {
 		return errors.New("nil pod")
 	}
-	pod.Spec.Affinity = affinity
-	return nil
+	return SetPodSpecAffinity(&pod.Spec, affinity)
 }
 
 // SetPodNodeSelector sets the node selector map.
@@ -140,8 +124,7 @@ func SetPodNodeSelector(pod *corev1.Pod, nodeSelector map[string]string) error {
 	if pod == nil {
 		return errors.New("nil pod")
 	}
-	pod.Spec.NodeSelector = nodeSelector
-	return nil
+	return SetPodSpecNodeSelector(&pod.Spec, nodeSelector)
 }
 
 // SetPodPriorityClassName sets the priority class name.
@@ -149,8 +132,7 @@ func SetPodPriorityClassName(pod *corev1.Pod, class string) error {
 	if pod == nil {
 		return errors.New("nil pod")
 	}
-	pod.Spec.PriorityClassName = class
-	return nil
+	return SetPodSpecPriorityClassName(&pod.Spec, class)
 }
 
 // SetPodHostNetwork configures host networking for the Pod.
@@ -158,8 +140,7 @@ func SetPodHostNetwork(pod *corev1.Pod, hostNetwork bool) error {
 	if pod == nil {
 		return errors.New("nil pod")
 	}
-	pod.Spec.HostNetwork = hostNetwork
-	return nil
+	return SetPodSpecHostNetwork(&pod.Spec, hostNetwork)
 }
 
 // SetPodHostPID configures host PID namespace usage for the Pod.
@@ -167,8 +148,7 @@ func SetPodHostPID(pod *corev1.Pod, hostPID bool) error {
 	if pod == nil {
 		return errors.New("nil pod")
 	}
-	pod.Spec.HostPID = hostPID
-	return nil
+	return SetPodSpecHostPID(&pod.Spec, hostPID)
 }
 
 // SetPodHostIPC configures host IPC namespace usage for the Pod.
@@ -176,8 +156,7 @@ func SetPodHostIPC(pod *corev1.Pod, hostIPC bool) error {
 	if pod == nil {
 		return errors.New("nil pod")
 	}
-	pod.Spec.HostIPC = hostIPC
-	return nil
+	return SetPodSpecHostIPC(&pod.Spec, hostIPC)
 }
 
 // SetPodDNSPolicy sets the DNS policy for the Pod.
@@ -185,57 +164,47 @@ func SetPodDNSPolicy(pod *corev1.Pod, policy corev1.DNSPolicy) error {
 	if pod == nil {
 		return errors.New("nil pod")
 	}
-	pod.Spec.DNSPolicy = policy
-	return nil
+	return SetPodSpecDNSPolicy(&pod.Spec, policy)
 }
 
 func SetPodDNSConfig(pod *corev1.Pod, dnsConfig *corev1.PodDNSConfig) error {
 	if pod == nil {
 		return errors.New("nil pod")
 	}
-	pod.Spec.DNSConfig = dnsConfig
-	return nil
+	return SetPodSpecDNSConfig(&pod.Spec, dnsConfig)
 }
 
 func SetPodHostname(pod *corev1.Pod, hostname string) error {
 	if pod == nil {
 		return errors.New("nil pod")
 	}
-	pod.Spec.Hostname = hostname
-	return nil
+	return SetPodSpecHostname(&pod.Spec, hostname)
 }
 
 func SetPodSubdomain(pod *corev1.Pod, subdomain string) error {
 	if pod == nil {
 		return errors.New("nil pod")
 	}
-	pod.Spec.Subdomain = subdomain
-	return nil
+	return SetPodSpecSubdomain(&pod.Spec, subdomain)
 }
 
 func SetPodRestartPolicy(pod *corev1.Pod, policy corev1.RestartPolicy) error {
 	if pod == nil {
 		return errors.New("nil pod")
 	}
-	pod.Spec.RestartPolicy = policy
-	return nil
+	return SetPodSpecRestartPolicy(&pod.Spec, policy)
 }
 
 func SetPodTerminationGracePeriod(pod *corev1.Pod, secs int64) error {
 	if pod == nil {
 		return errors.New("nil pod")
 	}
-	if pod.Spec.TerminationGracePeriodSeconds == nil {
-		pod.Spec.TerminationGracePeriodSeconds = new(int64)
-	}
-	*pod.Spec.TerminationGracePeriodSeconds = secs
-	return nil
+	return SetPodSpecTerminationGracePeriod(&pod.Spec, secs)
 }
 
 func SetPodSchedulerName(pod *corev1.Pod, scheduler string) error {
 	if pod == nil {
 		return errors.New("nil pod")
 	}
-	pod.Spec.SchedulerName = scheduler
-	return nil
+	return SetPodSpecSchedulerName(&pod.Spec, scheduler)
 }

--- a/internal/k8s/pod_test.go
+++ b/internal/k8s/pod_test.go
@@ -23,11 +23,11 @@ func TestCreatePod(t *testing.T) {
 	if pod.APIVersion != "v1" {
 		t.Errorf("expected apiVersion v1 got %q", pod.APIVersion)
 	}
-	if pod.Spec.RestartPolicy != corev1.RestartPolicyAlways {
+	if pod.Spec.RestartPolicy != "" {
 		t.Errorf("unexpected restart policy %v", pod.Spec.RestartPolicy)
 	}
-	if pod.Spec.TerminationGracePeriodSeconds == nil {
-		t.Errorf("expected TerminationGracePeriodSeconds to be set")
+	if pod.Spec.TerminationGracePeriodSeconds != nil {
+		t.Errorf("expected TerminationGracePeriodSeconds to be nil")
 	}
 }
 


### PR DESCRIPTION
## Summary
- simplify pod resource creation to use an empty PodSpec
- add helpers for assigning PodSpecs to complex resources
- delegate resource helper functions to the generic PodSpec helpers
- update unit tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6889e6b7032c832f910f2d50c3213a20