### PR TITLE
docs: update branch protection docs for ruleset migration

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -48,14 +48,16 @@ The `main` branch is protected — all changes must go through pull requests.
 
 ### Branch Protection Rules
 
+Enforced via the `main-protection` [repository ruleset](https://github.com/go-kure/kure/rules/12903081):
+
 - **Required status checks** (strict): `lint`, `test`, `build`, `rebase-check`
 - **Auto-rebase**: open PRs are automatically rebased when main is updated (via `auto-rebase.yml`)
-- **Required reviews**: 1 approving review
+- **Pull requests required**: all changes must go through a PR
+- **Conversation resolution**: all review threads must be resolved
 - **Linear history**: enforced (rebase only, no merge commits)
-- **Conversation resolution**: all conversations must be resolved
 - **Force pushes**: disabled
 - **Branch deletion**: disabled
-- **Enforced for admins**: yes
+- **Bypass actors**: `kure-release-bot` (GitHub App) — allowed to push release commits directly
 
 ## Development Workflow
 
@@ -214,7 +216,7 @@ The project uses several GitHub Actions workflows:
 - **Triggers**: Manual (`workflow_dispatch`)
 - **Inputs**: Release type (alpha/beta/rc/stable/bump), scope, dry-run
 - **Purpose**: Creates release commits and tags on `main`, pushes atomically
-- **Auth**: Uses GitHub App token (`RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY`) to push past branch protection
+- **Auth**: Uses GitHub App token (`RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY`); the `kure-release-bot` App is listed as a bypass actor in the `main-protection` repository ruleset, allowing it to push release commits directly to `main`
 - **Concurrency**: Only one release at a time (`release-create` group)
 
 To create a release:


### PR DESCRIPTION
## Summary

- Updated `DEVELOPMENT.md` to reflect the migration from classic GitHub branch protection to a repository ruleset (`main-protection`)
- Documents the `kure-release-bot` App as a bypass actor in the ruleset
- Fixes inaccurate claim that App tokens bypass `enforce_admins`

## Context

The "Create Release" workflow ([run #22095827756](https://github.com/go-kure/kure/actions/runs/22095827756/job/63852520405)) failed because the `kure-release-bot` App token could not push to `main` — classic branch protection has no bypass mechanism for GitHub App tokens.

**Fix applied (outside this PR):**
1. Created `main-protection` repository ruleset with `kure-release-bot` as a bypass actor
2. Deleted classic branch protection

This PR updates the documentation to match the new configuration.

## Follow-up

The `meta/` repo has related documentation and automation that also needs updating (separate MR):
- `meta/standards/release-process.md` — incorrect App token bypass claim
- `meta/standards/repository-settings-policy.yaml` — still describes classic protection
- `meta/scripts/github-settings.sh` — manages classic protection only
- `meta/guides/release-migration.md` — incorrect App token bypass claim

**Warning**: Do not run `github-settings.sh --apply` on kure until it is updated — it would re-create classic branch protection.

## Test plan

- [ ] Verify ruleset exists: `gh api repos/go-kure/kure/rulesets --jq '.[].name'` → `main-protection`
- [ ] Verify classic protection removed: `gh api repos/go-kure/kure/branches/main/protection` → 404
- [ ] Re-run the release workflow: Actions > "Create Release" > type=beta > dry_run=false