### PR TITLE
refactor: consolidate generator registries into pkg/stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Breaking Changes
 
 - **`Application.Config`** field changed from `*ApplicationConfig` (pointer-to-interface) to `ApplicationConfig` (interface directly). Update usages: `Config: &myConfig` → `Config: myConfig`
+- **`generators` package registry removed** — `generators.Register()`, `generators.Create()`, `generators.CreateFromGVK()`, `generators.ListKinds()`, `generators.HasKind()`, and `generators.ApplicationConfigFactory` have been removed. Use `stack.RegisterApplicationConfig()`, `stack.CreateApplicationConfig()`, `stack.ListApplicationConfigGVKs()`, and `stack.HasApplicationConfigGVK()` instead. GVK type re-exports (`generators.GVK`, `generators.ParseAPIVersion`) are preserved.
 
 ### Documentation
 

--- a/cmd/demo/generators_gvk_demo.go
+++ b/cmd/demo/generators_gvk_demo.go
@@ -8,7 +8,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/go-kure/kure/pkg/stack"
-	"github.com/go-kure/kure/pkg/stack/generators"
 	_ "github.com/go-kure/kure/pkg/stack/generators/appworkload" // Register AppWorkload
 	_ "github.com/go-kure/kure/pkg/stack/generators/fluxhelm"    // Register FluxHelm
 )
@@ -206,7 +205,7 @@ func DemoGVKGenerators() {
 	fmt.Println("\n5. Registered Generator Types:")
 	fmt.Println(strings.Repeat("-", 40))
 
-	registeredTypes := generators.ListKinds()
+	registeredTypes := stack.ListApplicationConfigGVKs()
 	for _, gvk := range registeredTypes {
 		fmt.Printf("  - %s\n", gvk)
 	}

--- a/cmd/demo/generators_gvk_demo_test.go
+++ b/cmd/demo/generators_gvk_demo_test.go
@@ -11,7 +11,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/go-kure/kure/pkg/stack"
-	"github.com/go-kure/kure/pkg/stack/generators"
 
 	// Import generators to register them
 	_ "github.com/go-kure/kure/pkg/stack/generators/appworkload"
@@ -357,7 +356,7 @@ func TestBundleWithMultipleGenerators(t *testing.T) {
 }
 
 func TestRegisteredGeneratorTypes(t *testing.T) {
-	registeredTypes := generators.ListKinds()
+	registeredTypes := stack.ListApplicationConfigGVKs()
 
 	if len(registeredTypes) == 0 {
 		t.Error("No generator types are registered")

--- a/pkg/stack/application_wrapper.go
+++ b/pkg/stack/application_wrapper.go
@@ -22,6 +22,16 @@ func CreateApplicationConfig(apiVersion, kind string) (ApplicationConfig, error)
 	return applicationConfigRegistry.Create(parsed)
 }
 
+// ListApplicationConfigGVKs returns all registered ApplicationConfig GVKs
+func ListApplicationConfigGVKs() []gvk.GVK {
+	return applicationConfigRegistry.ListGVKs()
+}
+
+// HasApplicationConfigGVK checks if an ApplicationConfig is registered for the given apiVersion and kind
+func HasApplicationConfigGVK(apiVersion, kind string) bool {
+	return applicationConfigRegistry.HasAPIVersion(apiVersion, kind)
+}
+
 // ApplicationWrapper provides type detection and unmarshaling for ApplicationConfig
 type ApplicationWrapper struct {
 	APIVersion string              `yaml:"apiVersion" json:"apiVersion"`

--- a/pkg/stack/generators/README.md
+++ b/pkg/stack/generators/README.md
@@ -4,7 +4,7 @@ The `generators` package provides a type-safe system for creating Kubernetes app
 
 ## Overview
 
-Generators use the GroupVersionKind (GVK) type system to identify and instantiate application configurations. Each generator is registered in a global registry and can be referenced by its GVK identifier.
+Generators use the GroupVersionKind (GVK) type system to identify and instantiate application configurations. Each generator is registered in the `stack` package's global registry and can be referenced by its GVK identifier.
 
 ## Available Generators
 
@@ -19,13 +19,10 @@ Generators use the GroupVersionKind (GVK) type system to identify and instantiat
 ### Creating a Generator from GVK
 
 ```go
-import "github.com/go-kure/kure/pkg/stack/generators"
+import "github.com/go-kure/kure/pkg/stack"
 
-// Look up generator by GVK
-factory, err := generators.GetGenerator("generators/AppWorkload")
-
-// Create application config from YAML configuration
-config, err := factory.FromConfig(yamlData)
+// Create application config by apiVersion and kind
+config, err := stack.CreateApplicationConfig("generators.gokure.dev/v1alpha1", "AppWorkload")
 
 // Use in domain model
 app := stack.NewApplication("my-app", "default", config)
@@ -56,14 +53,20 @@ spec:
 Register custom generators:
 
 ```go
-generators.Register("mycompany/CustomApp", &MyGeneratorFactory{})
+stack.RegisterApplicationConfig(gvk.GVK{
+    Group:   "mycompany.dev",
+    Version: "v1",
+    Kind:    "CustomApp",
+}, func() stack.ApplicationConfig {
+    return &MyCustomConfig{}
+})
 ```
 
 Query available generators:
 
 ```go
 // List all registered generator GVKs
-gvks := generators.ListRegistered()
+gvks := stack.ListApplicationConfigGVKs()
 ```
 
 ## Sub-packages

--- a/pkg/stack/generators/appworkload/v1alpha1.go
+++ b/pkg/stack/generators/appworkload/v1alpha1.go
@@ -10,22 +10,14 @@ import (
 )
 
 func init() {
-	// Register the AppWorkload v1alpha1 generator with both registries
-	gvkObj := gvk.GVK{
+	// Register the AppWorkload v1alpha1 generator
+	stack.RegisterApplicationConfig(gvk.GVK{
 		Group:   "generators.gokure.dev",
 		Version: "v1alpha1",
 		Kind:    "AppWorkload",
-	}
-
-	factory := func() stack.ApplicationConfig {
+	}, func() stack.ApplicationConfig {
 		return &ConfigV1Alpha1{}
-	}
-
-	// Register with generators package for backward compatibility
-	generators.Register(generators.GVK(gvkObj), factory)
-
-	// Register with stack package for direct usage
-	stack.RegisterApplicationConfig(gvkObj, factory)
+	})
 }
 
 // ConfigV1Alpha1 describes a single deployable application with GVK support

--- a/pkg/stack/generators/appworkload/v1alpha1_test.go
+++ b/pkg/stack/generators/appworkload/v1alpha1_test.go
@@ -8,7 +8,6 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/go-kure/kure/internal/gvk"
 	"github.com/go-kure/kure/pkg/stack"
 	"github.com/go-kure/kure/pkg/stack/generators"
 	"github.com/go-kure/kure/pkg/stack/generators/appworkload/internal"
@@ -482,29 +481,19 @@ func TestConfigV1Alpha1_Generate_EmptyContainers(t *testing.T) {
 }
 
 func TestRegistration(t *testing.T) {
-	// Test that the AppWorkload generator is properly registered
-	expectedGVK := gvk.GVK{
-		Group:   "generators.gokure.dev",
-		Version: "v1alpha1",
-		Kind:    "AppWorkload",
-	}
-
-	// Test generators package registration using Create function
-	config, err := generators.CreateFromGVK(generators.GVK(expectedGVK))
+	// Test that the AppWorkload generator is properly registered in the stack registry
+	config, err := stack.CreateApplicationConfig("generators.gokure.dev/v1alpha1", "AppWorkload")
 	if err != nil {
-		t.Errorf("AppWorkload generator not registered in generators package: %v", err)
-		return
+		t.Fatalf("AppWorkload generator not registered in stack package: %v", err)
 	}
 
 	if config == nil {
-		t.Error("CreateFromGVK returned nil config")
-		return
+		t.Fatal("CreateApplicationConfig returned nil config")
 	}
 
 	appWorkloadConfig, ok := config.(*ConfigV1Alpha1)
 	if !ok {
-		t.Errorf("CreateFromGVK returned wrong type: %T, want *ConfigV1Alpha1", config)
-		return
+		t.Fatalf("CreateApplicationConfig returned wrong type: %T, want *ConfigV1Alpha1", config)
 	}
 
 	if appWorkloadConfig.GetAPIVersion() != "generators.gokure.dev/v1alpha1" {
@@ -513,23 +502,6 @@ func TestRegistration(t *testing.T) {
 
 	if appWorkloadConfig.GetKind() != "AppWorkload" {
 		t.Errorf("Config Kind = %s, want AppWorkload", appWorkloadConfig.GetKind())
-	}
-
-	// Test stack package registration
-	stackConfig, err := stack.CreateApplicationConfig("generators.gokure.dev/v1alpha1", "AppWorkload")
-	if err != nil {
-		t.Errorf("AppWorkload generator not registered in stack package: %v", err)
-		return
-	}
-
-	if stackConfig == nil {
-		t.Error("CreateApplicationConfig returned nil config")
-		return
-	}
-
-	_, ok = stackConfig.(*ConfigV1Alpha1)
-	if !ok {
-		t.Errorf("CreateApplicationConfig returned wrong type: %T, want *ConfigV1Alpha1", stackConfig)
 	}
 }
 

--- a/pkg/stack/generators/doc.go
+++ b/pkg/stack/generators/doc.go
@@ -36,14 +36,14 @@
 //
 // # Registration
 //
-// Generators self-register during package initialization:
+// Generators self-register with the stack registry during package initialization:
 //
 //	func init() {
-//	    generators.Register(generators.GVK{
+//	    stack.RegisterApplicationConfig(gvk.GVK{
 //	        Group:   "generators.gokure.dev",
 //	        Version: "v1alpha1",
 //	        Kind:    "MyGenerator",
-//	    }, func() interface{} {
+//	    }, func() stack.ApplicationConfig {
 //	        return &MyGeneratorV1Alpha1{}
 //	    })
 //	}

--- a/pkg/stack/generators/fluxhelm/v1alpha1.go
+++ b/pkg/stack/generators/fluxhelm/v1alpha1.go
@@ -10,22 +10,14 @@ import (
 )
 
 func init() {
-	// Register the FluxHelm v1alpha1 generator with both registries
-	gvkObj := gvk.GVK{
+	// Register the FluxHelm v1alpha1 generator
+	stack.RegisterApplicationConfig(gvk.GVK{
 		Group:   "generators.gokure.dev",
 		Version: "v1alpha1",
 		Kind:    "FluxHelm",
-	}
-
-	factory := func() stack.ApplicationConfig {
+	}, func() stack.ApplicationConfig {
 		return &ConfigV1Alpha1{}
-	}
-
-	// Register with generators package for backward compatibility
-	generators.Register(generators.GVK(gvkObj), factory)
-
-	// Register with stack package for direct usage
-	stack.RegisterApplicationConfig(gvkObj, factory)
+	})
 }
 
 // ConfigV1Alpha1 generates Flux HelmRelease and source resources

--- a/pkg/stack/generators/fluxhelm/v1alpha1_test.go
+++ b/pkg/stack/generators/fluxhelm/v1alpha1_test.go
@@ -7,7 +7,6 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/go-kure/kure/internal/gvk"
 	"github.com/go-kure/kure/pkg/stack"
 	"github.com/go-kure/kure/pkg/stack/generators"
 	"github.com/go-kure/kure/pkg/stack/generators/fluxhelm/internal"
@@ -615,29 +614,19 @@ func TestConfigV1Alpha1_Generate_InferSourceFromOCIUrl(t *testing.T) {
 }
 
 func TestRegistration(t *testing.T) {
-	// Test that the FluxHelm generator is properly registered
-	expectedGVK := gvk.GVK{
-		Group:   "generators.gokure.dev",
-		Version: "v1alpha1",
-		Kind:    "FluxHelm",
-	}
-
-	// Test generators package registration
-	config, err := generators.CreateFromGVK(generators.GVK(expectedGVK))
+	// Test that the FluxHelm generator is properly registered in the stack registry
+	config, err := stack.CreateApplicationConfig("generators.gokure.dev/v1alpha1", "FluxHelm")
 	if err != nil {
-		t.Errorf("FluxHelm generator not registered in generators package: %v", err)
-		return
+		t.Fatalf("FluxHelm generator not registered in stack package: %v", err)
 	}
 
 	if config == nil {
-		t.Error("CreateFromGVK returned nil config")
-		return
+		t.Fatal("CreateApplicationConfig returned nil config")
 	}
 
 	fluxHelmConfig, ok := config.(*ConfigV1Alpha1)
 	if !ok {
-		t.Errorf("CreateFromGVK returned wrong type: %T, want *ConfigV1Alpha1", config)
-		return
+		t.Fatalf("CreateApplicationConfig returned wrong type: %T, want *ConfigV1Alpha1", config)
 	}
 
 	if fluxHelmConfig.GetAPIVersion() != "generators.gokure.dev/v1alpha1" {
@@ -646,23 +635,6 @@ func TestRegistration(t *testing.T) {
 
 	if fluxHelmConfig.GetKind() != "FluxHelm" {
 		t.Errorf("Config Kind = %s, want FluxHelm", fluxHelmConfig.GetKind())
-	}
-
-	// Test stack package registration
-	stackConfig, err := stack.CreateApplicationConfig("generators.gokure.dev/v1alpha1", "FluxHelm")
-	if err != nil {
-		t.Errorf("FluxHelm generator not registered in stack package: %v", err)
-		return
-	}
-
-	if stackConfig == nil {
-		t.Error("CreateApplicationConfig returned nil config")
-		return
-	}
-
-	_, ok = stackConfig.(*ConfigV1Alpha1)
-	if !ok {
-		t.Errorf("CreateApplicationConfig returned wrong type: %T, want *ConfigV1Alpha1", stackConfig)
 	}
 }
 

--- a/pkg/stack/generators/kurelpackage/v1alpha1.go
+++ b/pkg/stack/generators/kurelpackage/v1alpha1.go
@@ -20,21 +20,13 @@ import (
 
 func init() {
 	// Register the KurelPackage v1alpha1 generator
-	gvkObj := gvk.GVK{
+	stack.RegisterApplicationConfig(gvk.GVK{
 		Group:   "generators.gokure.dev",
 		Version: "v1alpha1",
 		Kind:    "KurelPackage",
-	}
-
-	factory := func() stack.ApplicationConfig {
+	}, func() stack.ApplicationConfig {
 		return &ConfigV1Alpha1{}
-	}
-
-	// Register with generators package for backward compatibility
-	generators.Register(generators.GVK(gvkObj), factory)
-
-	// Register with stack package for direct usage
-	stack.RegisterApplicationConfig(gvkObj, factory)
+	})
 }
 
 // ConfigV1Alpha1 generates a kurel package structure

--- a/pkg/stack/generators/registry.go
+++ b/pkg/stack/generators/registry.go
@@ -2,7 +2,6 @@ package generators
 
 import (
 	"github.com/go-kure/kure/internal/gvk"
-	"github.com/go-kure/kure/pkg/stack"
 )
 
 // Re-export GVK type for backward compatibility
@@ -12,35 +11,3 @@ type GVK = gvk.GVK
 var (
 	ParseAPIVersion = gvk.ParseAPIVersion
 )
-
-// ApplicationConfigFactory is a function that creates a new ApplicationConfig instance
-type ApplicationConfigFactory = gvk.Factory[stack.ApplicationConfig]
-
-// globalRegistry is the singleton registry instance for ApplicationConfig
-var globalRegistry = gvk.NewRegistry[stack.ApplicationConfig]()
-
-// Register adds a new ApplicationConfig type to the global registry
-func Register(gvk GVK, factory ApplicationConfigFactory) {
-	globalRegistry.Register(gvk, factory)
-}
-
-// Create creates a new ApplicationConfig instance for the given apiVersion and kind
-func Create(apiVersion, kind string) (stack.ApplicationConfig, error) {
-	parsed := gvk.ParseAPIVersion(apiVersion, kind)
-	return globalRegistry.Create(parsed)
-}
-
-// CreateFromGVK creates a new ApplicationConfig instance for the given GVK
-func CreateFromGVK(gvkObj GVK) (stack.ApplicationConfig, error) {
-	return globalRegistry.Create(gvkObj)
-}
-
-// ListKinds returns all registered GVKs from the global registry
-func ListKinds() []GVK {
-	return globalRegistry.ListGVKs()
-}
-
-// HasKind checks if a GVK is registered in the global registry
-func HasKind(apiVersion, kind string) bool {
-	return globalRegistry.HasAPIVersion(apiVersion, kind)
-}

--- a/pkg/stack/generators/registry_test.go
+++ b/pkg/stack/generators/registry_test.go
@@ -3,12 +3,7 @@ package generators_test
 import (
 	"testing"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/go-kure/kure/pkg/stack"
 	"github.com/go-kure/kure/pkg/stack/generators"
-	_ "github.com/go-kure/kure/pkg/stack/generators/appworkload" // Register AppWorkload
-	_ "github.com/go-kure/kure/pkg/stack/generators/fluxhelm"    // Register FluxHelm
 )
 
 func TestRegistry(t *testing.T) {
@@ -50,70 +45,4 @@ func TestRegistry(t *testing.T) {
 			})
 		}
 	})
-
-	t.Run("Register and Create", func(t *testing.T) {
-		// Test using global registry functions
-		testGVK := generators.GVK{
-			Group:   "test.gokure.dev",
-			Version: "v1",
-			Kind:    "TestGeneratorRC", // Make unique
-		}
-
-		called := false
-		generators.Register(testGVK, func() stack.ApplicationConfig {
-			called = true
-			return &mockConfig{}
-		})
-
-		// Create an instance
-		config, err := generators.CreateFromGVK(testGVK)
-		if err != nil {
-			t.Fatalf("Failed to create config: %v", err)
-		}
-
-		if !called {
-			t.Error("Factory function was not called")
-		}
-
-		if config == nil {
-			t.Error("Created config is nil")
-		}
-	})
-
-	t.Run("Create Unknown Type", func(t *testing.T) {
-		unknownGVK := generators.GVK{
-			Group:   "unknown.gokure.dev",
-			Version: "v1",
-			Kind:    "UnknownType",
-		}
-
-		_, err := generators.CreateFromGVK(unknownGVK)
-		if err == nil {
-			t.Error("Expected error for unknown type, got nil")
-		}
-	})
-
-	t.Run("Global Registry", func(t *testing.T) {
-		// Test that built-in types are registered
-		if !generators.HasKind("generators.gokure.dev/v1alpha1", "AppWorkload") {
-			t.Error("AppWorkload should be registered")
-		}
-
-		if !generators.HasKind("generators.gokure.dev/v1alpha1", "FluxHelm") {
-			t.Error("FluxHelm should be registered")
-		}
-
-		// List all registered kinds
-		kinds := generators.ListKinds()
-		if len(kinds) < 2 {
-			t.Errorf("Expected at least 2 registered kinds, got %d", len(kinds))
-		}
-	})
-}
-
-// mockConfig is a test implementation of ApplicationConfig
-type mockConfig struct{}
-
-func (m *mockConfig) Generate(app *stack.Application) ([]*client.Object, error) {
-	return nil, nil
 }


### PR DESCRIPTION
## Summary

Closes #179.

- Remove the duplicate `globalRegistry` from `pkg/stack/generators`, consolidating all `ApplicationConfig` registration into the single registry in `pkg/stack`
- Eliminate redundant dual-registration in generator `init()` functions (appworkload, fluxhelm, kurelpackage)
- Add `ListApplicationConfigGVKs()` and `HasApplicationConfigGVK()` query functions to `pkg/stack`

### Breaking changes

`generators.Register()`, `generators.Create()`, `generators.CreateFromGVK()`, `generators.ListKinds()`, `generators.HasKind()`, and `generators.ApplicationConfigFactory` are removed. Use `stack.RegisterApplicationConfig()`, `stack.CreateApplicationConfig()`, `stack.ListApplicationConfigGVKs()`, and `stack.HasApplicationConfigGVK()` instead. GVK type re-exports (`generators.GVK`, `generators.ParseAPIVersion`) are preserved.

## Test plan

- [x] `make check` — lint + vet + short tests pass
- [x] `make precommit` — full tidy + lint + test suite passes
- [x] `grep` for removed symbols returns zero matches