### PR TITLE
fix: add release notes extraction to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,11 +94,17 @@ jobs:
       - name: Install syft
         uses: anchore/sbom-action/download-syft@v0
 
+      - name: Install git-cliff
+        uses: kenji-miyake/setup-git-cliff@v2
+
+      - name: Extract release notes
+        run: git-cliff --latest --strip header -o release-notes.md
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"
-          args: release --clean
+          args: release --clean --release-notes release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Install `git-cliff` in the `goreleaser` job and extract the current tag's changelog section before running GoReleaser
- Pass `--release-notes release-notes.md` to GoReleaser so GitHub Releases have proper changelogs
- Root cause: `.goreleaser.yml` disables the built-in changelog (`changelog: disable: true`) but nothing was feeding release notes from `git-cliff`

All releases since `v0.1.0-alpha.1` had empty release notes. The 3 affected releases (`v0.1.0-alpha.3`, `v0.1.0-alpha.4`, `v0.1.0-beta.0`) have been backfilled via `gh release edit`.

Also updated issue #199 to check off 5 completed roadmap items (#195, #196, #197, #136, #139) and added an investigation comment.

## Test plan

- [ ] Verify `make check` passes (no Go code changes)
- [ ] Confirm backfilled releases show changelog content on GitHub
- [ ] Confirm next tag push generates release notes automatically (dry-run or next release)