### PR TITLE
feat(cmd): add kure init scaffolding command

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,7 +42,15 @@
       "Bash(go run:*)",
       "Bash(go env:*)",
       "Bash(git pull:*)",
-      "Bash(go vet:*)"
+      "Bash(go vet:*)",
+      "Bash(git -C /home/serge/src/autops/wharf/kure diff)",
+      "Bash(git -C /home/serge/src/autops/wharf/kure add internal/kubernetes/job.go internal/kubernetes/job_test.go internal/kubernetes/setters_test.go pkg/kubernetes/cronjob.go pkg/kubernetes/cronjob_test.go pkg/kubernetes/doc.go pkg/kubernetes/README.md)",
+      "Bash(git -C /home/serge/src/autops/wharf/kure commit -m \"$\\(cat <<''EOF''\nfeat\\(kubernetes\\): expose CronJob helpers in pkg/kubernetes\n\nMove CronJob builder functions from internal/kubernetes to\npkg/kubernetes so external consumers \\(Crane\\) can generate CronJob\nresources. The public API uses inline implementations with explicit\nnil checks, matching the Deployment helper pattern. The constructor\ndefaults restartPolicy to Never to produce valid manifests out of\nthe box.\n\nCloses #177\nEOF\n\\)\")",
+      "Bash(git -C /home/serge/src/autops/wharf/kure push -u origin feat/expose-cronjob-helpers)",
+      "Bash(git -C /home/serge/src/autops/wharf/kure checkout main)",
+      "Bash(git -C /home/serge/src/autops/wharf/kure pull)",
+      "Bash(git stash:*)",
+      "Bash(git rebase:*)"
     ]
   },
   "outputStyle": "default"

--- a/pkg/cmd/kure/cmd.go
+++ b/pkg/cmd/kure/cmd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/go-kure/kure/pkg/cmd/kure/generate"
+	"github.com/go-kure/kure/pkg/cmd/kure/initialize"
 	"github.com/go-kure/kure/pkg/cmd/shared"
 	"github.com/go-kure/kure/pkg/cmd/shared/options"
 )
@@ -38,6 +39,7 @@ supporting both Flux and ArgoCD workflows for GitOps-native resource management.
 	// Add subcommands
 	cmd.AddCommand(
 		newGenerateCommand(globalOpts),
+		initialize.NewInitCommand(globalOpts),
 		NewPatchCommand(globalOpts),
 		newValidateCommand(globalOpts),
 		newConfigCommand(globalOpts),

--- a/pkg/cmd/kure/initialize/doc.go
+++ b/pkg/cmd/kure/initialize/doc.go
@@ -1,0 +1,4 @@
+// Package initialize implements the "kure init" command, which scaffolds
+// a new project directory with cluster configuration and example application
+// templates ready for use with "kure generate cluster".
+package initialize

--- a/pkg/cmd/kure/initialize/init.go
+++ b/pkg/cmd/kure/initialize/init.go
@@ -1,0 +1,210 @@
+package initialize
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/go-kure/kure/pkg/cli"
+	"github.com/go-kure/kure/pkg/cmd/shared/options"
+	"github.com/go-kure/kure/pkg/errors"
+)
+
+// dnsNameRegex validates RFC 1123 DNS label names.
+var dnsNameRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+
+// InitOptions contains options for the init command.
+type InitOptions struct {
+	ProjectName string
+	OutputDir   string
+	GitOpsType  string
+
+	Factory   cli.Factory
+	IOStreams cli.IOStreams
+}
+
+// NewInitCommand creates the init subcommand.
+func NewInitCommand(globalOpts *options.GlobalOptions) *cobra.Command {
+	factory := cli.NewFactory(globalOpts)
+	o := &InitOptions{
+		Factory:   factory,
+		IOStreams: factory.IOStreams(),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "init [PROJECT_NAME] [flags]",
+		Short: "Scaffold a new kure project",
+		Long: `Scaffold a new kure project with cluster configuration and example application templates.
+
+Creates a directory structure ready for use with "kure generate cluster":
+  cluster.yaml    - Cluster configuration
+  apps/           - Application definitions
+  infra/          - Infrastructure definitions
+
+Examples:
+  # Scaffold in current directory using directory name as project name
+  kure init
+
+  # Scaffold with explicit project name
+  kure init my-cluster
+
+  # Scaffold for ArgoCD
+  kure init my-cluster --gitops argocd
+
+  # Scaffold in a specific directory
+  kure init my-cluster --dir /path/to/project`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				o.ProjectName = args[0]
+			}
+
+			if err := o.Complete(); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			return o.Run()
+		},
+	}
+
+	o.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// AddFlags adds flags to the command.
+func (o *InitOptions) AddFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&o.OutputDir, "dir", ".", "target directory")
+	flags.StringVar(&o.GitOpsType, "gitops", "flux", "gitops tool: flux or argocd")
+}
+
+// Complete fills in defaults for unset fields.
+func (o *InitOptions) Complete() error {
+	// Resolve output directory to absolute path
+	absDir, err := filepath.Abs(o.OutputDir)
+	if err != nil {
+		return errors.Wrapf(err, "failed to resolve output directory")
+	}
+	o.OutputDir = absDir
+
+	// Default project name to directory basename
+	if o.ProjectName == "" {
+		o.ProjectName = filepath.Base(o.OutputDir)
+	}
+
+	return nil
+}
+
+// Validate checks that all options are valid.
+func (o *InitOptions) Validate() error {
+	if !dnsNameRegex.MatchString(o.ProjectName) {
+		return errors.NewValidationError(
+			"project-name", o.ProjectName, "init",
+			[]string{"must be a valid DNS label: lowercase alphanumeric and hyphens, e.g. my-cluster"},
+		)
+	}
+
+	validGitOps := []string{"flux", "argocd"}
+	if !contains(validGitOps, o.GitOpsType) {
+		return errors.NewValidationError("gitops", o.GitOpsType, "init", validGitOps)
+	}
+
+	// Refuse to overwrite existing cluster.yaml
+	clusterFile := filepath.Join(o.OutputDir, "cluster.yaml")
+	if _, err := os.Stat(clusterFile); err == nil {
+		return errors.NewFileError("init", clusterFile, "file already exists; remove it first to re-initialize", nil)
+	}
+
+	return nil
+}
+
+// Run executes the init command.
+func (o *InitOptions) Run() error {
+	// Create subdirectories
+	for _, dir := range []string{"apps", "infra"} {
+		dirPath := filepath.Join(o.OutputDir, dir)
+		if err := os.MkdirAll(dirPath, 0755); err != nil {
+			return errors.Wrapf(err, "failed to create directory %s", dir)
+		}
+	}
+
+	// Write cluster.yaml
+	clusterContent := fmt.Sprintf(clusterTemplate, o.ProjectName, o.GitOpsType)
+	clusterFile := filepath.Join(o.OutputDir, "cluster.yaml")
+	if err := os.WriteFile(clusterFile, []byte(clusterContent), 0644); err != nil {
+		return errors.Wrapf(err, "failed to write cluster.yaml")
+	}
+
+	// Write apps/example.yaml
+	exampleContent := appExampleTemplate
+	exampleFile := filepath.Join(o.OutputDir, "apps", "example.yaml")
+	if err := os.WriteFile(exampleFile, []byte(exampleContent), 0644); err != nil {
+		return errors.Wrapf(err, "failed to write apps/example.yaml")
+	}
+
+	// Print summary
+	fmt.Fprintf(o.IOStreams.ErrOut, "Initialized kure project %q in %s\n", o.ProjectName, o.OutputDir)
+	fmt.Fprintf(o.IOStreams.ErrOut, "  created cluster.yaml\n")
+	fmt.Fprintf(o.IOStreams.ErrOut, "  created apps/example.yaml\n")
+	fmt.Fprintf(o.IOStreams.ErrOut, "  created apps/\n")
+	fmt.Fprintf(o.IOStreams.ErrOut, "  created infra/\n")
+	fmt.Fprintf(o.IOStreams.ErrOut, "\nNext steps:\n")
+	fmt.Fprintf(o.IOStreams.ErrOut, "  Edit apps/example.yaml or add more app configs under apps/\n")
+	fmt.Fprintf(o.IOStreams.ErrOut, "  Run: kure generate cluster cluster.yaml\n")
+
+	return nil
+}
+
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+// Templates — simple runtime format consumed by "kure generate cluster".
+
+const clusterTemplate = `name: %s
+gitops:
+  type: %s
+  bootstrap:
+    enabled: true
+    sourceURL: "oci://ghcr.io/example/cluster-manifests"
+    sourceRef: "v1.0.0"
+node:
+  name: flux-system
+  children:
+    - name: apps
+    - name: infra
+`
+
+const appExampleTemplate = `apiVersion: generators.gokure.dev/v1alpha1
+kind: AppWorkload
+metadata:
+  name: example
+  namespace: apps
+spec:
+  workload: Deployment
+  replicas: 1
+  containers:
+    - name: app
+      image: nginx:1.27-alpine
+      ports:
+        - name: http
+          containerPort: 80
+      resources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 128Mi
+          cpu: 100m
+`

--- a/pkg/cmd/kure/initialize/init_test.go
+++ b/pkg/cmd/kure/initialize/init_test.go
@@ -1,0 +1,362 @@
+package initialize
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/go-kure/kure/pkg/cli"
+	"github.com/go-kure/kure/pkg/cmd/shared/options"
+	"github.com/go-kure/kure/pkg/stack"
+
+	// Register generators so ApplicationWrapper can decode AppWorkload specs.
+	_ "github.com/go-kure/kure/pkg/stack/generators/appworkload"
+)
+
+// newTestOptions creates InitOptions wired to captured IO buffers.
+func newTestOptions(t *testing.T, projectName, dir, gitops string) (*InitOptions, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	globalOpts := options.NewGlobalOptions()
+	factory := cli.NewFactory(globalOpts)
+
+	var stdout, stderr bytes.Buffer
+	streams := cli.IOStreams{
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+
+	return &InitOptions{
+		ProjectName: projectName,
+		OutputDir:   dir,
+		GitOpsType:  gitops,
+		Factory:     factory,
+		IOStreams:   streams,
+	}, &stdout, &stderr
+}
+
+func TestInitCreatesProjectStructure(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	o, _, _ := newTestOptions(t, "my-cluster", tmpDir, "flux")
+	if err := o.Complete(); err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if err := o.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if err := o.Run(); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	// Verify files and directories exist
+	for _, path := range []string{
+		"cluster.yaml",
+		"apps",
+		"apps/example.yaml",
+		"infra",
+	} {
+		full := filepath.Join(tmpDir, path)
+		if _, err := os.Stat(full); os.IsNotExist(err) {
+			t.Errorf("expected %s to exist", path)
+		}
+	}
+}
+
+func TestInitClusterYAMLIsValid(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	o, _, _ := newTestOptions(t, "test-cluster", tmpDir, "flux")
+	if err := o.Complete(); err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if err := o.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if err := o.Run(); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	// Parse cluster.yaml into stack.Cluster
+	data, err := os.ReadFile(filepath.Join(tmpDir, "cluster.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read cluster.yaml: %v", err)
+	}
+
+	var cluster stack.Cluster
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	if err := dec.Decode(&cluster); err != nil {
+		t.Fatalf("failed to decode cluster.yaml: %v", err)
+	}
+
+	if cluster.Name != "test-cluster" {
+		t.Errorf("cluster.Name = %q, want %q", cluster.Name, "test-cluster")
+	}
+	if cluster.GitOps == nil {
+		t.Fatal("cluster.GitOps is nil")
+	}
+	if cluster.GitOps.Type != "flux" {
+		t.Errorf("cluster.GitOps.Type = %q, want %q", cluster.GitOps.Type, "flux")
+	}
+	if cluster.Node == nil {
+		t.Fatal("cluster.Node is nil")
+	}
+	if cluster.Node.Name != "flux-system" {
+		t.Errorf("cluster.Node.Name = %q, want %q", cluster.Node.Name, "flux-system")
+	}
+	if len(cluster.Node.Children) != 2 {
+		t.Fatalf("len(cluster.Node.Children) = %d, want 2", len(cluster.Node.Children))
+	}
+
+	childNames := make(map[string]bool)
+	for _, child := range cluster.Node.Children {
+		childNames[child.Name] = true
+	}
+	for _, expected := range []string{"apps", "infra"} {
+		if !childNames[expected] {
+			t.Errorf("expected child node %q not found", expected)
+		}
+	}
+}
+
+func TestInitAppYAMLIsValid(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	o, _, _ := newTestOptions(t, "my-cluster", tmpDir, "flux")
+	if err := o.Complete(); err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if err := o.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if err := o.Run(); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	// Parse apps/example.yaml via ApplicationWrapper
+	data, err := os.ReadFile(filepath.Join(tmpDir, "apps", "example.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read apps/example.yaml: %v", err)
+	}
+
+	var wrapper stack.ApplicationWrapper
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	if err := dec.Decode(&wrapper); err != nil {
+		t.Fatalf("failed to decode apps/example.yaml: %v", err)
+	}
+
+	if wrapper.Metadata.Name != "example" {
+		t.Errorf("metadata.name = %q, want %q", wrapper.Metadata.Name, "example")
+	}
+	if wrapper.Metadata.Namespace != "apps" {
+		t.Errorf("metadata.namespace = %q, want %q", wrapper.Metadata.Namespace, "apps")
+	}
+
+	// Verify ToApplication succeeds
+	app := wrapper.ToApplication()
+	if app == nil {
+		t.Fatal("ToApplication() returned nil")
+	}
+	if app.Name != "example" {
+		t.Errorf("app.Name = %q, want %q", app.Name, "example")
+	}
+}
+
+func TestInitRefusesOverwrite(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// First run succeeds
+	o1, _, _ := newTestOptions(t, "my-cluster", tmpDir, "flux")
+	if err := o1.Complete(); err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if err := o1.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if err := o1.Run(); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	// Second run must fail at Validate
+	o2, _, _ := newTestOptions(t, "my-cluster", tmpDir, "flux")
+	if err := o2.Complete(); err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	err := o2.Validate()
+	if err == nil {
+		t.Fatal("expected error on second init, got nil")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("expected 'already exists' in error, got %q", err.Error())
+	}
+}
+
+func TestInitValidatesProjectName(t *testing.T) {
+	tests := []struct {
+		name    string
+		project string
+		wantErr bool
+	}{
+		{"valid lowercase", "my-cluster", false},
+		{"valid single word", "cluster", false},
+		{"valid with numbers", "cluster-01", false},
+		{"uppercase rejected", "My-Cluster", true},
+		{"underscores rejected", "my_cluster", true},
+		{"dots rejected", "my.cluster", true},
+		{"starts with hyphen", "-cluster", true},
+		{"ends with hyphen", "cluster-", true},
+		{"empty string", "", true},
+		{"spaces rejected", "my cluster", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			o, _, _ := newTestOptions(t, tt.project, tmpDir, "flux")
+			// Skip Complete to test Validate directly with the exact project name
+			o.OutputDir = tmpDir
+			err := o.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestInitValidatesGitOpsType(t *testing.T) {
+	tests := []struct {
+		name    string
+		gitops  string
+		wantErr bool
+	}{
+		{"flux accepted", "flux", false},
+		{"argocd accepted", "argocd", false},
+		{"invalid rejected", "invalid", true},
+		{"empty rejected", "", true},
+		{"capitalize rejected", "Flux", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			o, _, _ := newTestOptions(t, "my-cluster", tmpDir, tt.gitops)
+			o.OutputDir = tmpDir
+			err := o.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestInitArgoCD(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	o, _, _ := newTestOptions(t, "my-cluster", tmpDir, "argocd")
+	if err := o.Complete(); err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if err := o.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if err := o.Run(); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "cluster.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read cluster.yaml: %v", err)
+	}
+
+	var cluster stack.Cluster
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	if err := dec.Decode(&cluster); err != nil {
+		t.Fatalf("failed to decode cluster.yaml: %v", err)
+	}
+
+	if cluster.GitOps == nil {
+		t.Fatal("cluster.GitOps is nil")
+	}
+	if cluster.GitOps.Type != "argocd" {
+		t.Errorf("cluster.GitOps.Type = %q, want %q", cluster.GitOps.Type, "argocd")
+	}
+}
+
+func TestInitCompleteDefaultsProjectName(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	o, _, _ := newTestOptions(t, "", tmpDir, "flux")
+	if err := o.Complete(); err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+
+	expected := filepath.Base(tmpDir)
+	if o.ProjectName != expected {
+		t.Errorf("ProjectName = %q, want %q", o.ProjectName, expected)
+	}
+}
+
+func TestInitCompleteResolvesAbsolutePath(t *testing.T) {
+	o, _, _ := newTestOptions(t, "test", ".", "flux")
+	if err := o.Complete(); err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+
+	if !filepath.IsAbs(o.OutputDir) {
+		t.Errorf("OutputDir %q is not absolute", o.OutputDir)
+	}
+}
+
+func TestNewInitCommand(t *testing.T) {
+	globalOpts := options.NewGlobalOptions()
+	cmd := NewInitCommand(globalOpts)
+
+	if cmd == nil {
+		t.Fatal("expected non-nil init command")
+	}
+
+	if cmd.Use != "init [PROJECT_NAME] [flags]" {
+		t.Errorf("unexpected Use: %s", cmd.Use)
+	}
+
+	if cmd.Short == "" {
+		t.Error("expected non-empty short description")
+	}
+
+	// Check flags exist
+	for _, flag := range []string{"dir", "gitops"} {
+		if cmd.Flags().Lookup(flag) == nil {
+			t.Errorf("expected flag %q to exist", flag)
+		}
+	}
+}
+
+func TestInitSummaryOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	o, _, stderr := newTestOptions(t, "my-cluster", tmpDir, "flux")
+	if err := o.Complete(); err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if err := o.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if err := o.Run(); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	output := stderr.String()
+	for _, expected := range []string{
+		"Initialized kure project",
+		"cluster.yaml",
+		"apps/example.yaml",
+		"kure generate cluster",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("expected stderr to contain %q, got:\n%s", expected, output)
+		}
+	}
+}

--- a/site/content/guides/generators.md
+++ b/site/content/guides/generators.md
@@ -7,6 +7,23 @@ weight = 30
 
 Generators provide a type-safe way to create application workloads from configuration. They implement the `ApplicationConfig` interface and are identified by GroupVersionKind (GVK) strings.
 
+## Getting Started
+
+The fastest way to start a new project is with `kure init`:
+
+```bash
+kure init my-cluster
+```
+
+This creates a ready-to-use directory structure with `cluster.yaml` and an
+example application under `apps/`. You can then generate manifests with:
+
+```bash
+kure generate cluster cluster.yaml
+```
+
+See `kure init --help` for options like `--gitops argocd`.
+
 ## The GVK System
 
 Each generator is registered with a GVK identifier that uniquely identifies its type:


### PR DESCRIPTION
## Summary

Closes #136.

- Adds `kure init [PROJECT_NAME]` command to scaffold a new project directory with `cluster.yaml`, `apps/example.yaml`, and `apps/` + `infra/` directories
- Supports `--gitops flux|argocd` and `--dir` flags
- Generated files are directly consumable by `kure generate cluster`
- Refuses to overwrite an existing `cluster.yaml` to prevent data loss

## Test plan

- [x] `make precommit` passes (fmt, tidy, lint, test)
- [ ] Manual smoke test: `kure init my-cluster && kure generate cluster cluster.yaml --dry-run`
- [ ] Verify `--gitops argocd` produces correct `type: argocd` in cluster.yaml
- [ ] Verify running `kure init` twice in the same directory fails with a clear error