### PR TITLE
Add node-only layout option

### DIFF
--- a/pkg/layout/walker.go
+++ b/pkg/layout/walker.go
@@ -8,18 +8,41 @@ import (
 )
 
 // WalkCluster traverses a stack.Cluster and builds a ManifestLayout tree that
-// mirrors the node and bundle hierarchy. Applications are generated and their
-// resources are assigned to the corresponding directories based on the
-// parent-child relationships of nodes and bundle names.
-func WalkCluster(c *stack.Cluster) (*ManifestLayout, error) {
+// mirrors the node and bundle hierarchy. Behaviour is controlled via
+// LayoutRules. When BundleGrouping and ApplicationGrouping are set to
+// GroupFlat, all application resources are written directly to their parent
+// node's directory.
+func WalkCluster(c *stack.Cluster, rules LayoutRules) (*ManifestLayout, error) {
 	if c == nil || c.Node == nil {
 		return nil, nil
 	}
-	return walkNode(c.Node, nil)
+
+	// Apply documented defaults for unset options.
+	def := DefaultLayoutRules()
+	if rules.NodeGrouping == GroupUnset {
+		rules.NodeGrouping = def.NodeGrouping
+	}
+	if rules.BundleGrouping == GroupUnset {
+		rules.BundleGrouping = def.BundleGrouping
+	}
+	if rules.ApplicationGrouping == GroupUnset {
+		rules.ApplicationGrouping = def.ApplicationGrouping
+	}
+	if rules.FilePer == FilePerUnset {
+		rules.FilePer = def.FilePer
+	}
+
+	nodeOnly := rules.BundleGrouping == GroupFlat && rules.ApplicationGrouping == GroupFlat
+	filePer := rules.FilePer
+	if nodeOnly {
+		filePer = FilePerResource
+	}
+
+	return walkNode(c.Node, nil, nodeOnly, filePer)
 }
 
 // walkNode recursively processes a stack.Node and its children.
-func walkNode(n *stack.Node, ancestors []string) (*ManifestLayout, error) {
+func walkNode(n *stack.Node, ancestors []string, nodeOnly bool, filePer FileExportMode) (*ManifestLayout, error) {
 	if n == nil {
 		return nil, nil
 	}
@@ -29,53 +52,88 @@ func walkNode(n *stack.Node, ancestors []string) (*ManifestLayout, error) {
 		currentPath = append(currentPath, n.Name)
 	}
 
-	var children []*ManifestLayout
+	ml := &ManifestLayout{
+		Name:      n.Name,
+		Namespace: filepath.Join(ancestors...),
+		FilePer:   filePer,
+	}
 
-	if b := n.Bundle; b != nil {
-		var bundleChildren []*ManifestLayout
-		for _, app := range b.Applications {
-			if app == nil {
-				continue
+	if nodeOnly {
+		if b := n.Bundle; b != nil {
+			for _, app := range b.Applications {
+				if app == nil {
+					continue
+				}
+				objsPtr, err := app.Generate()
+				if err != nil {
+					return nil, err
+				}
+				for _, o := range objsPtr {
+					if o == nil {
+						continue
+					}
+					ml.Resources = append(ml.Resources, *o)
+				}
 			}
-			objsPtr, err := app.Generate()
+		}
+	} else {
+		var children []*ManifestLayout
+		if b := n.Bundle; b != nil {
+			var bundleChildren []*ManifestLayout
+			for _, app := range b.Applications {
+				if app == nil {
+					continue
+				}
+				objsPtr, err := app.Generate()
+				if err != nil {
+					return nil, err
+				}
+				var objs []client.Object
+				for _, o := range objsPtr {
+					if o == nil {
+						continue
+					}
+					objs = append(objs, *o)
+				}
+				appLayout := &ManifestLayout{
+					Name:      app.Name,
+					Namespace: filepath.Join(append(currentPath, b.Name)...),
+					Resources: objs,
+				}
+				bundleChildren = append(bundleChildren, appLayout)
+			}
+			bundleLayout := &ManifestLayout{
+				Name:      b.Name,
+				Namespace: filepath.Join(currentPath...),
+				Children:  bundleChildren,
+			}
+			children = append(children, bundleLayout)
+		}
+
+		for _, child := range n.Children {
+			cl, err := walkNode(child, currentPath, nodeOnly, filePer)
 			if err != nil {
 				return nil, err
 			}
-			var objs []client.Object
-			for _, o := range objsPtr {
-				if o == nil {
-					continue
-				}
-				objs = append(objs, *o)
+			if cl != nil {
+				children = append(children, cl)
 			}
-			appLayout := &ManifestLayout{
-				Name:      app.Name,
-				Namespace: filepath.Join(append(currentPath, b.Name)...),
-				Resources: objs,
-			}
-			bundleChildren = append(bundleChildren, appLayout)
 		}
-		bundleLayout := &ManifestLayout{
-			Name:      b.Name,
-			Namespace: filepath.Join(currentPath...),
-			Children:  bundleChildren,
-		}
-		children = append(children, bundleLayout)
+
+		ml.Children = children
 	}
 
-	for _, child := range n.Children {
-		cl, err := walkNode(child, currentPath)
-		if err != nil {
-			return nil, err
-		}
-		if cl != nil {
-			children = append(children, cl)
+	if nodeOnly {
+		for _, child := range n.Children {
+			cl, err := walkNode(child, currentPath, nodeOnly, filePer)
+			if err != nil {
+				return nil, err
+			}
+			if cl != nil {
+				ml.Children = append(ml.Children, cl)
+			}
 		}
 	}
 
-	return &ManifestLayout{
-		Name:      n.Name,
-		Namespace: filepath.Join(ancestors...),
-		Children:  children,
-	}, nil
+	return ml, nil
 }


### PR DESCRIPTION
## Summary
- support rules-driven node-only layout in WalkCluster
- add tests covering node-only layout behavior

## Testing
- `go test ./pkg/...`


------
https://chatgpt.com/codex/tasks/task_e_688cde327aec832f8e27813dbb773bb5