### PR TITLE
feat(ci): add auto-rebase workflow and rebase-check job

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -92,7 +92,7 @@ git push -u origin <type>/<description>
 gh pr create
 ```
 
-Required checks: `lint`, `test`, `build`. See `AGENTS.md` § Git Workflow for full details.
+Required checks: `lint`, `test`, `build`, `rebase-check`. Branches are automatically rebased when main is updated. See `AGENTS.md` § Git Workflow for full details.
 
 ## Quick Commands
 

--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -1,0 +1,28 @@
+name: Auto-Rebase
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auto-rebase
+  cancel-in-progress: true
+
+jobs:
+  auto-rebase:
+    name: auto-rebase
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.repository == 'go-kure/kure'
+
+    steps:
+      - name: Rebase open PRs
+        uses: peter-evans/rebase@v4
+        with:
+          token: ${{ secrets.AUTO_REBASE_PAT }}
+          base: main
+          exclude-labels: dependencies
+          exclude-drafts: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,32 @@ concurrency:
 
 jobs:
   # =============================================================================
+  # Pre-flight: Rebase Freshness Check
+  # =============================================================================
+
+  rebase-check:
+    name: rebase-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    if: github.event_name == 'pull_request'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+
+    - name: Check branch is rebased on main
+      run: |
+        git fetch origin main
+        if ! git merge-base --is-ancestor origin/main HEAD; then
+          echo "::error::Branch is not rebased on latest main. Please run: git rebase origin/main"
+          exit 1
+        fi
+        echo "Branch is up to date with main."
+
+  # =============================================================================
   # Stage 1: Fast Validation
   # =============================================================================
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,8 @@ make precommit
   git checkout -b <type>/<description> main
   ```
 - **Branch prefixes**: `feat/`, `fix/`, `docs/`, `chore/`
-- **Required CI checks** that must pass: `lint`, `test`, `build`
+- **Required CI checks** that must pass: `lint`, `test`, `build`, `rebase-check`
+- **Auto-rebase**: open PRs are automatically rebased when main is updated
 - **1 approving review** required
 - **Linear history** enforced — rebase only, no merge commits
 - **All conversations** must be resolved before merge

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -48,7 +48,8 @@ The `main` branch is protected — all changes must go through pull requests.
 
 ### Branch Protection Rules
 
-- **Required status checks** (strict): `lint`, `test`, `build`
+- **Required status checks** (strict): `lint`, `test`, `build`, `rebase-check`
+- **Auto-rebase**: open PRs are automatically rebased when main is updated (via `auto-rebase.yml`)
 - **Required reviews**: 1 approving review
 - **Linear history**: enforced (rebase only, no merge commits)
 - **Conversation resolution**: all conversations must be resolved
@@ -201,6 +202,13 @@ The project uses several GitHub Actions workflows:
 - **Triggers**: Push, PRs
 - **Purpose**: Static analysis with JetBrains Qodana
 - **Uses**: `make deps` for setup
+
+### Auto-Rebase (`.github/workflows/auto-rebase.yml`)
+- **Triggers**: Push to main
+- **Purpose**: Automatically rebases all open PRs targeting main
+- **Uses**: `peter-evans/rebase@v4`
+- **Excludes**: Dependabot PRs (`dependencies` label), draft PRs
+- **Auth**: Requires `AUTO_REBASE_PAT` secret (PAT needed to trigger CI on rebased branches)
 
 ### Release Pipeline (`.github/workflows/release.yml`)
 - **Triggers**: Version tags (`v*.*.*`)


### PR DESCRIPTION
## Summary

- Add `auto-rebase.yml` workflow: rebases all open PRs when main is updated using `peter-evans/rebase@v4`
- Add `rebase-check` job to CI: verifies PR branches are current with main (mirrors GitLab rebase-check template)
- Update documentation: github-workflows.md, AGENTS.md, CLAUDE.md, DEVELOPMENT.md

## Manual Setup Required

Before auto-rebase will work, an admin must:

1. Create a **fine-grained PAT** (GitHub Settings > Developer settings)
   - Repository: `go-kure/kure` only
   - Permissions: `Contents: Read+Write`, `Pull requests: Read`
2. Add it as repository secret `AUTO_REBASE_PAT`

A PAT is needed because pushes with GITHUB_TOKEN do not trigger workflow runs.

## Test plan

- [ ] Verify GitHub Actions tab shows no syntax errors for both workflows
- [ ] Verify `rebase-check` job appears as a check on this PR and passes
- [ ] After merge + PAT setup: verify auto-rebase runs when a subsequent PR merges to main