### PR TITLE
chore: use individual usernames in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @go-kure/maintainers
+* @srgvg @vincentvdk


### PR DESCRIPTION
## Summary
- Replace team reference (`@go-kure/maintainers`) with individual GitHub usernames (`@srgvg @vincentvdk`)
- Individual usernames are clearer for a small team
- CODEOWNERS auto-assigns reviewers but does not block merges (since `required_pull_request_reviews` is disabled in branch protection)

## Test plan
- [ ] Verify CODEOWNERS syntax is valid (GitHub shows no warnings on PR)
- [ ] Confirm reviewers are auto-assigned on new PRs