### PR TITLE
Add workflow abstraction and profile-specific layout defaults

### DIFF
--- a/pkg/layout/profile.go
+++ b/pkg/layout/profile.go
@@ -1,0 +1,33 @@
+package layout
+
+import "fmt"
+
+// Profile identifies a supported layout profile.
+type Profile string
+
+const (
+	// FluxProfile represents defaults matching FluxCD conventions.
+	FluxProfile Profile = "flux"
+	// ArgoProfile represents defaults matching Argo CD conventions.
+	ArgoProfile Profile = "argo"
+)
+
+// DefaultConfigForProfile returns a Config initialised with defaults for the
+// given profile. Unknown profiles fall back to FluxProfile.
+func DefaultConfigForProfile(p Profile) Config {
+	switch p {
+	case ArgoProfile:
+		return Config{
+			ManifestsDir:        "applications",
+			FluxDir:             "applications",
+			FilePer:             FilePerResource,
+			ApplicationFileMode: AppFileSingle,
+			ManifestFileName:    DefaultManifestFileName,
+			KustomizationFileName: func(name string) string {
+				return fmt.Sprintf("application-%s.yaml", name)
+			},
+		}
+	default:
+		return DefaultLayoutConfig()
+	}
+}

--- a/pkg/stack/argo/argo.go
+++ b/pkg/stack/argo/argo.go
@@ -1,0 +1,84 @@
+package argo
+
+import (
+	"path/filepath"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/kure/pkg/stack"
+)
+
+// Workflow implements the stack.Workflow interface for Argo CD.
+type Workflow struct {
+	// RepoURL is used as the source repo for generated Applications.
+	RepoURL string
+}
+
+// Cluster converts a Cluster into Argo CD Applications.
+func (w Workflow) Cluster(c *stack.Cluster) ([]client.Object, error) {
+	if c == nil || c.Node == nil {
+		return nil, nil
+	}
+	return w.Node(c.Node)
+}
+
+// Node converts a Node and its children into Applications.
+func (w Workflow) Node(n *stack.Node) ([]client.Object, error) {
+	if n == nil {
+		return nil, nil
+	}
+	var objs []client.Object
+	if n.Bundle != nil {
+		bObjs, err := w.Bundle(n.Bundle)
+		if err != nil {
+			return nil, err
+		}
+		objs = append(objs, bObjs...)
+	}
+	for _, child := range n.Children {
+		cObjs, err := w.Node(child)
+		if err != nil {
+			return nil, err
+		}
+		objs = append(objs, cObjs...)
+	}
+	return objs, nil
+}
+
+// Bundle converts a Bundle into an Argo CD Application.
+func (w Workflow) Bundle(b *stack.Bundle) ([]client.Object, error) {
+	if b == nil {
+		return nil, nil
+	}
+	app := &unstructured.Unstructured{}
+	app.SetAPIVersion("argoproj.io/v1alpha1")
+	app.SetKind("Application")
+	app.SetName(b.Name)
+	app.SetNamespace("argocd")
+
+	source := map[string]interface{}{"repoURL": w.RepoURL, "path": bundlePath(b)}
+	dest := map[string]interface{}{"server": "https://kubernetes.default.svc", "namespace": "default"}
+	_ = unstructured.SetNestedField(app.Object, source, "spec", "source")
+	_ = unstructured.SetNestedField(app.Object, dest, "spec", "destination")
+	if len(b.DependsOn) > 0 {
+		var deps []string
+		for _, d := range b.DependsOn {
+			deps = append(deps, d.Name)
+		}
+		_ = unstructured.SetNestedStringSlice(app.Object, deps, "spec", "dependencies")
+	}
+
+	var obj client.Object = app
+	return []client.Object{obj}, nil
+}
+
+func bundlePath(b *stack.Bundle) string {
+	var parts []string
+	for p := b; p != nil; p = p.Parent {
+		if p.Name != "" {
+			parts = append([]string{p.Name}, parts...)
+		}
+	}
+	return filepath.ToSlash(filepath.Join(parts...))
+}

--- a/pkg/stack/workflow.go
+++ b/pkg/stack/workflow.go
@@ -1,0 +1,15 @@
+package stack
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+// Workflow defines an interface for translating stack objects into
+// workflow-specific custom resources such as Flux Kustomizations or
+// Argo CD Applications.
+type Workflow interface {
+	// Cluster converts a Cluster into workflow specific CRDs.
+	Cluster(*Cluster) ([]client.Object, error)
+	// Node converts a Node into workflow specific CRDs.
+	Node(*Node) ([]client.Object, error)
+	// Bundle converts a Bundle into workflow specific CRDs.
+	Bundle(*Bundle) ([]client.Object, error)
+}


### PR DESCRIPTION
## Summary
- define Workflow interface for translating stack types into workflow-specific CRDs
- add Flux and Argo implementations for generating Kustomization and Application objects
- introduce layout Profile defaults to configure path and resource naming conventions

## Testing
- `go test ./pkg/...`


------
https://chatgpt.com/codex/tasks/task_e_688cc9e44dd4832fa9f3349c0b6c7535