### PR TITLE
feat: add layout grouping and app file mode

### DIFF
--- a/pkg/layout/config.go
+++ b/pkg/layout/config.go
@@ -19,6 +19,9 @@ type Config struct {
 	FluxDir string
 	// FilePer determines how resources are grouped into files when writing manifests.
 	FilePer FileExportMode
+	// ApplicationFileMode controls whether application resources are written
+	// to a single file or split per resource. Defaults to AppFilePerResource.
+	ApplicationFileMode ApplicationFileMode
 	// ManifestFileName formats the file name for a resource manifest.
 	ManifestFileName ManifestFileNameFunc
 	// KustomizationFileName formats the file name for a Flux Kustomization.
@@ -32,6 +35,7 @@ func DefaultLayoutConfig() Config {
 		ManifestsDir:          "clusters",
 		FluxDir:               "clusters",
 		FilePer:               FilePerResource,
+		ApplicationFileMode:   AppFilePerResource,
 		ManifestFileName:      DefaultManifestFileName,
 		KustomizationFileName: DefaultKustomizationFileName,
 	}

--- a/pkg/layout/manifest_test.go
+++ b/pkg/layout/manifest_test.go
@@ -64,3 +64,34 @@ func TestManifestLayoutWriteWithConfig(t *testing.T) {
 		t.Fatalf("expected file not written: %v", err)
 	}
 }
+
+func TestManifestLayoutSingleFile(t *testing.T) {
+	obj1 := &unstructured.Unstructured{}
+	obj1.SetAPIVersion("v1")
+	obj1.SetKind("ConfigMap")
+	obj1.SetName("one")
+	obj1.SetNamespace("demo")
+
+	obj2 := &unstructured.Unstructured{}
+	obj2.SetAPIVersion("v1")
+	obj2.SetKind("Secret")
+	obj2.SetName("two")
+	obj2.SetNamespace("demo")
+
+	ml := &layout.ManifestLayout{
+		Name:                "app",
+		Namespace:           "demo",
+		ApplicationFileMode: layout.AppFileSingle,
+		Resources:           []client.Object{obj1, obj2},
+	}
+
+	dir := t.TempDir()
+	if err := ml.WriteToDisk(dir); err != nil {
+		t.Fatalf("write to disk: %v", err)
+	}
+
+	expected := filepath.Join(dir, "demo", "app", "app.yaml")
+	if _, err := os.Stat(expected); err != nil {
+		t.Fatalf("expected single file not written: %v", err)
+	}
+}

--- a/pkg/layout/types.go
+++ b/pkg/layout/types.go
@@ -2,6 +2,8 @@
 // Kubernetes manifests and Flux resources.
 package layout
 
+import "fmt"
+
 // FileExportMode determines how resources are written to disk.
 type FileExportMode string
 
@@ -14,8 +16,106 @@ const (
 	FilePerUnset FileExportMode = ""
 )
 
+// GroupingMode controls how nodes, bundles and applications are laid out on disk.
+//
+// The default for all grouping modes is GroupByName which creates a directory per
+// entity. GroupFlat places all entities in the same directory.
+type GroupingMode string
+
+const (
+	// GroupByName creates a directory for each item in the hierarchy.
+	GroupByName GroupingMode = "name"
+	// GroupFlat flattens the hierarchy placing all items in the same directory.
+	GroupFlat GroupingMode = "flat"
+	// GroupUnset indicates that no grouping preference was specified.
+	GroupUnset GroupingMode = ""
+)
+
+// ApplicationFileMode specifies how resources within an application are written.
+//
+// The default is AppFilePerResource which mirrors the behaviour of FilePerResource
+// and writes each generated resource to its own file. AppFileSingle groups all
+// resources belonging to an application into a single manifest file.
+type ApplicationFileMode string
+
+const (
+	// AppFilePerResource writes each application resource to its own file.
+	AppFilePerResource ApplicationFileMode = "resource"
+	// AppFileSingle writes all resources for an application into one file.
+	AppFileSingle ApplicationFileMode = "single"
+	// AppFileUnset indicates that no application file mode was specified.
+	AppFileUnset ApplicationFileMode = ""
+)
+
 // LayoutRules control how layouts are generated.
+//
+// Zero values are interpreted as the defaults described in the field
+// documentation.
 type LayoutRules struct {
-	// FilePer sets the default file export mode for resources.
+	// NodeGrouping controls how nodes are written to disk. Defaults to
+	// GroupByName.
+	NodeGrouping GroupingMode
+	// BundleGrouping controls how bundles are written to disk. Defaults to
+	// GroupByName.
+	BundleGrouping GroupingMode
+	// ApplicationGrouping controls how applications are written to disk.
+	// Defaults to GroupByName.
+	ApplicationGrouping GroupingMode
+	// ApplicationFileMode controls whether application resources are
+	// combined into a single file or split per resource. Defaults to
+	// AppFilePerResource.
+	ApplicationFileMode ApplicationFileMode
+	// FilePer sets the default file export mode for resources. Defaults to
+	// FilePerResource.
 	FilePer FileExportMode
+}
+
+// DefaultLayoutRules returns a LayoutRules instance populated with the
+// documented default values.
+func DefaultLayoutRules() LayoutRules {
+	return LayoutRules{
+		NodeGrouping:        GroupByName,
+		BundleGrouping:      GroupByName,
+		ApplicationGrouping: GroupByName,
+		ApplicationFileMode: AppFilePerResource,
+		FilePer:             FilePerResource,
+	}
+}
+
+// Validate ensures the LayoutRules contain known option values.
+func (lr LayoutRules) Validate() error {
+	validGrouping := func(g GroupingMode) bool {
+		switch g {
+		case GroupByName, GroupFlat, GroupUnset:
+			return true
+		default:
+			return false
+		}
+	}
+
+	if !validGrouping(lr.NodeGrouping) {
+		return fmt.Errorf("invalid node grouping: %s", lr.NodeGrouping)
+	}
+	if !validGrouping(lr.BundleGrouping) {
+		return fmt.Errorf("invalid bundle grouping: %s", lr.BundleGrouping)
+	}
+	if !validGrouping(lr.ApplicationGrouping) {
+		return fmt.Errorf("invalid application grouping: %s", lr.ApplicationGrouping)
+	}
+
+	switch lr.ApplicationFileMode {
+	case AppFilePerResource, AppFileSingle, AppFileUnset:
+		// valid
+	default:
+		return fmt.Errorf("invalid application file mode: %s", lr.ApplicationFileMode)
+	}
+
+	switch lr.FilePer {
+	case FilePerResource, FilePerKind, FilePerUnset:
+		// valid
+	default:
+		return fmt.Errorf("invalid file export mode: %s", lr.FilePer)
+	}
+
+	return nil
 }

--- a/pkg/layout/write.go
+++ b/pkg/layout/write.go
@@ -22,6 +22,10 @@ func WriteManifest(basePath string, cfg Config, ml *ManifestLayout) error {
 	if mode == FilePerUnset {
 		mode = cfg.FilePer
 	}
+	appMode := ml.ApplicationFileMode
+	if appMode == AppFileUnset {
+		appMode = cfg.ApplicationFileMode
+	}
 
 	fullPath := filepath.Join(basePath, cfg.ManifestsDir, ml.FullRepoPath())
 	if err := os.MkdirAll(fullPath, 0755); err != nil {
@@ -36,7 +40,14 @@ func WriteManifest(basePath string, cfg Config, ml *ManifestLayout) error {
 		}
 		kind := strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind)
 		name := obj.GetName()
-		fileName := cfg.ManifestFileName(ns, kind, name, mode)
+
+		var fileName string
+		if appMode == AppFileSingle {
+			fileName = fmt.Sprintf("%s.yaml", ml.Name)
+		} else {
+			fileName = cfg.ManifestFileName(ns, kind, name, mode)
+		}
+
 		fileGroups[fileName] = append(fileGroups[fileName], obj)
 	}
 


### PR DESCRIPTION
## Summary
- add grouping and application file mode enums with validation
- support single-file application output in layout config and writer
- test single-file application manifest output

## Testing
- `go vet ./pkg/layout`
- `go test ./pkg/layout -run .`


------
https://chatgpt.com/codex/tasks/task_e_688cc07120b0832fb9cbf1194e070f4d