### PR TITLE
docs(changelog): document ApplicationConfig breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 ## [0.1.0-alpha.3] - 2026-02-12
 
+### Breaking Changes
+
+- **`Application.Config`** field changed from `*ApplicationConfig` (pointer-to-interface) to `ApplicationConfig` (interface directly). Update usages: `Config: &myConfig` → `Config: myConfig`
+
 ### Documentation
 
 - Add changelog entry for v0.1.0-alpha.3


### PR DESCRIPTION
## Summary

- Documents the `Application.Config` field type change from `*ApplicationConfig` to `ApplicationConfig` as a breaking change in the CHANGELOG under `[0.1.0-alpha.3]`

Closes #178

## Test plan

- [x] `make check` passes (lint, vet, tests)
- [x] No code changes — CHANGELOG only