### PR TITLE
feat(io): add deterministic YAML serialization option

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,19 +34,15 @@
       "Bash(yq:*)",
       "Bash(./scripts/github-settings.sh:*)",
       "Bash(python3:*)",
-      "Bash(for issue in 173 174 176 177)",
-      "Bash(do echo \"Assigning issue #$issue to milestone 1...\")",
-      "Bash(done)",
-      "Bash(for issue in 175 178 179 180)",
-      "Bash(do echo \"Assigning issue #$issue to milestone 2...\")",
-      "Bash(for issue in 128 129 133)",
-      "Bash(do echo \"Assigning issue #$issue to milestone 3...\")",
-      "Bash(for issue in 128 129 133 134 135 136 137 138 139 140 141 142 143 144 145 146 173 174 175 176 177 178 179 180)",
-      "Bash(do)",
-      "Bash(for issue in 173 174)",
-      "Bash(__NEW_LINE_02ad66f24dece53b__ echo \"\")",
-      "Bash(for issue in 176 177)",
-      "Bash(go doc:*)"
+      "Bash(git -C /home/serge/src/autops/wharf/kure log --oneline -10)",
+      "Bash(git -C /home/serge/src/autops/wharf/kure log --oneline --all)",
+      "Bash(git -C /home/serge/src/autops/wharf/kure rebase main)",
+      "Bash(git -C /home/serge/src/autops/wharf/kure push --force-with-lease)",
+      "Bash(go list:*)",
+      "Bash(go run:*)",
+      "Bash(go env:*)",
+      "Bash(git pull:*)",
+      "Bash(go vet:*)"
     ]
   },
   "outputStyle": "default"

--- a/pkg/io/README.md
+++ b/pkg/io/README.md
@@ -53,6 +53,15 @@ yamlData, err := io.EncodeObjectsToYAML(objects)
 jsonData, err := io.EncodeObjectsToJSON(objects)
 ```
 
+### Deterministic Field Ordering
+
+```go
+// Encode with Kubernetes-conventional field ordering
+opts := io.EncodeOptions{KubernetesFieldOrder: true}
+yamlData, err := io.EncodeObjectsToYAMLWithOptions(objects, opts)
+// Output: apiVersion, kind, metadata, spec, ... status (last)
+```
+
 ## Printing
 
 ### Output Formats

--- a/pkg/io/doc.go
+++ b/pkg/io/doc.go
@@ -74,6 +74,14 @@
 //	io.PrintObjectsAsJSON(resources, os.Stdout)
 //	io.PrintObjectsAsTable(resources, wide, noHeaders, os.Stdout)
 //
+// # Deterministic field ordering
+//
+// [EncodeObjectsToYAMLWithOptions] accepts [EncodeOptions] to control YAML
+// output. When KubernetesFieldOrder is true, top-level fields are emitted in
+// the conventional order used by kubectl, Helm, and Kustomize:
+// apiVersion, kind, metadata, spec, data, stringData, then remaining fields
+// alphabetically, with status last.
+//
 // The package forms the foundation for the other packages within this
 // repository but can be imported directly by any program that requires
 // lightweight YAML handling, runtime object parsing, and kubectl-compatible

--- a/pkg/io/order.go
+++ b/pkg/io/order.go
@@ -1,0 +1,181 @@
+package io
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+)
+
+// EncodeOptions controls how Kubernetes objects are serialized to YAML.
+type EncodeOptions struct {
+	// KubernetesFieldOrder emits top-level resource keys in the
+	// conventional order used by kubectl, Helm, and Kustomize:
+	// apiVersion, kind, metadata, spec, data, stringData, type,
+	// then remaining keys alphabetically, with status last.
+	// Nested maps remain alphabetically sorted.
+	KubernetesFieldOrder bool
+}
+
+// kubernetesKeyPriority maps well-known top-level Kubernetes resource
+// fields to their conventional emission order.
+var kubernetesKeyPriority = map[string]int{
+	"apiVersion": 0,
+	"kind":       1,
+	"metadata":   2,
+	"spec":       3,
+	"data":       4,
+	"stringData": 5,
+	"type":       6,
+	// "status" handled separately as 999
+}
+
+const (
+	priorityDefault = 100
+	priorityStatus  = 999
+)
+
+// marshalOrderedYAML converts a cleaned resource map to YAML bytes with
+// top-level keys in Kubernetes-conventional order.
+func marshalOrderedYAML(m map[string]interface{}) ([]byte, error) {
+	node := mapToNode(m, true)
+	doc := &yaml.Node{
+		Kind:    yaml.DocumentNode,
+		Content: []*yaml.Node{node},
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(doc); err != nil {
+		return nil, fmt.Errorf("failed to encode ordered YAML: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close YAML encoder: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// mapToNode builds a yaml.v3 MappingNode from a map. When topLevel is
+// true, keys are ordered per Kubernetes conventions; otherwise keys are
+// sorted alphabetically.
+func mapToNode(m map[string]interface{}, topLevel bool) *yaml.Node {
+	node := &yaml.Node{
+		Kind: yaml.MappingNode,
+	}
+	keys := sortedKeys(m, topLevel)
+	for _, k := range keys {
+		keyNode := &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: k,
+			Tag:   "!!str",
+		}
+		valNode := valueToNode(m[k])
+		node.Content = append(node.Content, keyNode, valNode)
+	}
+	return node
+}
+
+// valueToNode converts a value produced by json.Unmarshal into interface{}
+// to a yaml.v3 Node.
+func valueToNode(v interface{}) *yaml.Node {
+	switch val := v.(type) {
+	case nil:
+		return &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: "null",
+			Tag:   "!!null",
+		}
+	case bool:
+		s := "false"
+		if val {
+			s = "true"
+		}
+		return &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: s,
+			Tag:   "!!bool",
+		}
+	case float64:
+		return floatToNode(val)
+	case string:
+		return &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: val,
+			Tag:   "!!str",
+		}
+	case []interface{}:
+		node := &yaml.Node{
+			Kind: yaml.SequenceNode,
+		}
+		for _, item := range val {
+			node.Content = append(node.Content, valueToNode(item))
+		}
+		return node
+	case map[string]interface{}:
+		return mapToNode(val, false)
+	default:
+		// Fallback: render as string
+		return &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: fmt.Sprintf("%v", val),
+			Tag:   "!!str",
+		}
+	}
+}
+
+// floatToNode converts a float64 to a yaml.v3 ScalarNode, rendering
+// integer-valued floats without a decimal point (e.g. 8080 not 8080.0).
+func floatToNode(f float64) *yaml.Node {
+	if f == math.Trunc(f) && !math.IsInf(f, 0) && !math.IsNaN(f) {
+		return &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: fmt.Sprintf("%.0f", f),
+			Tag:   "!!int",
+		}
+	}
+	return &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Value: strconv.FormatFloat(f, 'g', -1, 64),
+		Tag:   "!!float",
+	}
+}
+
+// sortedKeys returns the keys of m in the appropriate order.
+// When topLevel is true, well-known Kubernetes fields are sorted by
+// their conventional priority; remaining keys are sorted alphabetically
+// and status is always last. When topLevel is false, all keys are
+// sorted alphabetically.
+func sortedKeys(m map[string]interface{}, topLevel bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	if !topLevel {
+		sort.Strings(keys)
+		return keys
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		pi := keyPriority(keys[i])
+		pj := keyPriority(keys[j])
+		if pi != pj {
+			return pi < pj
+		}
+		return keys[i] < keys[j]
+	})
+	return keys
+}
+
+// keyPriority returns the sort weight for a top-level Kubernetes field.
+func keyPriority(key string) int {
+	if key == "status" {
+		return priorityStatus
+	}
+	if p, ok := kubernetesKeyPriority[key]; ok {
+		return p
+	}
+	return priorityDefault
+}

--- a/pkg/io/order_test.go
+++ b/pkg/io/order_test.go
@@ -1,0 +1,335 @@
+package io
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+func TestSortedKeysKubernetesOrder(t *testing.T) {
+	m := map[string]interface{}{
+		"status":     map[string]interface{}{},
+		"spec":       map[string]interface{}{},
+		"metadata":   map[string]interface{}{},
+		"kind":       "Deployment",
+		"apiVersion": "apps/v1",
+		"extra":      "value",
+		"another":    "value",
+	}
+
+	keys := sortedKeys(m, true)
+	expected := []string{"apiVersion", "kind", "metadata", "spec", "another", "extra", "status"}
+
+	if len(keys) != len(expected) {
+		t.Fatalf("expected %d keys, got %d: %v", len(expected), len(keys), keys)
+	}
+	for i, k := range expected {
+		if keys[i] != k {
+			t.Errorf("position %d: expected %q, got %q (full order: %v)", i, k, keys[i], keys)
+		}
+	}
+}
+
+func TestSortedKeysAlphabetical(t *testing.T) {
+	m := map[string]interface{}{
+		"zebra":  1,
+		"alpha":  2,
+		"middle": 3,
+	}
+
+	keys := sortedKeys(m, false)
+	expected := []string{"alpha", "middle", "zebra"}
+
+	if len(keys) != len(expected) {
+		t.Fatalf("expected %d keys, got %d: %v", len(expected), len(keys), keys)
+	}
+	for i, k := range expected {
+		if keys[i] != k {
+			t.Errorf("position %d: expected %q, got %q", i, k, keys[i])
+		}
+	}
+}
+
+func TestValueToNode(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		wantTag  string
+		wantVal  string
+		wantKind int
+	}{
+		{"nil", nil, "!!null", "null", 8}, // yaml.ScalarNode == 8
+		{"bool true", true, "!!bool", "true", 8},
+		{"bool false", false, "!!bool", "false", 8},
+		{"integer float", float64(8080), "!!int", "8080", 8},
+		{"fractional float", float64(3.14), "!!float", "3.14", 8},
+		{"high precision float", float64(0.123456789), "!!float", "0.123456789", 8},
+		{"string", "hello", "!!str", "hello", 8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := valueToNode(tt.input)
+			if node.Tag != tt.wantTag {
+				t.Errorf("tag: got %q, want %q", node.Tag, tt.wantTag)
+			}
+			if node.Value != tt.wantVal {
+				t.Errorf("value: got %q, want %q", node.Value, tt.wantVal)
+			}
+		})
+	}
+
+	// Test slice
+	t.Run("slice", func(t *testing.T) {
+		node := valueToNode([]interface{}{"a", "b"})
+		if node.Kind != yaml.SequenceNode {
+			t.Errorf("expected SequenceNode (%d), got kind %d", yaml.SequenceNode, node.Kind)
+		}
+		if len(node.Content) != 2 {
+			t.Errorf("expected 2 items, got %d", len(node.Content))
+		}
+	})
+
+	// Test nested map
+	t.Run("nested map", func(t *testing.T) {
+		node := valueToNode(map[string]interface{}{"key": "val"})
+		if node.Kind != yaml.MappingNode {
+			t.Errorf("expected MappingNode (%d), got kind %d", yaml.MappingNode, node.Kind)
+		}
+	})
+}
+
+func TestMarshalOrderedYAML_Deployment(t *testing.T) {
+	m := map[string]interface{}{
+		"status":     map[string]interface{}{},
+		"spec":       map[string]interface{}{"replicas": float64(3)},
+		"metadata":   map[string]interface{}{"name": "test", "namespace": "default"},
+		"kind":       "Deployment",
+		"apiVersion": "apps/v1",
+	}
+
+	out, err := marshalOrderedYAML(m)
+	if err != nil {
+		t.Fatalf("marshalOrderedYAML: %v", err)
+	}
+
+	s := string(out)
+	lines := strings.Split(s, "\n")
+
+	// Verify first four keys appear in order
+	expectedOrder := []string{"apiVersion:", "kind:", "metadata:", "spec:", "status:"}
+	idx := 0
+	for _, line := range lines {
+		if idx < len(expectedOrder) && strings.HasPrefix(strings.TrimSpace(line), expectedOrder[idx]) {
+			idx++
+		}
+	}
+	if idx != len(expectedOrder) {
+		t.Errorf("expected keys in order %v, only found %d in output:\n%s", expectedOrder, idx, s)
+	}
+}
+
+func TestMarshalOrderedYAML_ConfigMap(t *testing.T) {
+	m := map[string]interface{}{
+		"data":       map[string]interface{}{"key": "value"},
+		"metadata":   map[string]interface{}{"name": "cm"},
+		"kind":       "ConfigMap",
+		"apiVersion": "v1",
+		"status":     map[string]interface{}{"phase": "Active"},
+	}
+
+	out, err := marshalOrderedYAML(m)
+	if err != nil {
+		t.Fatalf("marshalOrderedYAML: %v", err)
+	}
+
+	s := string(out)
+
+	// data should come after metadata and before status
+	dataIdx := strings.Index(s, "data:")
+	metadataIdx := strings.Index(s, "metadata:")
+	statusIdx := strings.Index(s, "status:")
+
+	if metadataIdx >= dataIdx {
+		t.Errorf("metadata should come before data:\n%s", s)
+	}
+	if dataIdx >= statusIdx {
+		t.Errorf("data should come before status:\n%s", s)
+	}
+}
+
+func TestMarshalOrderedYAML_NestedAlphabetical(t *testing.T) {
+	m := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"namespace": "default",
+			"name":      "test",
+			"labels": map[string]interface{}{
+				"zebra": "z",
+				"alpha": "a",
+			},
+		},
+	}
+
+	out, err := marshalOrderedYAML(m)
+	if err != nil {
+		t.Fatalf("marshalOrderedYAML: %v", err)
+	}
+
+	s := string(out)
+
+	// Inside metadata, labels should come before name, name before namespace (alphabetical)
+	labelsIdx := strings.Index(s, "labels:")
+	nameIdx := strings.Index(s, "name:")
+	namespaceIdx := strings.Index(s, "namespace:")
+
+	if labelsIdx >= nameIdx {
+		t.Errorf("labels should come before name (alphabetical):\n%s", s)
+	}
+	if nameIdx >= namespaceIdx {
+		t.Errorf("name should come before namespace (alphabetical):\n%s", s)
+	}
+
+	// Inside labels, alpha should come before zebra
+	alphaIdx := strings.Index(s, "alpha:")
+	zebraIdx := strings.Index(s, "zebra:")
+	if alphaIdx >= zebraIdx {
+		t.Errorf("alpha should come before zebra (alphabetical):\n%s", s)
+	}
+}
+
+func TestMarshalOrderedYAML_Deterministic(t *testing.T) {
+	m := map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name":      "test",
+			"namespace": "default",
+			"labels": map[string]interface{}{
+				"app":     "test",
+				"version": "v1",
+			},
+		},
+		"spec": map[string]interface{}{
+			"replicas": float64(3),
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{
+					"app": "test",
+				},
+			},
+		},
+		"status": map[string]interface{}{},
+	}
+
+	first, err := marshalOrderedYAML(m)
+	if err != nil {
+		t.Fatalf("first marshal: %v", err)
+	}
+
+	for i := 0; i < 100; i++ {
+		out, err := marshalOrderedYAML(m)
+		if err != nil {
+			t.Fatalf("marshal iteration %d: %v", i, err)
+		}
+		if string(out) != string(first) {
+			t.Fatalf("non-deterministic output at iteration %d:\nfirst:\n%s\ngot:\n%s", i, first, out)
+		}
+	}
+}
+
+func TestMarshalOrderedYAML_RoundTrip(t *testing.T) {
+	original := map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name":      "test",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"replicas": float64(3),
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "app",
+							"image": "nginx:latest",
+							"ports": []interface{}{
+								map[string]interface{}{
+									"containerPort": float64(8080),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out, err := marshalOrderedYAML(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var roundTripped map[string]interface{}
+	if err := sigsyaml.Unmarshal(out, &roundTripped); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Verify key data is preserved
+	if roundTripped["apiVersion"] != "apps/v1" {
+		t.Errorf("apiVersion lost: got %v", roundTripped["apiVersion"])
+	}
+	if roundTripped["kind"] != "Deployment" {
+		t.Errorf("kind lost: got %v", roundTripped["kind"])
+	}
+
+	meta, ok := roundTripped["metadata"].(map[string]interface{})
+	if !ok {
+		t.Fatal("metadata not a map")
+	}
+	if meta["name"] != "test" {
+		t.Errorf("metadata.name lost: got %v", meta["name"])
+	}
+
+	spec, ok := roundTripped["spec"].(map[string]interface{})
+	if !ok {
+		t.Fatal("spec not a map")
+	}
+	// sigs.k8s.io/yaml unmarshals into interface{} as float64
+	replicas, ok := spec["replicas"].(float64)
+	if !ok {
+		// May also be int depending on yaml library version
+		if r, ok2 := spec["replicas"].(int); ok2 {
+			replicas = float64(r)
+		} else {
+			t.Fatalf("spec.replicas unexpected type: %T", spec["replicas"])
+		}
+	}
+	if replicas != 3 {
+		t.Errorf("spec.replicas lost: got %v", replicas)
+	}
+
+	// Verify containers survived
+	tmpl, ok := spec["template"].(map[string]interface{})
+	if !ok {
+		t.Fatal("spec.template not a map")
+	}
+	tmplSpec, ok := tmpl["spec"].(map[string]interface{})
+	if !ok {
+		t.Fatal("spec.template.spec not a map")
+	}
+	containers, ok := tmplSpec["containers"].([]interface{})
+	if !ok || len(containers) != 1 {
+		t.Fatal("containers not preserved")
+	}
+	container, ok := containers[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("container not a map")
+	}
+	if container["image"] != "nginx:latest" {
+		t.Errorf("container image lost: got %v", container["image"])
+	}
+}

--- a/pkg/io/yaml_test.go
+++ b/pkg/io/yaml_test.go
@@ -3,7 +3,11 @@ package io
 import (
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type demo struct {
@@ -23,6 +27,94 @@ func TestBufferMarshalUnmarshal(t *testing.T) {
 	}
 	if !reflect.DeepEqual(in, out) {
 		t.Fatalf("round trip mismatch: %#v != %#v", in, out)
+	}
+}
+
+func TestEncodeObjectsToYAMLWithOptions(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("apps/v1")
+	obj.SetKind("Deployment")
+	obj.SetName("test-deploy")
+	obj.SetNamespace("default")
+	obj.Object["spec"] = map[string]interface{}{
+		"replicas": int64(3),
+		"selector": map[string]interface{}{
+			"matchLabels": map[string]interface{}{
+				"app": "test",
+			},
+		},
+	}
+
+	co := client.Object(obj)
+	objects := []*client.Object{&co}
+
+	opts := EncodeOptions{KubernetesFieldOrder: true}
+	out, err := EncodeObjectsToYAMLWithOptions(objects, opts)
+	if err != nil {
+		t.Fatalf("EncodeObjectsToYAMLWithOptions: %v", err)
+	}
+
+	s := string(out)
+
+	// Verify Kubernetes-conventional field order
+	apiVersionIdx := strings.Index(s, "apiVersion:")
+	kindIdx := strings.Index(s, "kind:")
+	metadataIdx := strings.Index(s, "metadata:")
+	specIdx := strings.Index(s, "spec:")
+
+	if apiVersionIdx >= kindIdx {
+		t.Errorf("apiVersion should come before kind:\n%s", s)
+	}
+	if kindIdx >= metadataIdx {
+		t.Errorf("kind should come before metadata:\n%s", s)
+	}
+	if metadataIdx >= specIdx {
+		t.Errorf("metadata should come before spec:\n%s", s)
+	}
+
+	// Verify the content is valid YAML with expected values
+	if !strings.Contains(s, "apiVersion: apps/v1") {
+		t.Errorf("expected apiVersion: apps/v1 in output:\n%s", s)
+	}
+	if !strings.Contains(s, "kind: Deployment") {
+		t.Errorf("expected kind: Deployment in output:\n%s", s)
+	}
+}
+
+func TestEncodeObjectsToYAML_BackwardCompatible(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("v1")
+	obj.SetKind("ConfigMap")
+	obj.SetName("test-cm")
+	obj.SetNamespace("default")
+	obj.Object["data"] = map[string]interface{}{
+		"key": "value",
+	}
+
+	co := client.Object(obj)
+	objects := []*client.Object{&co}
+
+	out, err := EncodeObjectsToYAML(objects)
+	if err != nil {
+		t.Fatalf("EncodeObjectsToYAML: %v", err)
+	}
+
+	s := string(out)
+
+	// Verify the existing function still produces valid YAML
+	if !strings.Contains(s, "apiVersion: v1") {
+		t.Errorf("expected apiVersion: v1 in output:\n%s", s)
+	}
+	if !strings.Contains(s, "kind: ConfigMap") {
+		t.Errorf("expected kind: ConfigMap in output:\n%s", s)
+	}
+	if !strings.Contains(s, "key: value") {
+		t.Errorf("expected data key in output:\n%s", s)
+	}
+
+	// Should NOT have creationTimestamp (it's null and should be stripped)
+	if strings.Contains(s, "creationTimestamp") {
+		t.Errorf("expected creationTimestamp to be stripped:\n%s", s)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `EncodeObjectsToYAMLWithOptions` with `KubernetesFieldOrder` option that emits top-level fields in the conventional order used by kubectl, Helm, and Kustomize (`apiVersion`, `kind`, `metadata`, `spec`, …, `status` last)
- Uses `gopkg.in/yaml.v3` Node trees to control key emission order, since `sigs.k8s.io/yaml.Marshal` re-sorts alphabetically
- Existing `EncodeObjectsToYAML` delegates to the new function with zero-value options — no breaking changes

## Test plan

- [x] `TestSortedKeysKubernetesOrder` — priority keys sorted correctly; remaining keys alphabetical; status last
- [x] `TestSortedKeysAlphabetical` — non-top-level keys use plain alphabetical
- [x] `TestValueToNode` — all JSON types including high-precision floats
- [x] `TestMarshalOrderedYAML_Deployment` — full Deployment map has correct field order
- [x] `TestMarshalOrderedYAML_ConfigMap` — `data` comes after metadata, before status
- [x] `TestMarshalOrderedYAML_NestedAlphabetical` — metadata sub-fields are alphabetical
- [x] `TestMarshalOrderedYAML_Deterministic` — marshal same resource 100× → byte-identical
- [x] `TestMarshalOrderedYAML_RoundTrip` — marshal ordered → unmarshal back → no data loss
- [x] `TestEncodeObjectsToYAMLWithOptions` — ordered output for a real Kubernetes object
- [x] `TestEncodeObjectsToYAML_BackwardCompatible` — existing function behavior unchanged
- [x] `make precommit` passes (tidy, lint, test)

Closes #175