### PR TITLE
Add layout grouping tests and document LayoutRules usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,36 @@ to stdout:
 go run ./cmd/cluster
 ```
 
+## Layout rules and FluxCD integration
+
+`LayoutRules` control how nodes, bundles and applications are grouped when
+writing manifests. The example below flattens bundles and applications under
+their parent node, writes the manifests to `./repo` and then generates Flux
+Kustomizations for the cluster:
+
+```go
+rules := layout.LayoutRules{
+    BundleGrouping:      layout.GroupFlat,
+    ApplicationGrouping: layout.GroupFlat,
+}
+
+ml, err := layout.WalkCluster(cluster, rules)
+if err != nil {
+    // handle error
+}
+
+cfg := layout.DefaultLayoutConfig()
+if err := layout.WriteManifest("./repo", cfg, ml); err != nil {
+    // handle error
+}
+
+wf := fluxcd.NewWorkflow()
+fluxObjs, err := wf.Cluster(cluster)
+if err != nil {
+    // handle error
+}
+```
+
 
 ## Flux vs ArgoCD paths
 

--- a/pkg/layout/grouping_test.go
+++ b/pkg/layout/grouping_test.go
@@ -1,0 +1,89 @@
+package layout_test
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/kure/pkg/layout"
+	"github.com/go-kure/kure/pkg/stack"
+)
+
+// buildTestCluster constructs a simple cluster with one node, bundle and application.
+func buildTestCluster() *stack.Cluster {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("v1")
+	obj.SetKind("ConfigMap")
+	obj.SetName("cm")
+	obj.SetNamespace("default")
+	var o client.Object = obj
+
+	app := stack.NewApplication("app", "ns", &fakeConfig{objs: []*client.Object{&o}})
+	bundle := &stack.Bundle{Name: "bundle", Applications: []*stack.Application{app}}
+	node := &stack.Node{Name: "apps", Bundle: bundle}
+	root := &stack.Node{Name: "root", Children: []*stack.Node{node}}
+	node.Parent = root
+	return &stack.Cluster{Name: "demo", Node: root}
+}
+
+func TestWalkClusterGroupingCombinations(t *testing.T) {
+	type testCase struct {
+		name     string
+		rules    layout.LayoutRules
+		nodeOnly bool
+	}
+
+	modes := []layout.GroupingMode{layout.GroupByName, layout.GroupFlat}
+	var tests []testCase
+	for _, ng := range modes {
+		for _, bg := range modes {
+			for _, ag := range modes {
+				tc := testCase{
+					name:     string(ng) + "_" + string(bg) + "_" + string(ag),
+					rules:    layout.LayoutRules{NodeGrouping: ng, BundleGrouping: bg, ApplicationGrouping: ag},
+					nodeOnly: bg == layout.GroupFlat && ag == layout.GroupFlat,
+				}
+				tests = append(tests, tc)
+			}
+		}
+	}
+
+	cluster := buildTestCluster()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ml, err := layout.WalkCluster(cluster, tc.rules)
+			if err != nil {
+				t.Fatalf("walk cluster: %v", err)
+			}
+			if len(ml.Children) != 1 {
+				t.Fatalf("expected one child, got %d", len(ml.Children))
+			}
+			nodeLayout := ml.Children[0]
+			if tc.nodeOnly {
+				if len(nodeLayout.Resources) != 1 {
+					t.Fatalf("expected resources at node, got %d", len(nodeLayout.Resources))
+				}
+				if len(nodeLayout.Children) != 0 {
+					t.Fatalf("unexpected children: %d", len(nodeLayout.Children))
+				}
+			} else {
+				if len(nodeLayout.Resources) != 0 {
+					t.Fatalf("unexpected node resources: %d", len(nodeLayout.Resources))
+				}
+				if len(nodeLayout.Children) != 1 {
+					t.Fatalf("expected bundle child, got %d", len(nodeLayout.Children))
+				}
+				bundleLayout := nodeLayout.Children[0]
+				if len(bundleLayout.Children) != 1 {
+					t.Fatalf("expected application child, got %d", len(bundleLayout.Children))
+				}
+				appLayout := bundleLayout.Children[0]
+				if len(appLayout.Resources) != 1 {
+					t.Fatalf("expected application resources, got %d", len(appLayout.Resources))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add table-driven tests for node/bundle/application grouping combinations
- document LayoutRules and FluxCD integration in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ce81b6b50832f85c333bf4b761b0b