### PR TITLE
feat(io): add comprehensive server-set field stripping

### DIFF
--- a/pkg/io/README.md
+++ b/pkg/io/README.md
@@ -75,6 +75,34 @@ yamlData, err := io.EncodeObjectsToYAMLWithOptions(objects, opts)
 // Output: apiVersion, kind, metadata, spec, ... status (last)
 ```
 
+### Server-Set Field Stripping
+
+By default, encoding strips server-managed metadata fields that should not appear in client-generated manifests: `managedFields`, `resourceVersion`, `uid`, `generation`, `selfLink`, the `kubectl.kubernetes.io/last-applied-configuration` annotation, null `creationTimestamp`, and empty `status`.
+
+```go
+// Default behavior — full stripping (zero value of ServerFieldStripping)
+yamlData, err := io.EncodeObjectsToYAML(objects)
+
+// Explicit full stripping with field ordering
+opts := io.EncodeOptions{
+    KubernetesFieldOrder: true,
+    ServerFieldStripping: io.StripServerFieldsFull,
+}
+yamlData, err := io.EncodeObjectsToYAMLWithOptions(objects, opts)
+
+// Basic stripping (only null creationTimestamp and empty status)
+opts := io.EncodeOptions{
+    ServerFieldStripping: io.StripServerFieldsBasic,
+}
+yamlData, err := io.EncodeObjectsToYAMLWithOptions(objects, opts)
+
+// No stripping — preserve all fields as-is
+opts := io.EncodeOptions{
+    ServerFieldStripping: io.StripServerFieldsNone,
+}
+yamlData, err := io.EncodeObjectsToYAMLWithOptions(objects, opts)
+```
+
 ## Printing
 
 ### Output Formats

--- a/pkg/io/doc.go
+++ b/pkg/io/doc.go
@@ -100,6 +100,26 @@
 // apiVersion, kind, metadata, spec, data, stringData, then remaining fields
 // alphabetically, with status last.
 //
+// # Server-set field stripping
+//
+// Resources exported from a cluster via `kubectl get -o yaml` include
+// server-managed metadata fields (managedFields, resourceVersion, uid,
+// generation, selfLink, and the kubectl.kubernetes.io/last-applied-configuration
+// annotation) that should not appear in client-generated manifests.
+//
+// The [ServerFieldStripping] option on [EncodeOptions] controls which of these
+// fields are removed during encoding:
+//
+//   - [StripServerFieldsFull] (default, zero value): removes all known
+//     server-set fields, null creationTimestamp, and empty status.
+//   - [StripServerFieldsBasic]: removes only null creationTimestamp and
+//     empty status.
+//   - [StripServerFieldsNone]: disables all stripping.
+//
+// Because the zero value of [ServerFieldStripping] is [StripServerFieldsFull],
+// all existing callers of [EncodeObjectsToYAML] benefit from enhanced stripping
+// without code changes.
+//
 // The package forms the foundation for the other packages within this
 // repository but can be imported directly by any program that requires
 // lightweight YAML handling, runtime object parsing, and kubectl-compatible

--- a/pkg/io/order.go
+++ b/pkg/io/order.go
@@ -10,6 +10,25 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// ServerFieldStripping controls which server-managed metadata fields are
+// removed during YAML encoding.
+type ServerFieldStripping int
+
+const (
+	// StripServerFieldsFull removes all known server-set metadata fields:
+	// managedFields, resourceVersion, uid, generation, selfLink,
+	// the kubectl.kubernetes.io/last-applied-configuration annotation,
+	// null creationTimestamp, and empty status.
+	StripServerFieldsFull ServerFieldStripping = iota
+
+	// StripServerFieldsBasic removes only null creationTimestamp and
+	// empty status (the pre-v0.1 behavior).
+	StripServerFieldsBasic
+
+	// StripServerFieldsNone disables all server-field stripping.
+	StripServerFieldsNone
+)
+
 // EncodeOptions controls how Kubernetes objects are serialized to YAML.
 type EncodeOptions struct {
 	// KubernetesFieldOrder emits top-level resource keys in the
@@ -18,6 +37,11 @@ type EncodeOptions struct {
 	// then remaining keys alphabetically, with status last.
 	// Nested maps remain alphabetically sorted.
 	KubernetesFieldOrder bool
+
+	// ServerFieldStripping controls removal of server-managed metadata
+	// fields during encoding. The zero value (StripServerFieldsFull)
+	// strips all known server-set fields by default.
+	ServerFieldStripping ServerFieldStripping
 }
 
 // kubernetesKeyPriority maps well-known top-level Kubernetes resource

--- a/pkg/io/yaml_test.go
+++ b/pkg/io/yaml_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -87,6 +88,15 @@ func TestEncodeObjectsToYAML_BackwardCompatible(t *testing.T) {
 	obj.SetKind("ConfigMap")
 	obj.SetName("test-cm")
 	obj.SetNamespace("default")
+	obj.SetUID("abc-123")
+	obj.SetResourceVersion("999")
+	obj.SetGeneration(5)
+	obj.SetManagedFields([]metav1.ManagedFieldsEntry{
+		{Manager: "kubectl", Operation: metav1.ManagedFieldsOperationApply},
+	})
+	obj.SetAnnotations(map[string]string{
+		"kubectl.kubernetes.io/last-applied-configuration": `{"some":"config"}`,
+	})
 	obj.Object["data"] = map[string]interface{}{
 		"key": "value",
 	}
@@ -116,6 +126,14 @@ func TestEncodeObjectsToYAML_BackwardCompatible(t *testing.T) {
 	if strings.Contains(s, "creationTimestamp") {
 		t.Errorf("expected creationTimestamp to be stripped:\n%s", s)
 	}
+
+	// Zero-value EncodeOptions means StripServerFieldsFull, so all server
+	// fields should be stripped by default.
+	for _, field := range []string{"managedFields", "resourceVersion", "uid", "generation", "last-applied-configuration"} {
+		if strings.Contains(s, field) {
+			t.Errorf("expected %s to be stripped by default:\n%s", field, s)
+		}
+	}
 }
 
 func TestSaveLoadFile(t *testing.T) {
@@ -131,5 +149,281 @@ func TestSaveLoadFile(t *testing.T) {
 	}
 	if !reflect.DeepEqual(d, out) {
 		t.Fatalf("file round trip mismatch: %#v != %#v", d, out)
+	}
+}
+
+// newServerFieldObj creates an Unstructured object with all server-set fields populated.
+func newServerFieldObj() *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("v1")
+	obj.SetKind("ConfigMap")
+	obj.SetName("test-cm")
+	obj.SetNamespace("default")
+	obj.SetUID("abc-123")
+	obj.SetResourceVersion("999")
+	obj.SetGeneration(5)
+	obj.SetSelfLink("/api/v1/namespaces/default/configmaps/test-cm")
+	obj.SetManagedFields([]metav1.ManagedFieldsEntry{
+		{Manager: "kubectl", Operation: metav1.ManagedFieldsOperationApply},
+	})
+	obj.SetAnnotations(map[string]string{
+		"kubectl.kubernetes.io/last-applied-configuration": `{"some":"config"}`,
+		"app.kubernetes.io/name":                           "myapp",
+	})
+	obj.Object["data"] = map[string]interface{}{
+		"key": "value",
+	}
+	return obj
+}
+
+func TestCleanResourceMap_FullStripping(t *testing.T) {
+	obj := newServerFieldObj()
+	co := client.Object(obj)
+	objects := []*client.Object{&co}
+
+	out, err := EncodeObjectsToYAMLWithOptions(objects, EncodeOptions{
+		ServerFieldStripping: StripServerFieldsFull,
+	})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	s := string(out)
+
+	// All server-set fields should be stripped
+	for _, field := range []string{
+		"managedFields", "resourceVersion", "uid", "generation",
+		"selfLink", "last-applied-configuration",
+	} {
+		if strings.Contains(s, field) {
+			t.Errorf("expected %s to be stripped:\n%s", field, s)
+		}
+	}
+
+	// User annotation must survive
+	if !strings.Contains(s, "app.kubernetes.io/name") {
+		t.Errorf("expected user annotation to be preserved:\n%s", s)
+	}
+
+	// Null creationTimestamp should be stripped
+	if strings.Contains(s, "creationTimestamp") {
+		t.Errorf("expected creationTimestamp to be stripped:\n%s", s)
+	}
+}
+
+func TestCleanResourceMap_NestedMetadata(t *testing.T) {
+	// Deployment with pod template metadata containing server fields
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("apps/v1")
+	obj.SetKind("Deployment")
+	obj.SetName("test-deploy")
+	obj.SetNamespace("default")
+	obj.SetUID("deploy-uid")
+	obj.SetResourceVersion("42")
+	obj.Object["spec"] = map[string]interface{}{
+		"replicas": int64(1),
+		"template": map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"creationTimestamp": nil,
+				"uid":               "pod-uid",
+				"resourceVersion":   "11",
+				"labels": map[string]interface{}{
+					"app": "test",
+				},
+			},
+		},
+	}
+
+	co := client.Object(obj)
+	objects := []*client.Object{&co}
+
+	out, err := EncodeObjectsToYAMLWithOptions(objects, EncodeOptions{})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	s := string(out)
+
+	// Server fields at both levels should be stripped
+	if strings.Contains(s, "uid") {
+		t.Errorf("expected uid to be stripped from all levels:\n%s", s)
+	}
+	if strings.Contains(s, "resourceVersion") {
+		t.Errorf("expected resourceVersion to be stripped from all levels:\n%s", s)
+	}
+	if strings.Contains(s, "creationTimestamp") {
+		t.Errorf("expected creationTimestamp to be stripped:\n%s", s)
+	}
+
+	// User labels must survive in nested template
+	if !strings.Contains(s, "app: test") {
+		t.Errorf("expected nested labels to be preserved:\n%s", s)
+	}
+}
+
+func TestCleanResourceMap_CronJobNested(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("batch/v1")
+	obj.SetKind("CronJob")
+	obj.SetName("test-cj")
+	obj.SetNamespace("default")
+	obj.Object["spec"] = map[string]interface{}{
+		"schedule": "*/5 * * * *",
+		"jobTemplate": map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"uid":               "job-uid",
+				"creationTimestamp": nil,
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"uid":               "pod-uid",
+						"resourceVersion":   "33",
+						"creationTimestamp": nil,
+						"labels": map[string]interface{}{
+							"job": "cron",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	co := client.Object(obj)
+	objects := []*client.Object{&co}
+
+	out, err := EncodeObjectsToYAMLWithOptions(objects, EncodeOptions{})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	s := string(out)
+
+	if strings.Contains(s, "uid") {
+		t.Errorf("expected uid stripped from CronJob nested metadata:\n%s", s)
+	}
+	if strings.Contains(s, "resourceVersion") {
+		t.Errorf("expected resourceVersion stripped from CronJob nested metadata:\n%s", s)
+	}
+	if strings.Contains(s, "creationTimestamp") {
+		t.Errorf("expected creationTimestamp stripped from CronJob nested metadata:\n%s", s)
+	}
+	if !strings.Contains(s, "job: cron") {
+		t.Errorf("expected nested labels preserved in CronJob:\n%s", s)
+	}
+}
+
+func TestCleanResourceMap_BasicLevel(t *testing.T) {
+	obj := newServerFieldObj()
+	co := client.Object(obj)
+	objects := []*client.Object{&co}
+
+	out, err := EncodeObjectsToYAMLWithOptions(objects, EncodeOptions{
+		ServerFieldStripping: StripServerFieldsBasic,
+	})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	s := string(out)
+
+	// Basic level should only strip null creationTimestamp and empty status.
+	// Server-set fields should be preserved.
+	if strings.Contains(s, "creationTimestamp") {
+		t.Errorf("expected creationTimestamp stripped at Basic level:\n%s", s)
+	}
+	for _, field := range []string{"managedFields", "resourceVersion", "uid", "generation"} {
+		if !strings.Contains(s, field) {
+			t.Errorf("expected %s to be preserved at Basic level:\n%s", field, s)
+		}
+	}
+}
+
+func TestCleanResourceMap_NoneLevel(t *testing.T) {
+	obj := newServerFieldObj()
+	// Set a non-null creationTimestamp so it appears in output
+	obj.Object["metadata"].(map[string]interface{})["creationTimestamp"] = "2024-01-01T00:00:00Z"
+	obj.Object["status"] = map[string]interface{}{}
+
+	co := client.Object(obj)
+	objects := []*client.Object{&co}
+
+	out, err := EncodeObjectsToYAMLWithOptions(objects, EncodeOptions{
+		ServerFieldStripping: StripServerFieldsNone,
+	})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	s := string(out)
+
+	// Nothing should be stripped
+	for _, field := range []string{
+		"managedFields", "resourceVersion", "uid", "generation",
+		"creationTimestamp", "status",
+	} {
+		if !strings.Contains(s, field) {
+			t.Errorf("expected %s to be preserved at None level:\n%s", field, s)
+		}
+	}
+}
+
+func TestCleanResourceMap_AnnotationPreservation(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("v1")
+	obj.SetKind("Service")
+	obj.SetName("test-svc")
+	obj.SetNamespace("default")
+	obj.SetAnnotations(map[string]string{
+		"kubectl.kubernetes.io/last-applied-configuration": `{"some":"config"}`,
+		"prometheus.io/scrape":                             "true",
+		"prometheus.io/port":                               "9090",
+	})
+
+	co := client.Object(obj)
+	objects := []*client.Object{&co}
+
+	out, err := EncodeObjectsToYAMLWithOptions(objects, EncodeOptions{})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	s := string(out)
+
+	// kubectl annotation stripped
+	if strings.Contains(s, "last-applied-configuration") {
+		t.Errorf("expected kubectl annotation to be stripped:\n%s", s)
+	}
+
+	// User annotations preserved
+	if !strings.Contains(s, "prometheus.io/scrape") {
+		t.Errorf("expected prometheus.io/scrape to be preserved:\n%s", s)
+	}
+	if !strings.Contains(s, "prometheus.io/port") {
+		t.Errorf("expected prometheus.io/port to be preserved:\n%s", s)
+	}
+
+	// Annotations map should still exist (not deleted because it has remaining entries)
+	if !strings.Contains(s, "annotations") {
+		t.Errorf("expected annotations key to remain:\n%s", s)
+	}
+}
+
+func TestCleanResourceMap_EmptyAnnotationsRemoved(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("v1")
+	obj.SetKind("ConfigMap")
+	obj.SetName("test-cm")
+	obj.SetNamespace("default")
+	// Only the kubectl annotation — should be removed along with the annotations map
+	obj.SetAnnotations(map[string]string{
+		"kubectl.kubernetes.io/last-applied-configuration": `{"some":"config"}`,
+	})
+
+	co := client.Object(obj)
+	objects := []*client.Object{&co}
+
+	out, err := EncodeObjectsToYAMLWithOptions(objects, EncodeOptions{})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	s := string(out)
+
+	if strings.Contains(s, "annotations") {
+		t.Errorf("expected empty annotations map to be removed:\n%s", s)
 	}
 }

--- a/site/content/guides/library-usage.md
+++ b/site/content/guides/library-usage.md
@@ -64,7 +64,27 @@ err := io.PrintObjectsAsYAML(objects, os.Stdout)
 err := io.SaveFile("output.yaml", deployment)
 ```
 
-See the [IO reference](/api-reference/io) for all output formats.
+### Clean YAML encoding
+
+When encoding resources exported from a cluster, server-managed metadata fields (`managedFields`, `resourceVersion`, `uid`, etc.) clutter the output. The default encoding strips all of these automatically:
+
+```go
+// Default: strips all server-set fields and uses standard key order
+data, err := io.EncodeObjectsToYAMLWithOptions(objects, io.EncodeOptions{
+    KubernetesFieldOrder: true,
+})
+```
+
+Use `ServerFieldStripping` to control the level of stripping:
+
+```go
+// Preserve server fields (e.g. for debugging)
+data, err := io.EncodeObjectsToYAMLWithOptions(objects, io.EncodeOptions{
+    ServerFieldStripping: io.StripServerFieldsNone,
+})
+```
+
+See the [IO reference](/api-reference/io) for all output formats and stripping options.
 
 ## Working with the Domain Model
 


### PR DESCRIPTION
## Summary

Closes #196

- Add `ServerFieldStripping` enum on `EncodeOptions` with three levels: `Full` (default), `Basic`, and `None`
- Strip `managedFields`, `resourceVersion`, `uid`, `generation`, `selfLink`, and `kubectl.kubernetes.io/last-applied-configuration` annotation by default
- Apply stripping to nested metadata paths (pod templates, CronJob jobTemplates)
- Zero-value default (`StripServerFieldsFull`) means all existing callers benefit without code changes

## Test plan

- [x] `TestCleanResourceMap_FullStripping` — all server-set fields stripped, user annotations preserved
- [x] `TestCleanResourceMap_NestedMetadata` — Deployment pod template metadata stripped
- [x] `TestCleanResourceMap_CronJobNested` — CronJob jobTemplate + pod template nested stripping
- [x] `TestCleanResourceMap_BasicLevel` — only creationTimestamp/status stripped
- [x] `TestCleanResourceMap_NoneLevel` — nothing stripped
- [x] `TestCleanResourceMap_AnnotationPreservation` — user annotations survive kubectl annotation removal
- [x] `TestCleanResourceMap_EmptyAnnotationsRemoved` — empty annotations map removed after stripping
- [x] `TestEncodeObjectsToYAML_BackwardCompatible` — updated to verify zero-value = Full stripping
- [x] `make check` passes (lint, vet, tests)