### PR TITLE
Add comprehensive tests for application module

### DIFF
--- a/pkg/application/application_test.go
+++ b/pkg/application/application_test.go
@@ -1,0 +1,53 @@
+package application
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestNewApplicationAndSetters verifies constructor and setter behaviour.
+func TestNewApplicationAndSetters(t *testing.T) {
+	cfg1 := &fakeConfig{}
+	app := NewApplication("name", "ns", cfg1)
+	if app.Name != "name" || app.Namespace != "ns" || app.Config != cfg1 {
+		t.Fatalf("application fields not set correctly: %#v", app)
+	}
+
+	app.SetName("new-name")
+	if app.Name != "new-name" {
+		t.Errorf("SetName did not update name")
+	}
+	app.SetNamespace("new-ns")
+	if app.Namespace != "new-ns" {
+		t.Errorf("SetNamespace did not update namespace")
+	}
+
+	cfg2 := &fakeConfig{}
+	app.SetConfig(cfg2)
+	if app.Config != cfg2 {
+		t.Errorf("SetConfig did not replace config")
+	}
+}
+
+// TestGenerate exercises the Generate method with and without configuration.
+func TestGenerate(t *testing.T) {
+	app := NewApplication("app", "ns", nil)
+	if _, err := app.Generate(); err == nil {
+		t.Fatalf("expected error when Config is nil")
+	}
+
+	pod := &corev1.Pod{}
+	objs := []client.Object{pod}
+	cfg := &fakeConfig{objs: objs}
+	app.SetConfig(cfg)
+
+	res, err := app.Generate()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res) != 1 || res[0] != pod {
+		t.Fatalf("unexpected result: %#v", res)
+	}
+}

--- a/pkg/application/bundle_test.go
+++ b/pkg/application/bundle_test.go
@@ -1,12 +1,32 @@
 package application
 
-import (
-	"testing"
-)
+import "testing"
 
-func TestValidate(t *testing.T) {
-	as := &Bundle{Name: "", Applications: &[]*Application{}}
-	if err := as.Validate(); err == nil {
-		t.Fatalf("expected validation error")
+// TestBundleValidate exercises the Bundle validation logic against
+// the various failure modes as well as the happy path.
+func TestBundleValidate(t *testing.T) {
+	// nil bundle should error
+	var nilBundle *Bundle
+	if err := nilBundle.Validate(); err == nil {
+		t.Fatalf("expected error for nil bundle")
+	}
+
+	// empty name should error
+	b := &Bundle{Name: "", Applications: &[]*Application{}}
+	if err := b.Validate(); err == nil {
+		t.Fatalf("expected validation error for empty name")
+	}
+
+	// nil application inside the slice should error
+	b = &Bundle{Name: "test", Applications: &[]*Application{nil}}
+	if err := b.Validate(); err == nil {
+		t.Fatalf("expected error for nil application entry")
+	}
+
+	// valid bundle should pass
+	app := NewApplication("app", "ns", &fakeConfig{})
+	b = &Bundle{Name: "ok", Applications: &[]*Application{app}}
+	if err := b.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/pkg/application/helpers_test.go
+++ b/pkg/application/helpers_test.go
@@ -1,0 +1,13 @@
+package application
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+// fakeConfig implements the Config interface for testing.
+type fakeConfig struct {
+	objs []client.Object
+	err  error
+}
+
+func (f *fakeConfig) Generate(_ *Application) ([]client.Object, error) {
+	return f.objs, f.err
+}

--- a/pkg/application/workload_test.go
+++ b/pkg/application/workload_test.go
@@ -1,0 +1,108 @@
+package application
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+)
+
+// TestContainerConfigGenerate verifies ports and volume mounts are propagated.
+func TestContainerConfigGenerate(t *testing.T) {
+	cfg := ContainerConfig{
+		Name:         "ctr",
+		Image:        "nginx",
+		Ports:        []corev1.ContainerPort{{Name: "http", ContainerPort: 80, HostPort: 80}},
+		VolumeMounts: map[string]string{"data": "/data"},
+	}
+	container, ports, err := cfg.Generate()
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if len(ports) != 1 || ports[0].Name != "http" {
+		t.Fatalf("ports not returned correctly: %#v", ports)
+	}
+	if len(container.VolumeMounts) != 1 || container.VolumeMounts[0].Name != "data" {
+		t.Fatalf("volume mounts not applied: %#v", container.VolumeMounts)
+	}
+}
+
+// TestAppWorkloadGenerate ensures that different workload types produce expected objects.
+func TestAppWorkloadGenerate(t *testing.T) {
+	newBase := func() AppWorkloadConfig {
+		return AppWorkloadConfig{
+			Containers: []ContainerConfig{{
+				Name:  "ctr",
+				Image: "nginx",
+				Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 80, HostPort: 80}},
+			}},
+		}
+	}
+	app := NewApplication("app", "ns", nil)
+
+	// Deployment with service and ingress
+	depCfg := newBase()
+	depCfg.Workload = DeploymentWorkload
+	depCfg.Ingress = &IngressConfig{Host: "example.com", ServiceName: "app", ServicePortName: "http"}
+	objs, err := depCfg.Generate(app)
+	if err != nil {
+		t.Fatalf("deployment generate error: %v", err)
+	}
+	var hasDep, hasSvc, hasIng bool
+	for _, o := range objs {
+		switch o.(type) {
+		case *appsv1.Deployment:
+			hasDep = true
+		case *corev1.Service:
+			hasSvc = true
+		case *netv1.Ingress:
+			hasIng = true
+		}
+	}
+	if !hasDep || !hasSvc || !hasIng {
+		t.Fatalf("expected deployment, service and ingress, got: %#v", objs)
+	}
+
+	// StatefulSet without ports should only create workload
+	stsCfg := newBase()
+	stsCfg.Workload = StatefulSetWorkload
+	stsCfg.Containers[0].Ports = nil
+	objs, err = stsCfg.Generate(app)
+	if err != nil {
+		t.Fatalf("statefulset generate error: %v", err)
+	}
+	if len(objs) != 1 {
+		t.Fatalf("expected only statefulset, got %d objects", len(objs))
+	}
+	if _, ok := objs[0].(*appsv1.StatefulSet); !ok {
+		t.Fatalf("expected statefulset, got %T", objs[0])
+	}
+
+	// DaemonSet
+	dsCfg := newBase()
+	dsCfg.Workload = DaemonSetWorkload
+	objs, err = dsCfg.Generate(app)
+	if err != nil {
+		t.Fatalf("daemonset generate error: %v", err)
+	}
+	if len(objs) != 2 {
+		t.Fatalf("expected daemonset and service due to ports, got %d", len(objs))
+	}
+	foundDS := false
+	for _, o := range objs {
+		if _, ok := o.(*appsv1.DaemonSet); ok {
+			foundDS = true
+		}
+	}
+	if !foundDS {
+		t.Fatalf("daemonset not found in objects: %#v", objs)
+	}
+
+	// Unsupported workload type
+	badCfg := newBase()
+	badCfg.Workload = "Unknown"
+	if _, err := badCfg.Generate(app); err == nil {
+		t.Fatalf("expected error for unsupported workload type")
+	}
+}


### PR DESCRIPTION
## Summary
- expand bundle validation tests
- add coverage for Application API and generation logic
- verify container and workload generation across all workload types

## Testing
- `go test ./pkg/application -run Test -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688b51087f8c832fab99e6ac83559adb