### PR TITLE
Add AppWorkload example and CLI options

### DIFF
--- a/examples/app-workload.yaml
+++ b/examples/app-workload.yaml
@@ -1,0 +1,66 @@
+---
+name: web-app
+namespace: demo
+workload: Deployment
+replicas: 2
+labels:
+  app: web
+containers:
+  - name: web
+    image: nginx:1.21
+    ports:
+      - name: http
+        containerport: 80
+        hostport: 80
+    env:
+      ENV: prod
+    volumeMounts:
+      data: /usr/share/nginx/html
+volumes:
+  data: /data
+services:
+  - name: web
+    type: ClusterIP
+    port: 80
+    targetPort: 80
+    protocol: TCP
+    selector:
+      app: web
+ingress:
+  host: example.com
+  path: /
+  serviceName: web
+  servicePortName: http
+---
+name: db-app
+namespace: demo
+workload: StatefulSet
+replicas: 3
+labels:
+  app: db
+containers:
+  - name: db
+    image: postgres:14
+    ports:
+      - name: psql
+        containerport: 5432
+        hostport: 5432
+    env:
+      POSTGRES_DB: example
+    volumeMounts:
+      db-data: /var/lib/postgresql/data
+volumes:
+  db-data: /var/lib/postgresql/data
+services:
+  - name: db
+    type: ClusterIP
+    port: 5432
+    targetPort: 5432
+    protocol: TCP
+    selector:
+      app: db
+ingress:
+  host: db.example.com
+  path: /
+  serviceName: db
+  servicePortName: psql

--- a/go.mod
+++ b/go.mod
@@ -21,13 +21,13 @@ require (
 	github.com/fluxcd/pkg/apis/kustomize v1.10.0
 	github.com/fluxcd/pkg/apis/meta v1.13.0
 	github.com/fluxcd/source-controller/api v1.6.1
+	github.com/pelletier/go-toml/v2 v2.2.4
 	go.universe.tf/metallb v0.15.2
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.33.2
 	k8s.io/apiextensions-apiserver v0.33.2
 	k8s.io/apimachinery v0.33.2
 	k8s.io/cli-runtime v0.33.0
-	k8s.io/client-go v0.33.2
 	sigs.k8s.io/controller-runtime v0.21.0
 	sigs.k8s.io/kustomize/api v0.20.0
 	sigs.k8s.io/yaml v1.5.0
@@ -80,6 +80,7 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	k8s.io/client-go v0.33.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250628140032-d90c4fd18f59 // indirect
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/onsi/ginkgo/v2 v2.23.4 h1:ktYTpKJAVZnDT4VjxSbiBenUjmlL/5QkBEocaWXiQus
 github.com/onsi/ginkgo/v2 v2.23.4/go.mod h1:Bt66ApGPBFzHyR+JO10Zbt0Gsp4uWxu5mIOTusL46e8=
 github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=
 github.com/onsi/gomega v1.37.0/go.mod h1:8D9+Txp43QWKhM24yyOBEdpkzN8FvJyAwecBgsU4KU0=
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
## Summary
- add examples/app-workload.yaml with Deployment and StatefulSet AppWorkloadConfig examples
- extend demo CLI to support --internals/-i and --app-workload/-a, with configurable output formats

## Testing
- `go test ./...`
- `go run cmd/demo/main.go --app-workload`


------
https://chatgpt.com/codex/tasks/task_e_688b607fafc0832fb9ea28f013f40bd1