### PR TITLE
Implement cluster layout walker

### DIFF
--- a/pkg/layout/walker.go
+++ b/pkg/layout/walker.go
@@ -1,0 +1,81 @@
+package layout
+
+import (
+	"path/filepath"
+
+	"github.com/go-kure/kure/pkg/stack"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// WalkCluster traverses a stack.Cluster and builds a ManifestLayout tree that
+// mirrors the node and bundle hierarchy. Applications are generated and their
+// resources are assigned to the corresponding directories based on the
+// parent-child relationships of nodes and bundle names.
+func WalkCluster(c *stack.Cluster) (*ManifestLayout, error) {
+	if c == nil || c.Node == nil {
+		return nil, nil
+	}
+	return walkNode(c.Node, nil)
+}
+
+// walkNode recursively processes a stack.Node and its children.
+func walkNode(n *stack.Node, ancestors []string) (*ManifestLayout, error) {
+	if n == nil {
+		return nil, nil
+	}
+
+	currentPath := append([]string{}, ancestors...)
+	if n.Name != "" {
+		currentPath = append(currentPath, n.Name)
+	}
+
+	var children []*ManifestLayout
+
+	if b := n.Bundle; b != nil {
+		var bundleChildren []*ManifestLayout
+		for _, app := range b.Applications {
+			if app == nil {
+				continue
+			}
+			objsPtr, err := app.Generate()
+			if err != nil {
+				return nil, err
+			}
+			var objs []client.Object
+			for _, o := range objsPtr {
+				if o == nil {
+					continue
+				}
+				objs = append(objs, *o)
+			}
+			appLayout := &ManifestLayout{
+				Name:      app.Name,
+				Namespace: filepath.Join(append(currentPath, b.Name)...),
+				Resources: objs,
+			}
+			bundleChildren = append(bundleChildren, appLayout)
+		}
+		bundleLayout := &ManifestLayout{
+			Name:      b.Name,
+			Namespace: filepath.Join(currentPath...),
+			Children:  bundleChildren,
+		}
+		children = append(children, bundleLayout)
+	}
+
+	for _, child := range n.Children {
+		cl, err := walkNode(child, currentPath)
+		if err != nil {
+			return nil, err
+		}
+		if cl != nil {
+			children = append(children, cl)
+		}
+	}
+
+	return &ManifestLayout{
+		Name:      n.Name,
+		Namespace: filepath.Join(ancestors...),
+		Children:  children,
+	}, nil
+}

--- a/pkg/layout/walker_test.go
+++ b/pkg/layout/walker_test.go
@@ -1,0 +1,79 @@
+package layout_test
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/kure/pkg/layout"
+	"github.com/go-kure/kure/pkg/stack"
+)
+
+// fakeConfig implements stack.ApplicationConfig for testing purposes.
+type fakeConfig struct {
+	objs []*client.Object
+	err  error
+}
+
+func (f *fakeConfig) Generate(*stack.Application) ([]*client.Object, error) {
+	return f.objs, f.err
+}
+
+func TestWalkCluster(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("v1")
+	obj.SetKind("ConfigMap")
+	obj.SetName("cm")
+	obj.SetNamespace("default")
+	var o client.Object = obj
+
+	app := stack.NewApplication("app", "ns", &fakeConfig{objs: []*client.Object{&o}})
+	bundle := &stack.Bundle{Name: "bundle", Applications: []*stack.Application{app}}
+	node := &stack.Node{Name: "apps", Bundle: bundle}
+	root := &stack.Node{Name: "root", Children: []*stack.Node{node}}
+	node.Parent = root
+	cluster := &stack.Cluster{Name: "demo", Node: root}
+
+	ml, err := layout.WalkCluster(cluster)
+	if err != nil {
+		t.Fatalf("walk cluster: %v", err)
+	}
+	if ml == nil {
+		t.Fatalf("nil layout returned")
+	}
+
+	if len(ml.Children) != 1 {
+		t.Fatalf("expected 1 child, got %d", len(ml.Children))
+	}
+	nodeLayout := ml.Children[0]
+	if nodeLayout.Name != "apps" {
+		t.Fatalf("unexpected node name: %s", nodeLayout.Name)
+	}
+	if nodeLayout.Namespace != "root" {
+		t.Fatalf("unexpected node namespace: %s", nodeLayout.Namespace)
+	}
+	if len(nodeLayout.Children) != 1 {
+		t.Fatalf("expected bundle child")
+	}
+	bundleLayout := nodeLayout.Children[0]
+	if bundleLayout.Name != "bundle" {
+		t.Fatalf("unexpected bundle name: %s", bundleLayout.Name)
+	}
+	if bundleLayout.Namespace != "root/apps" {
+		t.Fatalf("unexpected bundle namespace: %s", bundleLayout.Namespace)
+	}
+	if len(bundleLayout.Children) != 1 {
+		t.Fatalf("expected application child")
+	}
+	appLayout := bundleLayout.Children[0]
+	if appLayout.Name != "app" {
+		t.Fatalf("unexpected application name: %s", appLayout.Name)
+	}
+	if appLayout.Namespace != "root/apps/bundle" {
+		t.Fatalf("unexpected application namespace: %s", appLayout.Namespace)
+	}
+	if len(appLayout.Resources) != 1 {
+		t.Fatalf("expected one resource, got %d", len(appLayout.Resources))
+	}
+}


### PR DESCRIPTION
## Summary
- add `WalkCluster` to build manifest layouts from a stack Cluster
- derive directories from node hierarchy and bundle names
- generate application resources and place them in the appropriate folders

## Testing
- `timeout 60 go test ./pkg/layout -run TestWalkCluster -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688cd31a504c832fbfd2cb720b601f89