### PR TITLE
feat(kurelpackage): implement Generate() for stack pipeline integration

### DIFF
--- a/examples/generators/README.md
+++ b/examples/generators/README.md
@@ -37,6 +37,10 @@ These examples demonstrate:
 - Release configuration options
 - Flux-specific settings (interval, timeout, suspend)
 
+### KurelPackage (generators.gokure.dev/v1alpha1)
+
+Generates Kubernetes resource objects from kurel packages. `Generate()` collects resources from the package structure and returns them as typed objects, making kurel packages usable in the stack generation pipeline.
+
 ## Usage
 
 To parse and generate resources from these examples:
@@ -52,6 +56,7 @@ import (
     "github.com/go-kure/kure/pkg/stack"
     _ "github.com/go-kure/kure/pkg/stack/generators/appworkload"
     _ "github.com/go-kure/kure/pkg/stack/generators/fluxhelm"
+    _ "github.com/go-kure/kure/pkg/stack/generators/kurelpackage"
 )
 
 func main() {

--- a/pkg/stack/generators/README.md
+++ b/pkg/stack/generators/README.md
@@ -88,7 +88,7 @@ Generates Flux HelmRelease resources for Helm-based applications:
 
 ### kurelpackage
 
-References kurel packages as applications within the stack hierarchy, enabling package-based deployments in cluster definitions.
+Generates Kubernetes resource objects from kurel packages. The `Generate()` method delegates to `GeneratePackageFiles()`, extracts files under the `resources/` prefix, and parses each one into typed `client.Object` values. Non-resource files (kurel.yaml, patches, values, extensions) are excluded — they are package metadata. This makes KurelPackage configs usable in the stack generation pipeline alongside other generators.
 
 ## Related Packages
 

--- a/pkg/stack/generators/kurelpackage/doc.go
+++ b/pkg/stack/generators/kurelpackage/doc.go
@@ -75,6 +75,13 @@
 //	    excludes: ["*test*"]     # Exclusion patterns
 //	    recurse: true            # Recurse into subdirectories
 //
+// # Generate
+//
+// The [ConfigV1Alpha1.Generate] method collects Kubernetes resource files from
+// the package structure produced by [ConfigV1Alpha1.GeneratePackageFiles] and
+// returns them as []*client.Object, making KurelPackage configs usable in the
+// stack generation pipeline alongside other ApplicationConfig implementations.
+//
 // # GVK Registration
 //
 // The generator is automatically registered during package initialization:

--- a/site/content/guides/generators.md
+++ b/site/content/guides/generators.md
@@ -15,7 +15,7 @@ Each generator is registered with a GVK identifier that uniquely identifies its 
 |-----|-----------|--------|
 | `generators/AppWorkload` | AppWorkload | Deployment, Service, ConfigMap |
 | `generators/FluxHelm` | FluxHelm | HelmRelease, HelmRepository |
-| `generators/KurelPackage` | KurelPackage | Kurel package reference |
+| `generators/KurelPackage` | KurelPackage | Kubernetes resources from kurel packages |
 
 ## Using Generators
 
@@ -79,7 +79,7 @@ Generates Flux HelmRelease resources:
 
 ### KurelPackage
 
-References kurel packages within the stack hierarchy, enabling package-based deployments alongside code-generated resources.
+Generates Kubernetes resource objects from kurel packages. `Generate()` delegates to `GeneratePackageFiles()`, extracts the resource files from the package, and parses them into typed objects. Non-resource metadata (kurel.yaml, patches, values, extensions) is excluded from the output. This allows kurel packages to participate in the stack generation pipeline alongside code-generated resources.
 
 ## Custom Generators
 


### PR DESCRIPTION
## Summary

- Replace the `Generate()` stub with a working implementation that delegates to `GeneratePackageFiles()`, extracts Kubernetes resource files (under the `resources/` prefix), and parses them via `io.ParseYAML` into `[]*client.Object`
- Non-resource files (kurel.yaml, patches, values, extensions) are excluded as package metadata
- Add comprehensive tests: basic resources, multiple resources, no resources, and non-resource file exclusion

## Motivation

The `Generate()` stub returned `"KurelPackage generator not yet implemented"`, blocking the YAML converter (#142) and preventing KurelPackage configs from participating in `Bundle.Generate()`, the layout walker, and the CLI generate command.

## Test plan

- [x] `TestGenerateBasicResources` — single Pod file, verifies typed `*corev1.Pod` with correct name
- [x] `TestGenerateMultipleResources` — ConfigMap + Service, verifies correct count and kinds
- [x] `TestGenerateNoResources` — no resources field, returns empty slice without error
- [x] `TestGenerateExcludesNonResourceFiles` — config with resources + patches; only resource objects returned
- [x] Updated existing tests that expected the "not implemented" error
- [x] `make precommit` passes (tidy, lint, test)

Closes #197