### PR TITLE
Refactor YAML helper functions into kio

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,11 +22,13 @@ require (
 	github.com/fluxcd/pkg/apis/meta v1.13.0
 	github.com/fluxcd/source-controller/api v1.6.1
 	go.universe.tf/metallb v0.15.2
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.33.2
 	k8s.io/apiextensions-apiserver v0.33.2
 	k8s.io/apimachinery v0.33.2
 	k8s.io/cli-runtime v0.33.0
 	k8s.io/client-go v0.33.2
+	sigs.k8s.io/controller-runtime v0.21.0
 	sigs.k8s.io/kustomize/api v0.20.0
 	sigs.k8s.io/yaml v1.5.0
 )
@@ -78,11 +80,9 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250628140032-d90c4fd18f59 // indirect
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
-	sigs.k8s.io/controller-runtime v0.21.0 // indirect
 	sigs.k8s.io/gateway-api v1.1.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.20.0 // indirect

--- a/internal/yaml/doc.go
+++ b/internal/yaml/doc.go
@@ -1,2 +1,0 @@
-// Package yaml contains utilities for working with YAML manifests.
-package yaml

--- a/pkg/cluster/loader.go
+++ b/pkg/cluster/loader.go
@@ -1,20 +1,13 @@
 package cluster
 
 import (
-	"os"
-
-	"gopkg.in/yaml.v3"
+	"github.com/go-kure/kure/pkg/kio"
 )
 
 // LoadClusterFromYAML reads and parses a cluster configuration from a YAML file.
 func LoadClusterFromYAML(configPath string) (*Cluster, error) {
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		return nil, err
-	}
-
 	var c Cluster
-	if err := yaml.Unmarshal(data, &c); err != nil {
+	if err := kio.LoadFile(configPath, &c); err != nil {
 		return nil, err
 	}
 	return &c, nil

--- a/pkg/fluxcd/bootstrap.go
+++ b/pkg/fluxcd/bootstrap.go
@@ -1,13 +1,13 @@
 package fluxcd
 
 import (
-	"os"
 	"time"
 
 	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/yaml"
+
+	"github.com/go-kure/kure/pkg/kio"
 )
 
 // NewOCIRepositoryYAML constructs an OCIRepository resource from config.
@@ -31,22 +31,13 @@ func NewOCIRepositoryYAML(cfg *OCIRepositoryConfig) *sourcev1beta2.OCIRepository
 
 // WriteYAMLResource marshals the object to YAML at the given path.
 func WriteYAMLResource(path string, obj client.Object) error {
-	data, err := yaml.Marshal(obj)
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(path, data, 0644)
+	return kio.SaveFile(path, obj)
 }
 
 // PatchOCIRepositoryFromFile loads an OCIRepository from path and applies a patch function.
 func PatchOCIRepositoryFromFile(path string, patchFn func(*sourcev1beta2.OCIRepository) error) error {
-	raw, err := os.ReadFile(path)
-	if err != nil {
-		return err
-	}
-
 	var repo sourcev1beta2.OCIRepository
-	if err := yaml.Unmarshal(raw, &repo); err != nil {
+	if err := kio.LoadFile(path, &repo); err != nil {
 		return err
 	}
 
@@ -54,12 +45,7 @@ func PatchOCIRepositoryFromFile(path string, patchFn func(*sourcev1beta2.OCIRepo
 		return err
 	}
 
-	newData, err := yaml.Marshal(repo)
-	if err != nil {
-		return err
-	}
-
-	return os.WriteFile(path, newData, 0644)
+	return kio.SaveFile(path, repo)
 }
 
 func parseDurationOrDefault(s string) time.Duration {

--- a/pkg/kio/runtime.go
+++ b/pkg/kio/runtime.go
@@ -1,4 +1,4 @@
-package yaml
+package kio
 
 import (
 	"bytes"

--- a/pkg/kio/runtime_test.go
+++ b/pkg/kio/runtime_test.go
@@ -1,4 +1,4 @@
-package yaml
+package kio
 
 import (
 	"errors"


### PR DESCRIPTION
## Summary
- move YAML runtime parsing utilities from `internal/yaml` to `pkg/kio`
- expose YAML helpers in the `kio` package
- use `kio` helpers in `fluxcd` and cluster loader

## Testing
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6889eab646a8832f9eb7f5e9f2b9721f