### PR TITLE
Add stack overview and cluster-to-flux demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,36 @@ to stdout:
 go run ./cmd/cluster
 ```
 
+## Layout rules and FluxCD integration
+
+`LayoutRules` control how nodes, bundles and applications are grouped when
+writing manifests. The example below flattens bundles and applications under
+their parent node, writes the manifests to `./repo` and then generates Flux
+Kustomizations for the cluster:
+
+```go
+rules := layout.LayoutRules{
+    BundleGrouping:      layout.GroupFlat,
+    ApplicationGrouping: layout.GroupFlat,
+}
+
+ml, err := layout.WalkCluster(cluster, rules)
+if err != nil {
+    // handle error
+}
+
+cfg := layout.DefaultLayoutConfig()
+if err := layout.WriteManifest("./repo", cfg, ml); err != nil {
+    // handle error
+}
+
+wf := fluxcd.NewWorkflow()
+fluxObjs, err := wf.Cluster(cluster)
+if err != nil {
+    // handle error
+}
+```
+
 
 ## Flux vs ArgoCD paths
 

--- a/STACK.md
+++ b/STACK.md
@@ -1,0 +1,41 @@
+# Stack Overview
+
+## Architecture
+
+### Stack model
+- A `Cluster` holds a root `Node` that represents a hierarchical tree of configuration bundles.
+- Each `Node` may carry a `Bundle`, which groups `Applications` and optional metadata such as source references, dependencies, and reconciliation interval.
+- An `Application` uses a pluggable `ApplicationConfig` to generate Kubernetes objects when requested via `Generate`.
+
+### FluxCD workflow
+- Package `stack/fluxcd` implements the `Workflow` interface to convert stack objects into Flux resources.
+- `Cluster` → `Node` → `Bundle` are traversed recursively; for each bundle a Flux `Kustomization` is produced. The repository path for a bundle is derived from its ancestry, intervals and source references are resolved, and `DependsOn` relationships become Flux dependencies.
+
+### Layout generation
+- `WalkCluster` in package `layout` traverses the `Cluster` tree and builds a `ManifestLayout` hierarchy, collecting the Kubernetes objects produced by each application. Layout rules determine whether bundles or applications are flattened or nested in the directory tree.
+- `WriteManifest` renders each `ManifestLayout` to disk: resources are grouped into files, a `kustomization.yaml` is generated when needed, and the function recurses into child layouts to build the full repository structure.
+
+## From Cluster to FluxCD YAML
+
+1. **Model the cluster** – Define a `Cluster` with a tree of `Node` and `Bundle` objects; each bundle aggregates `Application` instances that know how to generate their Kubernetes resources.
+2. **Render manifests** – Run `layout.WalkCluster` to collect the resources from all applications into a `ManifestLayout`, then invoke `layout.WriteManifest` to write those manifests (and local `kustomization.yaml` files) into the repository structure.
+3. **Create Flux definitions** – Execute the Flux workflow (`stack/fluxcd.Workflow`), which converts each bundle in the tree into a Flux `Kustomization` pointing at the appropriate path in the generated layout, including any dependency or interval information.
+4. **Write Flux YAML** – Treat the Flux `Kustomization` objects as another `ManifestLayout` and write them to disk with `layout.WriteManifest`, producing the FluxCD YAML that references the earlier manifest directories.
+5. **Result** – The repository now holds both the Kubernetes resource manifests and the FluxCD `Kustomization` CRDs, enabling Flux to reconcile the cluster by applying the rendered YAML deployments.
+
+## Demo
+
+The `cmd/stack` program demonstrates the complete workflow using the sample configuration in `examples/cluster`:
+
+1. Reads the cluster definition and application bundles.
+2. Walks the cluster with flat layout rules.
+3. Writes generated manifests to a temporary directory.
+4. Produces Flux `Kustomization` objects for each bundle and prints them as YAML.
+
+Run the demo with:
+
+```bash
+go run ./cmd/stack
+```
+
+The command logs the path where manifests are written and outputs Flux `Kustomization` resources that reference those paths.

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -1,521 +1,522 @@
 package main
 
 import (
-	"flag"
-	"io"
-	"log"
-	"os"
-	"path/filepath"
-	"time"
+    "flag"
+    "io"
+    "log"
+    "os"
+    "path/filepath"
+    "time"
 
-	batchv1 "k8s.io/api/batch/v1"
-	apiv1 "k8s.io/api/core/v1"
-	netv1 "k8s.io/api/networking/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/cli-runtime/pkg/printers"
+    batchv1 "k8s.io/api/batch/v1"
+    apiv1 "k8s.io/api/core/v1"
+    netv1 "k8s.io/api/networking/v1"
+    rbacv1 "k8s.io/api/rbac/v1"
+    apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+    "k8s.io/apimachinery/pkg/api/resource"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    "k8s.io/apimachinery/pkg/runtime"
+    "k8s.io/apimachinery/pkg/util/intstr"
+    "k8s.io/cli-runtime/pkg/printers"
 
-	helmv2 "github.com/fluxcd/helm-controller/api/v2"
-	imagev1 "github.com/fluxcd/image-automation-controller/api/v1beta2"
-	kustv1 "github.com/fluxcd/kustomize-controller/api/v1"
-	"github.com/fluxcd/pkg/apis/kustomize"
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
+    helmv2 "github.com/fluxcd/helm-controller/api/v2"
+    imagev1 "github.com/fluxcd/image-automation-controller/api/v1beta2"
+    kustv1 "github.com/fluxcd/kustomize-controller/api/v1"
+    "github.com/fluxcd/pkg/apis/kustomize"
+    sourcev1 "github.com/fluxcd/source-controller/api/v1"
+    sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 
-	certmanagerapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager"
-	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+    certmanagerapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager"
+    certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+    cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 
-	"github.com/go-kure/kure/internal/certmanager"
-	"github.com/go-kure/kure/internal/kubernetes"
-	"github.com/go-kure/kure/pkg/stack"
+    "github.com/go-kure/kure/internal/certmanager"
+    "github.com/go-kure/kure/internal/kubernetes"
+    "github.com/go-kure/kure/pkg/k8s"
+    "github.com/go-kure/kure/pkg/stack"
 
-	"github.com/go-kure/kure/internal/externalsecrets"
-	"github.com/go-kure/kure/internal/fluxcd"
-	"github.com/go-kure/kure/internal/metallb"
-	kio "github.com/go-kure/kure/pkg/io"
+    "github.com/go-kure/kure/internal/externalsecrets"
+    "github.com/go-kure/kure/internal/fluxcd"
+    "github.com/go-kure/kure/internal/metallb"
+    kio "github.com/go-kure/kure/pkg/io"
 
-	fluxv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
-	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
-	"github.com/fluxcd/notification-controller/api/v1"
-	notificationv1beta2 "github.com/fluxcd/notification-controller/api/v1beta2"
-	"github.com/fluxcd/pkg/apis/meta"
-	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
-	"gopkg.in/yaml.v3"
+    fluxv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+    esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+    "github.com/fluxcd/notification-controller/api/v1"
+    notificationv1beta2 "github.com/fluxcd/notification-controller/api/v1beta2"
+    "github.com/fluxcd/pkg/apis/meta"
+    metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
+    "gopkg.in/yaml.v3"
 )
 
 func ptr[T any](v T) *T { return &v }
 
 func logError(msg string, err error) {
-	if err != nil {
-		log.Printf("%s: %v", msg, err)
-	}
+    if err != nil {
+        log.Printf("%s: %v", msg, err)
+    }
 }
 
 func main() {
-	var (
-		internals   bool
-		appWorkload bool
-		clusterDemo bool
-		format      string
-	)
+    var (
+        internals   bool
+        appWorkload bool
+        clusterDemo bool
+        format      string
+    )
 
-	flag.BoolVar(&internals, "internals", false, "run internal demos")
-	flag.BoolVar(&internals, "i", false, "run internal demos")
-	flag.BoolVar(&appWorkload, "app-workload", false, "run AppWorkload example")
-	flag.BoolVar(&appWorkload, "a", false, "run AppWorkload example")
-	flag.BoolVar(&clusterDemo, "cluster", false, "run cluster example")
-	flag.BoolVar(&clusterDemo, "c", false, "run cluster example")
-	flag.StringVar(&format, "format", "json", "output format: json|yaml|toml")
-	flag.StringVar(&format, "f", "json", "output format: json|yaml|toml")
-	flag.Parse()
+    flag.BoolVar(&internals, "internals", false, "run internal demos")
+    flag.BoolVar(&internals, "i", false, "run internal demos")
+    flag.BoolVar(&appWorkload, "app-workload", false, "run AppWorkload example")
+    flag.BoolVar(&appWorkload, "a", false, "run AppWorkload example")
+    flag.BoolVar(&clusterDemo, "cluster", false, "run cluster example")
+    flag.BoolVar(&clusterDemo, "c", false, "run cluster example")
+    flag.StringVar(&format, "format", "json", "output format: json|yaml|toml")
+    flag.StringVar(&format, "f", "json", "output format: json|yaml|toml")
+    flag.Parse()
 
-	switch {
-	case internals:
-		runInternals()
-	case appWorkload:
-		if err := runAppWorkload(); err != nil {
-			log.Printf("app-workload error: %v", err)
-		}
-	case clusterDemo:
-		if err := runClusterExample(); err != nil {
-			log.Printf("cluster error: %v", err)
-		}
-	default:
-		flag.Usage()
-	}
+    switch {
+    case internals:
+        runInternals()
+    case appWorkload:
+        if err := runAppWorkload(); err != nil {
+            log.Printf("app-workload error: %v", err)
+        }
+    case clusterDemo:
+        if err := runClusterExample(); err != nil {
+            log.Printf("cluster error: %v", err)
+        }
+    default:
+        flag.Usage()
+    }
 }
 
 func runInternals() {
-	y := printers.YAMLPrinter{}
+    y := printers.YAMLPrinter{}
 
-	// Namespace example
-	ns := kubernetes.CreateNamespace("demo")
-	kubernetes.AddNamespaceLabel(ns, "env", "demo")
-	kubernetes.AddNamespaceAnnotation(ns, "owner", "example")
+    // Namespace example
+    ns := kubernetes.CreateNamespace("demo")
+    kubernetes.AddNamespaceLabel(ns, "env", "demo")
+    kubernetes.AddNamespaceAnnotation(ns, "owner", "example")
 
-	// Service account
-	sa := kubernetes.CreateServiceAccount("demo-sa", "demo")
-	logError("add serviceaccount secret", kubernetes.AddServiceAccountSecret(sa, apiv1.ObjectReference{Name: "sa-secret"}))
-	logError("add serviceaccount image pull secret", kubernetes.AddServiceAccountImagePullSecret(sa, apiv1.LocalObjectReference{Name: "sa-pull"}))
-	logError("set serviceaccount automount token", kubernetes.SetServiceAccountAutomountToken(sa, true))
+    // Service account
+    sa := kubernetes.CreateServiceAccount("demo-sa", "demo")
+    logError("add serviceaccount secret", kubernetes.AddServiceAccountSecret(sa, apiv1.ObjectReference{Name: "sa-secret"}))
+    logError("add serviceaccount image pull secret", kubernetes.AddServiceAccountImagePullSecret(sa, apiv1.LocalObjectReference{Name: "sa-pull"}))
+    logError("set serviceaccount automount token", kubernetes.SetServiceAccountAutomountToken(sa, true))
 
-	// Secret example
-	secret := kubernetes.CreateSecret("demo-secret", "demo")
-	logError("add secret data", kubernetes.AddSecretData(secret, "cert", []byte("data")))
-	logError("add secret string data", kubernetes.AddSecretStringData(secret, "token", "abcd"))
-	logError("set secret type", kubernetes.SetSecretType(secret, apiv1.SecretTypeOpaque))
-	logError("set secret immutable", kubernetes.SetSecretImmutable(secret, true))
+    // Secret example
+    secret := kubernetes.CreateSecret("demo-secret", "demo")
+    logError("add secret data", kubernetes.AddSecretData(secret, "cert", []byte("data")))
+    logError("add secret string data", kubernetes.AddSecretStringData(secret, "token", "abcd"))
+    logError("set secret type", kubernetes.SetSecretType(secret, apiv1.SecretTypeOpaque))
+    logError("set secret immutable", kubernetes.SetSecretImmutable(secret, true))
 
-	// ConfigMap example
-	cm := kubernetes.CreateConfigMap("demo-config", "demo")
-	logError("add configmap data", kubernetes.AddConfigMapData(cm, "foo", "bar"))
-	logError("add configmap data map", kubernetes.AddConfigMapDataMap(cm, map[string]string{"extra": "value"}))
-	logError("add configmap binary data", kubernetes.AddConfigMapBinaryData(cm, "bin", []byte{0x1}))
-	logError("add configmap binary data map", kubernetes.AddConfigMapBinaryDataMap(cm, map[string][]byte{"more": {0x2}}))
-	logError("set configmap data", kubernetes.SetConfigMapData(cm, map[string]string{"hello": "world"}))
-	logError("set configmap binary data", kubernetes.SetConfigMapBinaryData(cm, map[string][]byte{"bye": {0x0}}))
-	logError("set configmap immutable", kubernetes.SetConfigMapImmutable(cm, false))
+    // ConfigMap example
+    cm := kubernetes.CreateConfigMap("demo-config", "demo")
+    logError("add configmap data", kubernetes.AddConfigMapData(cm, "foo", "bar"))
+    logError("add configmap data map", kubernetes.AddConfigMapDataMap(cm, map[string]string{"extra": "value"}))
+    logError("add configmap binary data", kubernetes.AddConfigMapBinaryData(cm, "bin", []byte{0x1}))
+    logError("add configmap binary data map", kubernetes.AddConfigMapBinaryDataMap(cm, map[string][]byte{"more": {0x2}}))
+    logError("set configmap data", kubernetes.SetConfigMapData(cm, map[string]string{"hello": "world"}))
+    logError("set configmap binary data", kubernetes.SetConfigMapBinaryData(cm, map[string][]byte{"bye": {0x0}}))
+    logError("set configmap immutable", kubernetes.SetConfigMapImmutable(cm, false))
 
-	// PersistentVolumeClaim example
-	pvc := kubernetes.CreatePersistentVolumeClaim("demo-pvc", "demo")
-	kubernetes.AddPVCAccessMode(pvc, apiv1.ReadWriteOnce)
-	kubernetes.SetPVCStorageClassName(pvc, "standard")
-	kubernetes.SetPVCVolumeMode(pvc, apiv1.PersistentVolumeFilesystem)
-	kubernetes.SetPVCResources(pvc, apiv1.VolumeResourceRequirements{
-		Requests: apiv1.ResourceList{
-			apiv1.ResourceStorage: resource.MustParse("2Gi"),
-		},
-	})
-	kubernetes.SetPVCSelector(pvc, &metav1.LabelSelector{MatchLabels: map[string]string{"disk": "fast"}})
-	kubernetes.SetPVCVolumeName(pvc, "pv1")
-	kubernetes.SetPVCDataSource(pvc, &apiv1.TypedLocalObjectReference{Kind: "PersistentVolumeClaim", Name: "source"})
-	kubernetes.SetPVCDataSourceRef(pvc, &apiv1.TypedObjectReference{Kind: "PersistentVolumeClaim", Name: "source"})
+    // PersistentVolumeClaim example
+    pvc := kubernetes.CreatePersistentVolumeClaim("demo-pvc", "demo")
+    kubernetes.AddPVCAccessMode(pvc, apiv1.ReadWriteOnce)
+    kubernetes.SetPVCStorageClassName(pvc, "standard")
+    kubernetes.SetPVCVolumeMode(pvc, apiv1.PersistentVolumeFilesystem)
+    kubernetes.SetPVCResources(pvc, apiv1.VolumeResourceRequirements{
+        Requests: apiv1.ResourceList{
+            apiv1.ResourceStorage: resource.MustParse("2Gi"),
+        },
+    })
+    kubernetes.SetPVCSelector(pvc, &metav1.LabelSelector{MatchLabels: map[string]string{"disk": "fast"}})
+    kubernetes.SetPVCVolumeName(pvc, "pv1")
+    kubernetes.SetPVCDataSource(pvc, &apiv1.TypedLocalObjectReference{Kind: "PersistentVolumeClaim", Name: "source"})
+    kubernetes.SetPVCDataSourceRef(pvc, &apiv1.TypedObjectReference{Kind: "PersistentVolumeClaim", Name: "source"})
 
-	// StorageClass example
-	sc := kubernetes.CreateStorageClass("demo-sc", "kubernetes.io/no-provisioner")
-	kubernetes.AddStorageClassParameter(sc, "type", "local")
-	kubernetes.SetStorageClassAllowVolumeExpansion(sc, true)
-	kubernetes.SetPVCStorageClass(pvc, sc)
+    // StorageClass example
+    sc := kubernetes.CreateStorageClass("demo-sc", "kubernetes.io/no-provisioner")
+    kubernetes.AddStorageClassParameter(sc, "type", "local")
+    kubernetes.SetStorageClassAllowVolumeExpansion(sc, true)
+    kubernetes.SetPVCStorageClass(pvc, sc)
 
-	// Pod example
-	pod := kubernetes.CreatePod("demo-pod", "demo")
-	mainCtr := kubernetes.CreateContainer("app", "nginx", nil, nil)
-	logError("add container port", kubernetes.AddContainerPort(mainCtr, apiv1.ContainerPort{Name: "http", ContainerPort: 80}))
-	logError("add container env", kubernetes.AddContainerEnv(mainCtr, apiv1.EnvVar{Name: "ENV", Value: "prod"}))
-	logError("add container env from", kubernetes.AddContainerEnvFrom(mainCtr, apiv1.EnvFromSource{ConfigMapRef: &apiv1.ConfigMapEnvSource{LocalObjectReference: apiv1.LocalObjectReference{Name: cm.Name}}}))
-	logError("add container volume mount", kubernetes.AddContainerVolumeMount(mainCtr, apiv1.VolumeMount{Name: "data", MountPath: "/data"}))
-	logError("add container volume device", kubernetes.AddContainerVolumeDevice(mainCtr, apiv1.VolumeDevice{Name: "block", DevicePath: "/dev/block"}))
-	logError("set container liveness probe", kubernetes.SetContainerLivenessProbe(mainCtr, apiv1.Probe{InitialDelaySeconds: 5}))
-	logError("set container readiness probe", kubernetes.SetContainerReadinessProbe(mainCtr, apiv1.Probe{InitialDelaySeconds: 5}))
-	logError("set container startup probe", kubernetes.SetContainerStartupProbe(mainCtr, apiv1.Probe{InitialDelaySeconds: 1}))
-	logError("set container resources", kubernetes.SetContainerResources(mainCtr, apiv1.ResourceRequirements{
-		Limits: apiv1.ResourceList{"memory": resource.MustParse("128Mi")},
-		Requests: apiv1.ResourceList{
-			"cpu":    resource.MustParse("50m"),
-			"memory": resource.MustParse("64Mi"),
-		},
-	}))
-	logError("set container image pull policy", kubernetes.SetContainerImagePullPolicy(mainCtr, apiv1.PullIfNotPresent))
-	logError("set container security context", kubernetes.SetContainerSecurityContext(mainCtr, apiv1.SecurityContext{RunAsUser: ptr[int64](1000)}))
+    // Pod example
+    pod := kubernetes.CreatePod("demo-pod", "demo")
+    mainCtr := kubernetes.CreateContainer("app", "nginx", nil, nil)
+    logError("add container port", kubernetes.AddContainerPort(mainCtr, apiv1.ContainerPort{Name: "http", ContainerPort: 80}))
+    logError("add container env", kubernetes.AddContainerEnv(mainCtr, apiv1.EnvVar{Name: "ENV", Value: "prod"}))
+    logError("add container env from", kubernetes.AddContainerEnvFrom(mainCtr, apiv1.EnvFromSource{ConfigMapRef: &apiv1.ConfigMapEnvSource{LocalObjectReference: apiv1.LocalObjectReference{Name: cm.Name}}}))
+    logError("add container volume mount", kubernetes.AddContainerVolumeMount(mainCtr, apiv1.VolumeMount{Name: "data", MountPath: "/data"}))
+    logError("add container volume device", kubernetes.AddContainerVolumeDevice(mainCtr, apiv1.VolumeDevice{Name: "block", DevicePath: "/dev/block"}))
+    logError("set container liveness probe", kubernetes.SetContainerLivenessProbe(mainCtr, apiv1.Probe{InitialDelaySeconds: 5}))
+    logError("set container readiness probe", kubernetes.SetContainerReadinessProbe(mainCtr, apiv1.Probe{InitialDelaySeconds: 5}))
+    logError("set container startup probe", kubernetes.SetContainerStartupProbe(mainCtr, apiv1.Probe{InitialDelaySeconds: 1}))
+    logError("set container resources", kubernetes.SetContainerResources(mainCtr, apiv1.ResourceRequirements{
+        Limits: apiv1.ResourceList{"memory": resource.MustParse("128Mi")},
+        Requests: apiv1.ResourceList{
+            "cpu":    resource.MustParse("50m"),
+            "memory": resource.MustParse("64Mi"),
+        },
+    }))
+    logError("set container image pull policy", kubernetes.SetContainerImagePullPolicy(mainCtr, apiv1.PullIfNotPresent))
+    logError("set container security context", kubernetes.SetContainerSecurityContext(mainCtr, apiv1.SecurityContext{RunAsUser: ptr[int64](1000)}))
 
-	initCtr := kubernetes.CreateContainer("init", "busybox", []string{"sh", "-c"}, []string{"echo init"})
+    initCtr := kubernetes.CreateContainer("init", "busybox", []string{"sh", "-c"}, []string{"echo init"})
 
-	logError("add pod container", kubernetes.AddPodContainer(pod, mainCtr))
-	logError("add pod init container", kubernetes.AddPodInitContainer(pod, initCtr))
-	logError("add pod volume", kubernetes.AddPodVolume(pod, &apiv1.Volume{Name: "data"}))
-	logError("add pod image pull secret", kubernetes.AddPodImagePullSecret(pod, &apiv1.LocalObjectReference{Name: "pullsecret"}))
-	logError("add pod toleration", kubernetes.AddPodToleration(pod, &apiv1.Toleration{Key: "role"}))
-	tsc := apiv1.TopologySpreadConstraint{MaxSkew: 1, TopologyKey: "zone", WhenUnsatisfiable: apiv1.DoNotSchedule, LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo"}}}
-	logError("add pod topology spread constraints", kubernetes.AddPodTopologySpreadConstraints(pod, &tsc))
-	logError("set pod serviceaccount name", kubernetes.SetPodServiceAccountName(pod, sa.Name))
-	logError("set pod security context", kubernetes.SetPodSecurityContext(pod, &apiv1.PodSecurityContext{}))
-	logError("set pod affinity", kubernetes.SetPodAffinity(pod, &apiv1.Affinity{}))
-	logError("set pod node selector", kubernetes.SetPodNodeSelector(pod, map[string]string{"type": "worker"}))
+    logError("add pod container", kubernetes.AddPodContainer(pod, mainCtr))
+    logError("add pod init container", kubernetes.AddPodInitContainer(pod, initCtr))
+    logError("add pod volume", kubernetes.AddPodVolume(pod, &apiv1.Volume{Name: "data"}))
+    logError("add pod image pull secret", kubernetes.AddPodImagePullSecret(pod, &apiv1.LocalObjectReference{Name: "pullsecret"}))
+    logError("add pod toleration", kubernetes.AddPodToleration(pod, &apiv1.Toleration{Key: "role"}))
+    tsc := apiv1.TopologySpreadConstraint{MaxSkew: 1, TopologyKey: "zone", WhenUnsatisfiable: apiv1.DoNotSchedule, LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo"}}}
+    logError("add pod topology spread constraints", kubernetes.AddPodTopologySpreadConstraints(pod, &tsc))
+    logError("set pod serviceaccount name", kubernetes.SetPodServiceAccountName(pod, sa.Name))
+    logError("set pod security context", kubernetes.SetPodSecurityContext(pod, &apiv1.PodSecurityContext{}))
+    logError("set pod affinity", kubernetes.SetPodAffinity(pod, &apiv1.Affinity{}))
+    logError("set pod node selector", kubernetes.SetPodNodeSelector(pod, map[string]string{"type": "worker"}))
 
-	// Deployment example
-	dep := kubernetes.CreateDeployment("demo-deployment", "demo")
-	logError("add deployment container", kubernetes.AddDeploymentContainer(dep, mainCtr))
-	logError("add deployment init container", kubernetes.AddDeploymentInitContainer(dep, initCtr))
-	logError("add deployment volume", kubernetes.AddDeploymentVolume(dep, &apiv1.Volume{Name: "data"}))
-	logError("add deployment image pull secret", kubernetes.AddDeploymentImagePullSecret(dep, &apiv1.LocalObjectReference{Name: "pullsecret"}))
-	logError("add deployment toleration", kubernetes.AddDeploymentToleration(dep, &apiv1.Toleration{Key: "role"}))
-	logError("add deployment topology spread constraints", kubernetes.AddDeploymentTopologySpreadConstraints(dep, &tsc))
-	logError("set deployment serviceaccount name", kubernetes.SetDeploymentServiceAccountName(dep, sa.Name))
-	logError("set deployment security context", kubernetes.SetDeploymentSecurityContext(dep, &apiv1.PodSecurityContext{}))
-	logError("set deployment affinity", kubernetes.SetDeploymentAffinity(dep, &apiv1.Affinity{}))
-	logError("set deployment node selector", kubernetes.SetDeploymentNodeSelector(dep, map[string]string{"role": "web"}))
+    // Deployment example
+    dep := kubernetes.CreateDeployment("demo-deployment", "demo")
+    logError("add deployment container", kubernetes.AddDeploymentContainer(dep, mainCtr))
+    logError("add deployment init container", kubernetes.AddDeploymentInitContainer(dep, initCtr))
+    logError("add deployment volume", kubernetes.AddDeploymentVolume(dep, &apiv1.Volume{Name: "data"}))
+    logError("add deployment image pull secret", kubernetes.AddDeploymentImagePullSecret(dep, &apiv1.LocalObjectReference{Name: "pullsecret"}))
+    logError("add deployment toleration", kubernetes.AddDeploymentToleration(dep, &apiv1.Toleration{Key: "role"}))
+    logError("add deployment topology spread constraints", kubernetes.AddDeploymentTopologySpreadConstraints(dep, &tsc))
+    logError("set deployment serviceaccount name", kubernetes.SetDeploymentServiceAccountName(dep, sa.Name))
+    logError("set deployment security context", kubernetes.SetDeploymentSecurityContext(dep, &apiv1.PodSecurityContext{}))
+    logError("set deployment affinity", kubernetes.SetDeploymentAffinity(dep, &apiv1.Affinity{}))
+    logError("set deployment node selector", kubernetes.SetDeploymentNodeSelector(dep, map[string]string{"role": "web"}))
 
-	// StatefulSet example
-	sts := kubernetes.CreateStatefulSet("demo-sts", "demo")
-	logError("add statefulset container", kubernetes.AddStatefulSetContainer(sts, mainCtr))
-	logError("add statefulset init container", kubernetes.AddStatefulSetInitContainer(sts, initCtr))
-	logError("add statefulset volume", kubernetes.AddStatefulSetVolume(sts, &apiv1.Volume{Name: "data"}))
-	logError("add statefulset volumeclaim template", kubernetes.AddStatefulSetVolumeClaimTemplate(sts, *kubernetes.CreatePersistentVolumeClaim("data", "demo")))
-	logError("add statefulset toleration", kubernetes.AddStatefulSetToleration(sts, &apiv1.Toleration{Key: "role"}))
-	logError("set statefulset serviceaccount name", kubernetes.SetStatefulSetServiceAccountName(sts, sa.Name))
-	logError("set statefulset service name", kubernetes.SetStatefulSetServiceName(sts, "demo-svc"))
-	logError("set statefulset replicas", kubernetes.SetStatefulSetReplicas(sts, 3))
+    // StatefulSet example
+    sts := kubernetes.CreateStatefulSet("demo-sts", "demo")
+    logError("add statefulset container", kubernetes.AddStatefulSetContainer(sts, mainCtr))
+    logError("add statefulset init container", kubernetes.AddStatefulSetInitContainer(sts, initCtr))
+    logError("add statefulset volume", kubernetes.AddStatefulSetVolume(sts, &apiv1.Volume{Name: "data"}))
+    logError("add statefulset volumeclaim template", kubernetes.AddStatefulSetVolumeClaimTemplate(sts, *kubernetes.CreatePersistentVolumeClaim("data", "demo")))
+    logError("add statefulset toleration", kubernetes.AddStatefulSetToleration(sts, &apiv1.Toleration{Key: "role"}))
+    logError("set statefulset serviceaccount name", kubernetes.SetStatefulSetServiceAccountName(sts, sa.Name))
+    logError("set statefulset service name", kubernetes.SetStatefulSetServiceName(sts, "demo-svc"))
+    logError("set statefulset replicas", kubernetes.SetStatefulSetReplicas(sts, 3))
 
-	// DaemonSet example
-	ds := kubernetes.CreateDaemonSet("demo-ds", "demo")
-	logError("add daemonset container", kubernetes.AddDaemonSetContainer(ds, mainCtr))
-	logError("add daemonset init container", kubernetes.AddDaemonSetInitContainer(ds, initCtr))
-	logError("add daemonset volume", kubernetes.AddDaemonSetVolume(ds, &apiv1.Volume{Name: "data"}))
-	logError("add daemonset toleration", kubernetes.AddDaemonSetToleration(ds, &apiv1.Toleration{Key: "role"}))
-	logError("set daemonset serviceaccount name", kubernetes.SetDaemonSetServiceAccountName(ds, sa.Name))
-	logError("set daemonset node selector", kubernetes.SetDaemonSetNodeSelector(ds, map[string]string{"type": "worker"}))
+    // DaemonSet example
+    ds := kubernetes.CreateDaemonSet("demo-ds", "demo")
+    logError("add daemonset container", kubernetes.AddDaemonSetContainer(ds, mainCtr))
+    logError("add daemonset init container", kubernetes.AddDaemonSetInitContainer(ds, initCtr))
+    logError("add daemonset volume", kubernetes.AddDaemonSetVolume(ds, &apiv1.Volume{Name: "data"}))
+    logError("add daemonset toleration", kubernetes.AddDaemonSetToleration(ds, &apiv1.Toleration{Key: "role"}))
+    logError("set daemonset serviceaccount name", kubernetes.SetDaemonSetServiceAccountName(ds, sa.Name))
+    logError("set daemonset node selector", kubernetes.SetDaemonSetNodeSelector(ds, map[string]string{"type": "worker"}))
 
-	// Job example
-	job := kubernetes.CreateJob("demo-job", "demo")
-	logError("add job container", kubernetes.AddJobContainer(job, mainCtr))
-	logError("set job backoff limit", kubernetes.SetJobBackoffLimit(job, 3))
-	logError("set job completions", kubernetes.SetJobCompletions(job, 1))
-	logError("set job parallelism", kubernetes.SetJobParallelism(job, 1))
+    // Job example
+    job := kubernetes.CreateJob("demo-job", "demo")
+    logError("add job container", kubernetes.AddJobContainer(job, mainCtr))
+    logError("set job backoff limit", kubernetes.SetJobBackoffLimit(job, 3))
+    logError("set job completions", kubernetes.SetJobCompletions(job, 1))
+    logError("set job parallelism", kubernetes.SetJobParallelism(job, 1))
 
-	// CronJob example
-	cron := kubernetes.CreateCronJob("demo-cron", "demo", "*/5 * * * *")
-	logError("add cronjob container", kubernetes.AddCronJobContainer(cron, mainCtr))
-	logError("set cronjob concurrency policy", kubernetes.SetCronJobConcurrencyPolicy(cron, batchv1.ForbidConcurrent))
+    // CronJob example
+    cron := kubernetes.CreateCronJob("demo-cron", "demo", "*/5 * * * *")
+    logError("add cronjob container", kubernetes.AddCronJobContainer(cron, mainCtr))
+    logError("set cronjob concurrency policy", kubernetes.SetCronJobConcurrencyPolicy(cron, batchv1.ForbidConcurrent))
 
-	// Service and ingress example
-	svc := kubernetes.CreateService("demo-svc", "demo")
-	logError("set service selector", kubernetes.SetServiceSelector(svc, map[string]string{"app": "demo"}))
-	logError("add service port", kubernetes.AddServicePort(svc, apiv1.ServicePort{Name: "http", Port: 80, TargetPort: intstr.FromString("http")}))
-	logError("set service type", kubernetes.SetServiceType(svc, apiv1.ServiceTypeClusterIP))
-	logError("set service external traffic policy", kubernetes.SetServiceExternalTrafficPolicy(svc, apiv1.ServiceExternalTrafficPolicyCluster))
+    // Service and ingress example
+    svc := kubernetes.CreateService("demo-svc", "demo")
+    logError("set service selector", kubernetes.SetServiceSelector(svc, map[string]string{"app": "demo"}))
+    logError("add service port", kubernetes.AddServicePort(svc, apiv1.ServicePort{Name: "http", Port: 80, TargetPort: intstr.FromString("http")}))
+    logError("set service type", kubernetes.SetServiceType(svc, apiv1.ServiceTypeClusterIP))
+    logError("set service external traffic policy", kubernetes.SetServiceExternalTrafficPolicy(svc, apiv1.ServiceExternalTrafficPolicyCluster))
 
-	ing := kubernetes.CreateIngress("demo-ing", "demo", "nginx")
-	rule := kubernetes.CreateIngressRule("example.com")
-	pathtype := netv1.PathTypePrefix
-	path := kubernetes.CreateIngressPath("/", &pathtype, svc.Name, "http")
-	kubernetes.AddIngressRulePath(rule, path)
-	kubernetes.AddIngressRule(ing, rule)
-	kubernetes.AddIngressTLS(ing, netv1.IngressTLS{Hosts: []string{"example.com"}, SecretName: secret.Name})
+    ing := kubernetes.CreateIngress("demo-ing", "demo", "nginx")
+    rule := kubernetes.CreateIngressRule("example.com")
+    pathtype := netv1.PathTypePrefix
+    path := kubernetes.CreateIngressPath("/", &pathtype, svc.Name, "http")
+    kubernetes.AddIngressRulePath(rule, path)
+    kubernetes.AddIngressRule(ing, rule)
+    kubernetes.AddIngressTLS(ing, netv1.IngressTLS{Hosts: []string{"example.com"}, SecretName: secret.Name})
 
-	// RBAC examples
-	role := kubernetes.CreateRole("demo-role", "demo")
-	kubernetes.AddRoleRule(role, rbacv1.PolicyRule{Verbs: []string{"get"}, Resources: []string{"pods"}})
+    // RBAC examples
+    role := kubernetes.CreateRole("demo-role", "demo")
+    kubernetes.AddRoleRule(role, rbacv1.PolicyRule{Verbs: []string{"get"}, Resources: []string{"pods"}})
 
-	clusterRole := kubernetes.CreateClusterRole("demo-cr")
-	kubernetes.AddClusterRoleRule(clusterRole, rbacv1.PolicyRule{Verbs: []string{"list"}, Resources: []string{"nodes"}})
+    clusterRole := kubernetes.CreateClusterRole("demo-cr")
+    kubernetes.AddClusterRoleRule(clusterRole, rbacv1.PolicyRule{Verbs: []string{"list"}, Resources: []string{"nodes"}})
 
-	roleBind := kubernetes.CreateRoleBinding("demo-rb", "demo", rbacv1.RoleRef{Kind: "Role", Name: role.Name})
-	kubernetes.AddRoleBindingSubject(roleBind, rbacv1.Subject{Kind: "ServiceAccount", Name: sa.Name, Namespace: sa.Namespace})
+    roleBind := kubernetes.CreateRoleBinding("demo-rb", "demo", rbacv1.RoleRef{Kind: "Role", Name: role.Name})
+    kubernetes.AddRoleBindingSubject(roleBind, rbacv1.Subject{Kind: "ServiceAccount", Name: sa.Name, Namespace: sa.Namespace})
 
-	clusterRoleBind := kubernetes.CreateClusterRoleBinding("demo-crb", rbacv1.RoleRef{Kind: "ClusterRole", Name: clusterRole.Name})
-	kubernetes.AddClusterRoleBindingSubject(clusterRoleBind, rbacv1.Subject{Kind: "User", Name: "admin"})
+    clusterRoleBind := kubernetes.CreateClusterRoleBinding("demo-crb", rbacv1.RoleRef{Kind: "ClusterRole", Name: clusterRole.Name})
+    kubernetes.AddClusterRoleBindingSubject(clusterRoleBind, rbacv1.Subject{Kind: "User", Name: "admin"})
 
-	// HelmRelease example
-	hr := fluxcd.CreateHelmRelease("demo-hr", "demo", helmv2.HelmReleaseSpec{})
-	fluxcd.SetHelmReleaseReleaseName(hr, "demo")
-	fluxcd.SetHelmReleaseInterval(hr, metav1.Duration{Duration: time.Minute})
-	fluxcd.AddHelmReleaseLabel(hr, "app", "demo")
-	fluxcd.SetHelmReleaseChart(hr, &helmv2.HelmChartTemplate{
-		Spec: helmv2.HelmChartTemplateSpec{
-			Chart:   "demo",
-			Version: "1.0.0",
-			SourceRef: helmv2.CrossNamespaceObjectReference{
-				Kind:      "HelmRepository",
-				Name:      "demo",
-				Namespace: "demo",
-			},
-		},
-	})
+    // HelmRelease example
+    hr := fluxcd.CreateHelmRelease("demo-hr", "demo", helmv2.HelmReleaseSpec{})
+    fluxcd.SetHelmReleaseReleaseName(hr, "demo")
+    fluxcd.SetHelmReleaseInterval(hr, metav1.Duration{Duration: time.Minute})
+    fluxcd.AddHelmReleaseLabel(hr, "app", "demo")
+    fluxcd.SetHelmReleaseChart(hr, &helmv2.HelmChartTemplate{
+        Spec: helmv2.HelmChartTemplateSpec{
+            Chart:   "demo",
+            Version: "1.0.0",
+            SourceRef: helmv2.CrossNamespaceObjectReference{
+                Kind:      "HelmRepository",
+                Name:      "demo",
+                Namespace: "demo",
+            },
+        },
+    })
 
-	// Kustomization example
-	ks := fluxcd.CreateKustomization("demo-ks", "demo", kustv1.KustomizationSpec{Path: "./manifests", Prune: true})
-	fluxcd.SetKustomizationInterval(ks, metav1.Duration{Duration: time.Minute})
-	fluxcd.SetKustomizationSourceRef(ks, kustv1.CrossNamespaceSourceReference{Kind: "GitRepository", Name: "demo-repo"})
-	fluxcd.AddKustomizationImage(ks, kustomize.Image{Name: "nginx", NewTag: "latest"})
+    // Kustomization example
+    ks := fluxcd.CreateKustomization("demo-ks", "demo", kustv1.KustomizationSpec{Path: "./manifests", Prune: true})
+    fluxcd.SetKustomizationInterval(ks, metav1.Duration{Duration: time.Minute})
+    fluxcd.SetKustomizationSourceRef(ks, kustv1.CrossNamespaceSourceReference{Kind: "GitRepository", Name: "demo-repo"})
+    fluxcd.AddKustomizationImage(ks, kustomize.Image{Name: "nginx", NewTag: "latest"})
 
-	// Flux source-controller examples
-	gitRepo := fluxcd.CreateGitRepository("demo-git", "demo", sourcev1.GitRepositorySpec{})
-	fluxcd.SetGitRepositoryURL(gitRepo, "https://github.com/example/repo.git")
-	fluxcd.SetGitRepositoryInterval(gitRepo, metav1.Duration{Duration: time.Minute})
+    // Flux source-controller examples
+    gitRepo := fluxcd.CreateGitRepository("demo-git", "demo", sourcev1.GitRepositorySpec{})
+    fluxcd.SetGitRepositoryURL(gitRepo, "https://github.com/example/repo.git")
+    fluxcd.SetGitRepositoryInterval(gitRepo, metav1.Duration{Duration: time.Minute})
 
-	helmRepo := fluxcd.CreateHelmRepository("demo-helm", "demo", sourcev1.HelmRepositorySpec{})
-	fluxcd.SetHelmRepositoryURL(helmRepo, "https://charts.example.com")
-	fluxcd.SetHelmRepositoryInterval(helmRepo, metav1.Duration{Duration: time.Hour})
+    helmRepo := fluxcd.CreateHelmRepository("demo-helm", "demo", sourcev1.HelmRepositorySpec{})
+    fluxcd.SetHelmRepositoryURL(helmRepo, "https://charts.example.com")
+    fluxcd.SetHelmRepositoryInterval(helmRepo, metav1.Duration{Duration: time.Hour})
 
-	bucket := fluxcd.CreateBucket("demo-bucket", "demo", sourcev1.BucketSpec{})
-	fluxcd.SetBucketName(bucket, "artifacts")
-	fluxcd.SetBucketEndpoint(bucket, "https://s3.example.com")
+    bucket := fluxcd.CreateBucket("demo-bucket", "demo", sourcev1.BucketSpec{})
+    fluxcd.SetBucketName(bucket, "artifacts")
+    fluxcd.SetBucketEndpoint(bucket, "https://s3.example.com")
 
-	chart := fluxcd.CreateHelmChart("demo-chart", "demo", sourcev1.HelmChartSpec{})
-	fluxcd.SetHelmChartChart(chart, "app")
+    chart := fluxcd.CreateHelmChart("demo-chart", "demo", sourcev1.HelmChartSpec{})
+    fluxcd.SetHelmChartChart(chart, "app")
 
-	ociRepo := fluxcd.CreateOCIRepository("demo-oci", "demo", sourcev1beta2.OCIRepositorySpec{})
-	fluxcd.SetOCIRepositoryURL(ociRepo, "oci://registry/app")
+    ociRepo := fluxcd.CreateOCIRepository("demo-oci", "demo", sourcev1beta2.OCIRepositorySpec{})
+    fluxcd.SetOCIRepositoryURL(ociRepo, "oci://registry/app")
 
-	// Network policy example
-	np := kubernetes.CreateNetworkPolicy("demo-netpol", "demo")
-	npRule := netv1.NetworkPolicyIngressRule{}
-	peer := netv1.NetworkPolicyPeer{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo"}}}
-	kubernetes.AddNetworkPolicyIngressPeer(&npRule, peer)
-	kubernetes.AddNetworkPolicyIngressRule(np, npRule)
-	kubernetes.AddNetworkPolicyPolicyType(np, netv1.PolicyTypeIngress)
+    // Network policy example
+    np := kubernetes.CreateNetworkPolicy("demo-netpol", "demo")
+    npRule := netv1.NetworkPolicyIngressRule{}
+    peer := netv1.NetworkPolicyPeer{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo"}}}
+    kubernetes.AddNetworkPolicyIngressPeer(&npRule, peer)
+    kubernetes.AddNetworkPolicyIngressRule(np, npRule)
+    kubernetes.AddNetworkPolicyPolicyType(np, netv1.PolicyTypeIngress)
 
-	// Resource quota example
-	rq := kubernetes.CreateResourceQuota("demo-quota", "demo")
-	kubernetes.AddResourceQuotaHard(rq, apiv1.ResourceRequestsStorage, resource.MustParse("1Gi"))
+    // Resource quota example
+    rq := kubernetes.CreateResourceQuota("demo-quota", "demo")
+    kubernetes.AddResourceQuotaHard(rq, apiv1.ResourceRequestsStorage, resource.MustParse("1Gi"))
 
-	// Limit range example
-	lr := kubernetes.CreateLimitRange("demo-limits", "demo")
-	lrItem := apiv1.LimitRangeItem{Type: apiv1.LimitTypeContainer}
-	kubernetes.AddLimitRangeItemDefaultRequest(&lrItem, apiv1.ResourceCPU, resource.MustParse("100m"))
-	kubernetes.AddLimitRangeItem(lr, lrItem)
+    // Limit range example
+    lr := kubernetes.CreateLimitRange("demo-limits", "demo")
+    lrItem := apiv1.LimitRangeItem{Type: apiv1.LimitTypeContainer}
+    kubernetes.AddLimitRangeItemDefaultRequest(&lrItem, apiv1.ResourceCPU, resource.MustParse("100m"))
+    kubernetes.AddLimitRangeItem(lr, lrItem)
 
-	// Notification controller examples
-	provider := fluxcd.CreateProvider("demo-provider", "demo", notificationv1beta2.ProviderSpec{Type: notificationv1beta2.SlackProvider})
-	alert := fluxcd.CreateAlert("demo-alert", "demo", notificationv1beta2.AlertSpec{
-		ProviderRef:  meta.LocalObjectReference{Name: provider.Name},
-		EventSources: []v1.CrossNamespaceObjectReference{{Kind: "Kustomization", Name: dep.Name, Namespace: dep.Namespace}},
-	})
-	receiver := fluxcd.CreateReceiver("demo-receiver", "demo", notificationv1beta2.ReceiverSpec{
-		Type:      notificationv1beta2.GitHubReceiver,
-		Resources: []v1.CrossNamespaceObjectReference{{Kind: "Kustomization", Name: dep.Name, Namespace: dep.Namespace}},
-		SecretRef: meta.LocalObjectReference{Name: "webhook-secret"},
-	})
+    // Notification controller examples
+    provider := fluxcd.CreateProvider("demo-provider", "demo", notificationv1beta2.ProviderSpec{Type: notificationv1beta2.SlackProvider})
+    alert := fluxcd.CreateAlert("demo-alert", "demo", notificationv1beta2.AlertSpec{
+        ProviderRef:  meta.LocalObjectReference{Name: provider.Name},
+        EventSources: []v1.CrossNamespaceObjectReference{{Kind: "Kustomization", Name: dep.Name, Namespace: dep.Namespace}},
+    })
+    receiver := fluxcd.CreateReceiver("demo-receiver", "demo", notificationv1beta2.ReceiverSpec{
+        Type:      notificationv1beta2.GitHubReceiver,
+        Resources: []v1.CrossNamespaceObjectReference{{Kind: "Kustomization", Name: dep.Name, Namespace: dep.Namespace}},
+        SecretRef: meta.LocalObjectReference{Name: "webhook-secret"},
+    })
 
-	// Image automation example
-	author := fluxcd.CreateCommitUser("Flux Bot", "bot@example.com")
-	commit := fluxcd.CreateCommitSpec(author)
-	gitSpec := fluxcd.CreateGitSpec(commit, nil, nil)
-	autoSpec := imagev1.ImageUpdateAutomationSpec{
-		SourceRef: fluxcd.CreateCrossNamespaceSourceReference("", "GitRepository", "demo-repo", "demo"),
-		Interval:  metav1.Duration{Duration: time.Minute},
-		GitSpec:   gitSpec,
-	}
-	auto := fluxcd.CreateImageUpdateAutomation("demo-auto", "demo", autoSpec)
-	fluxcd.SetImageUpdateAutomationSuspend(auto, false)
+    // Image automation example
+    author := fluxcd.CreateCommitUser("Flux Bot", "bot@example.com")
+    commit := fluxcd.CreateCommitSpec(author)
+    gitSpec := fluxcd.CreateGitSpec(commit, nil, nil)
+    autoSpec := imagev1.ImageUpdateAutomationSpec{
+        SourceRef: fluxcd.CreateCrossNamespaceSourceReference("", "GitRepository", "demo-repo", "demo"),
+        Interval:  metav1.Duration{Duration: time.Minute},
+        GitSpec:   gitSpec,
+    }
+    auto := fluxcd.CreateImageUpdateAutomation("demo-auto", "demo", autoSpec)
+    fluxcd.SetImageUpdateAutomationSuspend(auto, false)
 
-	// cert-manager examples
-	issuer := certmanager.CreateIssuer("demo-issuer", "demo", certv1.IssuerSpec{})
-	acme := certmanager.CreateACMEIssuer("https://acme.example.com", "ops@example.com",
-		cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: "acme-key"}})
-	certmanager.AddACMEIssuerSolver(acme, certmanager.CreateACMEHTTP01Solver(apiv1.ServiceTypeNodePort, "nginx"))
-	certmanager.SetIssuerACME(issuer, acme)
+    // cert-manager examples
+    issuer := certmanager.CreateIssuer("demo-issuer", "demo", certv1.IssuerSpec{})
+    acme := certmanager.CreateACMEIssuer("https://acme.example.com", "ops@example.com",
+        cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: "acme-key"}})
+    certmanager.AddACMEIssuerSolver(acme, certmanager.CreateACMEHTTP01Solver(apiv1.ServiceTypeNodePort, "nginx"))
+    certmanager.SetIssuerACME(issuer, acme)
 
-	certmanager.SetIssuerCA(issuer, &certv1.CAIssuer{SecretName: "ca-key"})
-	cert := certmanager.CreateCertificate("demo-cert", "demo", certv1.CertificateSpec{})
-	certmanager.AddCertificateDNSName(cert, "example.com")
-	certmanager.SetCertificateIssuerRef(cert, cmmeta.ObjectReference{Name: issuer.Name, Kind: "Issuer", Group: certmanagerapi.GroupName})
-	clusterIssuer := certmanager.CreateClusterIssuer("demo-clusterissuer", certv1.IssuerSpec{})
+    certmanager.SetIssuerCA(issuer, &certv1.CAIssuer{SecretName: "ca-key"})
+    cert := certmanager.CreateCertificate("demo-cert", "demo", certv1.CertificateSpec{})
+    certmanager.AddCertificateDNSName(cert, "example.com")
+    certmanager.SetCertificateIssuerRef(cert, cmmeta.ObjectReference{Name: issuer.Name, Kind: "Issuer", Group: certmanagerapi.GroupName})
+    clusterIssuer := certmanager.CreateClusterIssuer("demo-clusterissuer", certv1.IssuerSpec{})
 
-	// metallb examples
-	pool := metallb.CreateIPAddressPool("demo-pool", "demo", metallbv1beta1.IPAddressPoolSpec{Addresses: []string{"172.18.0.0/24"}})
-	logError("add ipaddresspool address", metallb.AddIPAddressPoolAddress(pool, "172.19.0.0/24"))
-	l2adv := metallb.CreateL2Advertisement("demo-l2adv", "demo", metallbv1beta1.L2AdvertisementSpec{})
-	logError("add l2advertisement ipaddresspool", metallb.AddL2AdvertisementIPAddressPool(l2adv, pool.Name))
-	bgpadv := metallb.CreateBGPAdvertisement("demo-bgpadv", "demo", metallbv1beta1.BGPAdvertisementSpec{})
-	logError("set bgpadvertisement localpref", metallb.SetBGPAdvertisementLocalPref(bgpadv, 100))
-	bgpPeer := metallb.CreateBGPPeer("demo-peer", "demo", metallbv1beta1.BGPPeerSpec{MyASN: 64512, ASN: 64512, Address: "10.0.0.2"})
-	bfd := metallb.CreateBFDProfile("demo-bfd", "demo", metallbv1beta1.BFDProfileSpec{})
+    // metallb examples
+    pool := metallb.CreateIPAddressPool("demo-pool", "demo", metallbv1beta1.IPAddressPoolSpec{Addresses: []string{"172.18.0.0/24"}})
+    logError("add ipaddresspool address", metallb.AddIPAddressPoolAddress(pool, "172.19.0.0/24"))
+    l2adv := metallb.CreateL2Advertisement("demo-l2adv", "demo", metallbv1beta1.L2AdvertisementSpec{})
+    logError("add l2advertisement ipaddresspool", metallb.AddL2AdvertisementIPAddressPool(l2adv, pool.Name))
+    bgpadv := metallb.CreateBGPAdvertisement("demo-bgpadv", "demo", metallbv1beta1.BGPAdvertisementSpec{})
+    logError("set bgpadvertisement localpref", metallb.SetBGPAdvertisementLocalPref(bgpadv, 100))
+    bgpPeer := metallb.CreateBGPPeer("demo-peer", "demo", metallbv1beta1.BGPPeerSpec{MyASN: 64512, ASN: 64512, Address: "10.0.0.2"})
+    bfd := metallb.CreateBFDProfile("demo-bfd", "demo", metallbv1beta1.BFDProfileSpec{})
 
-	// external-secrets examples
-	ss := externalsecrets.CreateSecretStore("demo-store", "demo", esv1.SecretStoreSpec{})
-	ssProvider := &esv1.SecretStoreProvider{AWS: &esv1.AWSProvider{Service: esv1.AWSServiceSecretsManager, Region: "us-east-1"}}
-	externalsecrets.SetSecretStoreProvider(ss, ssProvider)
-	css := externalsecrets.CreateClusterSecretStore("demo-css", esv1.SecretStoreSpec{})
-	externalsecrets.SetClusterSecretStoreProvider(css, ssProvider)
-	es := externalsecrets.CreateExternalSecret("demo-external", "demo", esv1.ExternalSecretSpec{})
-	externalsecrets.AddExternalSecretData(es, esv1.ExternalSecretData{SecretKey: "password", RemoteRef: esv1.ExternalSecretDataRemoteRef{Key: "db/password"}})
-	externalsecrets.SetExternalSecretSecretStoreRef(es, esv1.SecretStoreRef{Name: ss.Name})
+    // external-secrets examples
+    ss := externalsecrets.CreateSecretStore("demo-store", "demo", esv1.SecretStoreSpec{})
+    ssProvider := &esv1.SecretStoreProvider{AWS: &esv1.AWSProvider{Service: esv1.AWSServiceSecretsManager, Region: "us-east-1"}}
+    externalsecrets.SetSecretStoreProvider(ss, ssProvider)
+    css := externalsecrets.CreateClusterSecretStore("demo-css", esv1.SecretStoreSpec{})
+    externalsecrets.SetClusterSecretStoreProvider(css, ssProvider)
+    es := externalsecrets.CreateExternalSecret("demo-external", "demo", esv1.ExternalSecretSpec{})
+    externalsecrets.AddExternalSecretData(es, esv1.ExternalSecretData{SecretKey: "password", RemoteRef: esv1.ExternalSecretDataRemoteRef{Key: "db/password"}})
+    externalsecrets.SetExternalSecretSecretStoreRef(es, esv1.SecretStoreRef{Name: ss.Name})
 
-	// flux-operator examples
-	fi := fluxcd.CreateFluxInstance("flux", "flux-system", fluxv1.FluxInstanceSpec{
-		Distribution: fluxv1.Distribution{Version: "2.x", Registry: "ghcr.io/fluxcd"},
-	})
-	logError("add flux instance component", fluxcd.AddFluxInstanceComponent(fi, "source-controller"))
+    // flux-operator examples
+    fi := fluxcd.CreateFluxInstance("flux", "flux-system", fluxv1.FluxInstanceSpec{
+        Distribution: fluxv1.Distribution{Version: "2.x", Registry: "ghcr.io/fluxcd"},
+    })
+    logError("add flux instance component", fluxcd.AddFluxInstanceComponent(fi, "source-controller"))
 
-	fr := fluxcd.CreateFluxReport("flux", "flux-system", fluxv1.FluxReportSpec{
-		Distribution: fluxv1.FluxDistributionStatus{Entitlement: "oss", Status: "Running"},
-	})
+    fr := fluxcd.CreateFluxReport("flux", "flux-system", fluxv1.FluxReportSpec{
+        Distribution: fluxv1.FluxDistributionStatus{Entitlement: "oss", Status: "Running"},
+    })
 
-	rs := fluxcd.CreateResourceSet("demo-rs", "demo", fluxv1.ResourceSetSpec{})
-	logError("add resource set resource", fluxcd.AddResourceSetResource(rs, &apiextensionsv1.JSON{Raw: []byte("{}")}))
+    rs := fluxcd.CreateResourceSet("demo-rs", "demo", fluxv1.ResourceSetSpec{})
+    logError("add resource set resource", fluxcd.AddResourceSetResource(rs, &apiextensionsv1.JSON{Raw: []byte("{}")}))
 
-	prov := fluxcd.CreateResourceSetInputProvider("demo-rsip", "demo", fluxv1.ResourceSetInputProviderSpec{Type: fluxv1.InputProviderStatic})
-	logError("add resource set input provider schedule", fluxcd.AddResourceSetInputProviderSchedule(prov, fluxcd.CreateSchedule("@daily")))
+    prov := fluxcd.CreateResourceSetInputProvider("demo-rsip", "demo", fluxv1.ResourceSetInputProviderSpec{Type: fluxv1.InputProviderStatic})
+    logError("add resource set input provider schedule", fluxcd.AddResourceSetInputProviderSchedule(prov, fluxcd.CreateSchedule("@daily")))
 
-	// Print objects as YAML
-	objects := []runtime.Object{
-		sa, ns, secret, cm, pvc, pod, dep, sts, ds, job, cron, svc, ing,
-		role, roleBind, clusterRole, clusterRoleBind, hr, ks, gitRepo,
-		helmRepo, bucket, chart, ociRepo, pool, l2adv, bgpadv, bgpPeer,
-		bfd, ss, css, es, fi, fr, rs, prov, np, rq, lr, provider, alert,
-		receiver, auto, issuer, clusterIssuer, cert,
-	}
+    // Print objects as YAML
+    objects := []runtime.Object{
+        sa, ns, secret, cm, pvc, pod, dep, sts, ds, job, cron, svc, ing,
+        role, roleBind, clusterRole, clusterRoleBind, hr, ks, gitRepo,
+        helmRepo, bucket, chart, ociRepo, pool, l2adv, bgpadv, bgpPeer,
+        bfd, ss, css, es, fi, fr, rs, prov, np, rq, lr, provider, alert,
+        receiver, auto, issuer, clusterIssuer, cert,
+    }
 
-	for _, obj := range objects {
-		logError("failed to print YAML", y.PrintObj(obj, os.Stdout))
-	}
+    for _, obj := range objects {
+        logError("failed to print YAML", y.PrintObj(obj, os.Stdout))
+    }
 }
 
 func runAppWorkload() error {
-	file, err := os.Open("examples/app-workload.yaml")
-	if err != nil {
-		return err
-	}
-	defer func(file *os.File) {
-		err := file.Close()
-		if err != nil {
+    file, err := os.Open("examples/app-workload.yaml")
+    if err != nil {
+        return err
+    }
+    defer func(file *os.File) {
+        err := file.Close()
+        if err != nil {
 
-		}
-	}(file)
+        }
+    }(file)
 
-	dec := yaml.NewDecoder(file)
-	var apps []*stack.Application
-	for {
-		var cfg stack.AppWorkloadConfig
-		if err := dec.Decode(&cfg); err != nil {
-			if err == io.EOF {
-				break
-			}
-			return err
-		}
-		app := stack.NewApplication(cfg.Name, cfg.Namespace, &cfg)
-		apps = append(apps, app)
-	}
+    dec := yaml.NewDecoder(file)
+    var apps []*stack.Application
+    for {
+        var cfg k8s.AppWorkloadConfig
+        if err := dec.Decode(&cfg); err != nil {
+            if err == io.EOF {
+                break
+            }
+            return err
+        }
+        app := stack.NewApplication(cfg.Name, cfg.Namespace, &cfg)
+        apps = append(apps, app)
+    }
 
-	bundle, err := stack.NewBundle("example", apps, nil)
-	if err != nil {
-		return err
-	}
-	err = bundle.Validate()
-	if err != nil {
-		return err
-	}
-	resources, err := bundle.Generate()
-	if err != nil {
-		return err
-	}
+    bundle, err := stack.NewBundle("example", apps, nil)
+    if err != nil {
+        return err
+    }
+    err = bundle.Validate()
+    if err != nil {
+        return err
+    }
+    resources, err := bundle.Generate()
+    if err != nil {
+        return err
+    }
 
-	out, err := kio.EncodeObjectsToYAML(resources)
-	if err != nil {
-		return err
-	}
-	_, err = os.Stdout.Write(out)
-	if err == nil {
-		_, err = os.Stdout.Write([]byte("\n"))
-	}
-	return err
+    out, err := kio.EncodeObjectsToYAML(resources)
+    if err != nil {
+        return err
+    }
+    _, err = os.Stdout.Write(out)
+    if err == nil {
+        _, err = os.Stdout.Write([]byte("\n"))
+    }
+    return err
 }
 
 func runClusterExample() error {
-	file, err := os.Open("examples/cluster/cluster.yaml")
-	if err != nil {
-		return err
-	}
-	defer func(f *os.File) {
-		_ = f.Close()
-	}(file)
+    file, err := os.Open("examples/cluster/cluster.yaml")
+    if err != nil {
+        return err
+    }
+    defer func(f *os.File) {
+        _ = f.Close()
+    }(file)
 
-	dec := yaml.NewDecoder(file)
-	var cl stack.Cluster
-	if err := dec.Decode(&cl); err != nil {
-		return err
-	}
-	if cl.Node == nil {
-		return nil
-	}
+    dec := yaml.NewDecoder(file)
+    var cl stack.Cluster
+    if err := dec.Decode(&cl); err != nil {
+        return err
+    }
+    if cl.Node == nil {
+        return nil
+    }
 
-	baseDir := "examples/cluster"
-	for _, child := range cl.Node.Children {
-		child.Parent = cl.Node
-		dir := filepath.Join(baseDir, child.Name)
-		entries, err := os.ReadDir(dir)
-		if err != nil {
-			return err
-		}
-		for _, entry := range entries {
-			if entry.IsDir() {
-				continue
-			}
-			ext := filepath.Ext(entry.Name())
-			if ext != ".yaml" && ext != ".yml" {
-				continue
-			}
-			fp := filepath.Join(dir, entry.Name())
-			f, err := os.Open(fp)
-			if err != nil {
-				return err
-			}
-			dec := yaml.NewDecoder(f)
-			for {
-				var cfg stack.AppWorkloadConfig
-				if err := dec.Decode(&cfg); err != nil {
-					if err == io.EOF {
-						break
-					}
-					_ = f.Close()
-					return err
-				}
-				app := stack.NewApplication(cfg.Name, cfg.Namespace, &cfg)
-				bundle, err := stack.NewBundle(cfg.Name, []*stack.Application{app}, nil)
-				if err != nil {
-					_ = f.Close()
-					return err
-				}
-				node := &stack.Node{Name: cfg.Name, Parent: child, Bundle: bundle}
-				child.Children = append(child.Children, node)
-			}
-			_ = f.Close()
-		}
-	}
+    baseDir := "examples/cluster"
+    for _, child := range cl.Node.Children {
+        child.Parent = cl.Node
+        dir := filepath.Join(baseDir, child.Name)
+        entries, err := os.ReadDir(dir)
+        if err != nil {
+            return err
+        }
+        for _, entry := range entries {
+            if entry.IsDir() {
+                continue
+            }
+            ext := filepath.Ext(entry.Name())
+            if ext != ".yaml" && ext != ".yml" {
+                continue
+            }
+            fp := filepath.Join(dir, entry.Name())
+            f, err := os.Open(fp)
+            if err != nil {
+                return err
+            }
+            dec := yaml.NewDecoder(f)
+            for {
+                var cfg k8s.AppWorkloadConfig
+                if err := dec.Decode(&cfg); err != nil {
+                    if err == io.EOF {
+                        break
+                    }
+                    _ = f.Close()
+                    return err
+                }
+                app := stack.NewApplication(cfg.Name, cfg.Namespace, &cfg)
+                bundle, err := stack.NewBundle(cfg.Name, []*stack.Application{app}, nil)
+                if err != nil {
+                    _ = f.Close()
+                    return err
+                }
+                node := &stack.Node{Name: cfg.Name, Parent: child, Bundle: bundle}
+                child.Children = append(child.Children, node)
+            }
+            _ = f.Close()
+        }
+    }
 
-	out, err := yaml.Marshal(&cl)
-	if err != nil {
-		return err
-	}
-	_, err = os.Stdout.Write(out)
-	if err == nil {
-		_, err = os.Stdout.Write([]byte("\n"))
-	}
-	return err
+    out, err := yaml.Marshal(&cl)
+    if err != nil {
+        return err
+    }
+    _, err = os.Stdout.Write(out)
+    if err == nil {
+        _, err = os.Stdout.Write([]byte("\n"))
+    }
+    return err
 }

--- a/cmd/stack/main.go
+++ b/cmd/stack/main.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	kio "github.com/go-kure/kure/pkg/io"
+	"github.com/go-kure/kure/pkg/k8s"
+	"github.com/go-kure/kure/pkg/layout"
+	"github.com/go-kure/kure/pkg/stack"
+	fluxstack "github.com/go-kure/kure/pkg/stack/fluxcd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func main() {
+	baseDir := flag.String("base", "examples/cluster", "path to cluster example")
+	flag.Parse()
+
+	cl, err := loadCluster(*baseDir)
+	if err != nil {
+		log.Fatalf("load cluster: %v", err)
+	}
+
+	// walk cluster to build manifest layout
+	rules := layout.LayoutRules{BundleGrouping: layout.GroupFlat, ApplicationGrouping: layout.GroupFlat}
+	ml, err := layout.WalkCluster(cl, rules)
+	if err != nil {
+		log.Fatalf("walk cluster: %v", err)
+	}
+
+	// write manifests to a temporary directory
+	tempDir, err := os.MkdirTemp("", "stack-demo-")
+	if err != nil {
+		log.Fatalf("create temp dir: %v", err)
+	}
+	cfg := layout.DefaultLayoutConfig()
+	if err := layout.WriteManifest(tempDir, cfg, ml); err != nil {
+		log.Fatalf("write manifests: %v", err)
+	}
+	log.Printf("manifests written to %s", tempDir)
+
+	// build Flux kustomizations from the cluster
+	wf := fluxstack.NewWorkflow()
+	fluxObjs, err := wf.Cluster(cl)
+	if err != nil {
+		log.Fatalf("flux workflow: %v", err)
+	}
+	var ptrs []*client.Object
+	for _, obj := range fluxObjs {
+		o := obj
+		ptrs = append(ptrs, &o)
+	}
+	out, err := kio.EncodeObjectsToYAML(ptrs)
+	if err != nil {
+		log.Fatalf("encode flux objects: %v", err)
+	}
+	os.Stdout.Write(out)
+}
+
+func loadCluster(baseDir string) (*stack.Cluster, error) {
+	file, err := os.Open(filepath.Join(baseDir, "cluster.yaml"))
+	if err != nil {
+		return nil, err
+	}
+	defer func(f *os.File) { _ = f.Close() }(file)
+
+	dec := yaml.NewDecoder(file)
+	var cl stack.Cluster
+	if err := dec.Decode(&cl); err != nil {
+		return nil, err
+	}
+	if cl.Node == nil {
+		return &cl, nil
+	}
+
+	for _, child := range cl.Node.Children {
+		child.Parent = cl.Node
+		dir := filepath.Join(baseDir, child.Name)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			ext := filepath.Ext(entry.Name())
+			if ext != ".yaml" && ext != ".yml" {
+				continue
+			}
+			fp := filepath.Join(dir, entry.Name())
+			f, err := os.Open(fp)
+			if err != nil {
+				return nil, err
+			}
+			dec := yaml.NewDecoder(f)
+			for {
+				var cfg k8s.AppWorkloadConfig
+				if err := dec.Decode(&cfg); err != nil {
+					if err == io.EOF {
+						break
+					}
+					_ = f.Close()
+					return nil, err
+				}
+				app := stack.NewApplication(cfg.Name, cfg.Namespace, &cfg)
+				bundle, err := stack.NewBundle(cfg.Name, []*stack.Application{app}, nil)
+				if err != nil {
+					_ = f.Close()
+					return nil, err
+				}
+				if err := bundle.Validate(); err != nil {
+					_ = f.Close()
+					return nil, err
+				}
+				node := &stack.Node{Name: cfg.Name, Parent: child, Bundle: bundle}
+				child.Children = append(child.Children, node)
+			}
+			_ = f.Close()
+		}
+	}
+
+	return &cl, nil
+}

--- a/pkg/k8s/appworkload_test.go
+++ b/pkg/k8s/appworkload_test.go
@@ -1,4 +1,4 @@
-package stack
+package k8s
 
 import (
 	"testing"
@@ -6,6 +6,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+
+	"github.com/go-kure/kure/pkg/stack"
 )
 
 // TestContainerConfigGenerate verifies ports and volume mounts are propagated.
@@ -39,7 +41,7 @@ func TestAppWorkloadGenerate(t *testing.T) {
 			}},
 		}
 	}
-	app := NewApplication("app", "ns", nil)
+	app := stack.NewApplication("app", "ns", nil)
 
 	// Deployment with service and ingress
 	depCfg := newBase()

--- a/pkg/layout/grouping_test.go
+++ b/pkg/layout/grouping_test.go
@@ -1,0 +1,89 @@
+package layout_test
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/kure/pkg/layout"
+	"github.com/go-kure/kure/pkg/stack"
+)
+
+// buildTestCluster constructs a simple cluster with one node, bundle and application.
+func buildTestCluster() *stack.Cluster {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("v1")
+	obj.SetKind("ConfigMap")
+	obj.SetName("cm")
+	obj.SetNamespace("default")
+	var o client.Object = obj
+
+	app := stack.NewApplication("app", "ns", &fakeConfig{objs: []*client.Object{&o}})
+	bundle := &stack.Bundle{Name: "bundle", Applications: []*stack.Application{app}}
+	node := &stack.Node{Name: "apps", Bundle: bundle}
+	root := &stack.Node{Name: "root", Children: []*stack.Node{node}}
+	node.Parent = root
+	return &stack.Cluster{Name: "demo", Node: root}
+}
+
+func TestWalkClusterGroupingCombinations(t *testing.T) {
+	type testCase struct {
+		name     string
+		rules    layout.LayoutRules
+		nodeOnly bool
+	}
+
+	modes := []layout.GroupingMode{layout.GroupByName, layout.GroupFlat}
+	var tests []testCase
+	for _, ng := range modes {
+		for _, bg := range modes {
+			for _, ag := range modes {
+				tc := testCase{
+					name:     string(ng) + "_" + string(bg) + "_" + string(ag),
+					rules:    layout.LayoutRules{NodeGrouping: ng, BundleGrouping: bg, ApplicationGrouping: ag},
+					nodeOnly: bg == layout.GroupFlat && ag == layout.GroupFlat,
+				}
+				tests = append(tests, tc)
+			}
+		}
+	}
+
+	cluster := buildTestCluster()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ml, err := layout.WalkCluster(cluster, tc.rules)
+			if err != nil {
+				t.Fatalf("walk cluster: %v", err)
+			}
+			if len(ml.Children) != 1 {
+				t.Fatalf("expected one child, got %d", len(ml.Children))
+			}
+			nodeLayout := ml.Children[0]
+			if tc.nodeOnly {
+				if len(nodeLayout.Resources) != 1 {
+					t.Fatalf("expected resources at node, got %d", len(nodeLayout.Resources))
+				}
+				if len(nodeLayout.Children) != 0 {
+					t.Fatalf("unexpected children: %d", len(nodeLayout.Children))
+				}
+			} else {
+				if len(nodeLayout.Resources) != 0 {
+					t.Fatalf("unexpected node resources: %d", len(nodeLayout.Resources))
+				}
+				if len(nodeLayout.Children) != 1 {
+					t.Fatalf("expected bundle child, got %d", len(nodeLayout.Children))
+				}
+				bundleLayout := nodeLayout.Children[0]
+				if len(bundleLayout.Children) != 1 {
+					t.Fatalf("expected application child, got %d", len(bundleLayout.Children))
+				}
+				appLayout := bundleLayout.Children[0]
+				if len(appLayout.Resources) != 1 {
+					t.Fatalf("expected application resources, got %d", len(appLayout.Resources))
+				}
+			}
+		})
+	}
+}

--- a/pkg/layout/profile.go
+++ b/pkg/layout/profile.go
@@ -6,28 +6,28 @@ import "fmt"
 type Profile string
 
 const (
-    // FluxProfile represents defaults matching FluxCD conventions.
-    FluxProfile Profile = "flux"
-    // ArgoProfile represents defaults matching Argo CD conventions.
-    ArgoProfile Profile = "argocd"
+	// FluxProfile represents defaults matching FluxCD conventions.
+	FluxProfile Profile = "flux"
+	// ArgoProfile represents defaults matching Argo CD conventions.
+	ArgoProfile Profile = "argocd"
 )
 
 // DefaultConfigForProfile returns a Config initialised with defaults for the
 // given profile. Unknown profiles fall back to FluxProfile.
 func DefaultConfigForProfile(p Profile) Config {
-    switch p {
-    case ArgoProfile:
-        return Config{
-            ManifestsDir:        "applications",
-            FluxDir:             "applications",
-            FilePer:             FilePerResource,
-            ApplicationFileMode: AppFileSingle,
-            ManifestFileName:    DefaultManifestFileName,
-            KustomizationFileName: func(name string) string {
-                return fmt.Sprintf("application-%s.yaml", name)
-            },
-        }
-    default:
-        return DefaultLayoutConfig()
-    }
+	switch p {
+	case ArgoProfile:
+		return Config{
+			ManifestsDir:        "applications",
+			FluxDir:             "applications",
+			FilePer:             FilePerResource,
+			ApplicationFileMode: AppFileSingle,
+			ManifestFileName:    DefaultManifestFileName,
+			KustomizationFileName: func(name string) string {
+				return fmt.Sprintf("application-%s.yaml", name)
+			},
+		}
+	default:
+		return DefaultLayoutConfig()
+	}
 }


### PR DESCRIPTION
## Summary
- document stack architecture and workflow in STACK.md
- add cmd/stack example that renders the sample cluster and Flux Kustomizations

## Testing
- `go run ./cmd/stack`
- `go test ./...` *(fails: import cycle in pkg/stack)*

------
https://chatgpt.com/codex/tasks/task_e_688ceb1ad67c832fab3503e9dd2f68f1