### PR TITLE
fix(docs): resolve 30+ broken links on gokure.dev

### DIFF
--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -291,6 +291,5 @@ Most workflows use Go module caching:
 
 ## See Also
 
-- [Makefile](../Makefile) - Local development commands
-- [CLAUDE.md](../CLAUDE.md) - Development guidelines
-- [mise.toml](../mise.toml) - Local tool version management
+- [Makefile](https://github.com/go-kure/kure/blob/main/Makefile) - Local development commands
+- [mise.toml](https://github.com/go-kure/kure/blob/main/mise.toml) - Local tool version management

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -134,8 +134,8 @@ flux reconcile kustomization flux-system --with-source
 
 ## Next Steps
 
-- **Architecture**: Read [ARCHITECTURE.md](ARCHITECTURE.md) for a deep dive into Kure's design
+- **Architecture**: Read the [Architecture](/concepts/architecture/) page for a deep dive into Kure's design
 - **Examples**: Explore the `examples/` directory for more complex configurations
 - **API Reference**: See the full API at [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure)
-- **Patching**: Learn about declarative patching in the [README](../README.md#declarative-patching)
+- **Patching**: Learn about declarative patching in the [README](https://github.com/go-kure/kure#declarative-patching)
 - **CLI Reference**: Run `kure --help` and `kurel --help` for all available commands

--- a/examples/generators/README.md
+++ b/examples/generators/README.md
@@ -15,7 +15,7 @@ Kure uses a Group, Version, Kind (GVK) pattern similar to Kubernetes for identif
 
 Creates standard Kubernetes workloads (Deployments, StatefulSets, DaemonSets) with associated resources.
 
-**Example:** [`appworkload.yaml`](appworkload.yaml)
+**Example:** [`appworkload.yaml`](https://github.com/go-kure/kure/blob/main/examples/generators/appworkload.yaml)
 
 This example creates:
 - A Deployment with 3 replicas
@@ -28,8 +28,8 @@ This example creates:
 Creates Flux HelmRelease resources with their source configurations.
 
 **Examples:**
-- [`fluxhelm.yaml`](fluxhelm.yaml) - Traditional Helm repository source
-- [`fluxhelm-oci.yaml`](fluxhelm-oci.yaml) - OCI registry source
+- [`fluxhelm.yaml`](https://github.com/go-kure/kure/blob/main/examples/generators/fluxhelm.yaml) - Traditional Helm repository source
+- [`fluxhelm-oci.yaml`](https://github.com/go-kure/kure/blob/main/examples/generators/fluxhelm-oci.yaml) - OCI registry source
 
 These examples demonstrate:
 - HelmRepository and OCIRepository sources

--- a/examples/validation/README.md
+++ b/examples/validation/README.md
@@ -37,4 +37,4 @@ kure validate examples/validation/bundle-intervals.yaml
 go run examples/validation/test-validation.go
 ```
 
-For more information, see the main [README.md](../../README.md#configuration-validation) validation section.
+For more information, see the main [README.md](https://github.com/go-kure/kure#configuration-validation) validation section.

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -57,6 +57,6 @@ config, err := cli.LoadConfig("~/.kure/config.yaml")
 
 ## Related Packages
 
-- [pkg/cmd/kure](../cmd/kure/) - kure CLI command implementation
-- [pkg/cmd/kurel](../cmd/kurel/) - kurel CLI command implementation
+- [pkg/cmd/kure](/api-reference/cli/) - kure CLI command implementation
+- [pkg/cmd/kurel](https://pkg.go.dev/github.com/go-kure/kure/pkg/cmd/kurel) - kurel CLI command implementation
 - [io](../io/) - Resource printing and serialization

--- a/pkg/io/README.md
+++ b/pkg/io/README.md
@@ -137,4 +137,4 @@ err := printer.Print(objects, os.Stdout)
 ## Related Packages
 
 - [errors](../errors/) - Error types for parse failures
-- [kubernetes](../kubernetes/) - Scheme registration for type-aware parsing
+- [kubernetes](/api-reference/kubernetes-builders/) - Scheme registration for type-aware parsing

--- a/pkg/kubernetes/README.md
+++ b/pkg/kubernetes/README.md
@@ -163,5 +163,5 @@ err = kubernetes.AddIngressTLS(ing, netv1.IngressTLS{
 
 ## Related Packages
 
-- [fluxcd](fluxcd/) - FluxCD resource constructors
+- [fluxcd](/api-reference/fluxcd-builders/) - FluxCD resource constructors
 - [errors](../errors/) - Structured error types used for nil-check sentinels

--- a/pkg/kubernetes/fluxcd/README.md
+++ b/pkg/kubernetes/fluxcd/README.md
@@ -136,5 +136,5 @@ err := fluxcd.AddKustomizationDependency(ks, kustv1.Dependency{
 
 ## Related Packages
 
-- [stack/fluxcd](../../stack/fluxcd/) - High-level Flux workflow engine
-- [stack](../../stack/) - Domain model that produces Flux resources
+- [stack/fluxcd](/api-reference/flux-engine/) - High-level Flux workflow engine
+- [stack](/api-reference/stack/) - Domain model that produces Flux resources

--- a/pkg/launcher/README.md
+++ b/pkg/launcher/README.md
@@ -334,9 +334,9 @@ Kurel is part of the [Kure](https://github.com/go-kure/kure) project. See the ma
 
 ## 📚 Documentation
 
-- [Design Specification](DESIGN.md) - Technical design and architecture
-- [Detailed Design Document](DESIGN-DETAILS.md) - Complete design discussion and decisions
-- [Kure Documentation](../../../README.md) - Main project documentation
+- [Design Specification](https://github.com/go-kure/kure/blob/main/pkg/launcher/DESIGN.md) - Technical design and architecture
+- [Detailed Design Document](https://github.com/go-kure/kure/blob/main/pkg/launcher/DESIGN-DETAILS.md) - Complete design discussion and decisions
+- [Kure Documentation](https://github.com/go-kure/kure#readme) - Main project documentation
 
 ## 🎯 Philosophy
 

--- a/pkg/patch/README.md
+++ b/pkg/patch/README.md
@@ -136,7 +136,7 @@ patchSet.KindLookup = lookup
 resolved, reports, err := patchSet.ResolveWithConflictCheck()
 ```
 
-SMP patches are applied before field-level patches. See [DESIGN.md](DESIGN.md) for full specification.
+SMP patches are applied before field-level patches. See [DESIGN.md](https://github.com/go-kure/kure/blob/main/pkg/patch/DESIGN.md) for full specification.
 
 ## API Reference
 

--- a/pkg/stack/README.md
+++ b/pkg/stack/README.md
@@ -156,7 +156,6 @@ node.SetPackageRef(&stack.SourceRef{
 
 ## Related Packages
 
-- [stack/fluxcd](fluxcd/) - FluxCD workflow engine implementation
-- [stack/generators](generators/) - Application generator system
-- [stack/layout](layout/) - Manifest directory organization
-- [stack/argocd](argocd/) - ArgoCD workflow (deferred)
+- [stack/fluxcd](/api-reference/flux-engine/) - FluxCD workflow engine implementation
+- [stack/generators](/api-reference/generators/) - Application generator system
+- [stack/layout](/api-reference/layout/) - Manifest directory organization

--- a/pkg/stack/fluxcd/README.md
+++ b/pkg/stack/fluxcd/README.md
@@ -116,4 +116,4 @@ Controls where Flux Kustomization resources are placed:
 
 - [stack](../) - Core domain model
 - [stack/layout](../layout/) - Manifest directory organization
-- [kubernetes/fluxcd](../../kubernetes/fluxcd/) - Low-level Flux resource builders
+- [kubernetes/fluxcd](/api-reference/fluxcd-builders/) - Low-level Flux resource builders

--- a/pkg/stack/generators/README.md
+++ b/pkg/stack/generators/README.md
@@ -93,4 +93,4 @@ Generates Kubernetes resource objects from kurel packages. The `Generate()` meth
 ## Related Packages
 
 - [stack](../) - Core domain model and ApplicationConfig interface
-- [stack/fluxcd](../fluxcd/) - Flux workflow engine
+- [stack/fluxcd](/api-reference/flux-engine/) - Flux workflow engine

--- a/site/content/concepts/domain-model.md
+++ b/site/content/concepts/domain-model.md
@@ -85,4 +85,4 @@ The [Layout Engine](/api-reference/layout) handles this mapping, and the [Flux E
 
 - [Stack package reference](/api-reference/stack) for API details
 - [Flux workflow guide](/guides/flux-workflow) for end-to-end usage
-- [Architecture](architecture) for system-level design
+- [Architecture](/concepts/architecture/) for system-level design

--- a/site/content/guides/flux-workflow.md
+++ b/site/content/guides/flux-workflow.md
@@ -135,4 +135,4 @@ objects, err := engine.GenerateBootstrap(bootstrapConfig, rootNode)
 - [Stack](/api-reference/stack) - Domain model reference
 - [Flux Engine](/api-reference/flux-engine) - Workflow engine reference
 - [Layout Engine](/api-reference/layout) - Directory organization reference
-- [Generators](generators) - Application generator guide
+- [Generators](/guides/generators/) - Application generator guide

--- a/site/content/guides/generators.md
+++ b/site/content/guides/generators.md
@@ -112,4 +112,4 @@ The factory must implement the generator interface, providing a `FromConfig` met
 
 - [Generators reference](/api-reference/generators) for API details
 - [Generator examples](/examples/generators) for working samples
-- [Flux workflow](flux-workflow) for using generators in clusters
+- [Flux workflow](/guides/flux-workflow/) for using generators in clusters

--- a/site/content/guides/kurel-packages.md
+++ b/site/content/guides/kurel-packages.md
@@ -54,7 +54,7 @@ Place standard Kubernetes manifests in `resources/`. These are the starting poin
 
 ### 3. Write Patches
 
-Patches customize the base resources. See the [Patching guide](patching) for the TOML patch format.
+Patches customize the base resources. See the [Patching guide](/guides/patching/) for the TOML patch format.
 
 ### 4. Add Conditional Patches
 
@@ -110,4 +110,4 @@ my-app.local.kurel/
 
 - [Launcher reference](/api-reference/launcher) for the package system API
 - [Kurel Frigate example](/examples/kurel-frigate) for a complete package
-- [Patching guide](patching) for the patch format
+- [Patching guide](/guides/patching/) for the patch format

--- a/site/content/guides/library-usage.md
+++ b/site/content/guides/library-usage.md
@@ -102,7 +102,7 @@ cluster := stack.NewClusterBuilder("production").
     Build()
 ```
 
-Then use the [Flux Engine](/api-reference/flux-engine) and [Layout Engine](/api-reference/layout) to generate a complete GitOps repository structure. See the [Generating Flux Manifests](flux-workflow) guide for the full workflow.
+Then use the [Flux Engine](/api-reference/flux-engine) and [Layout Engine](/api-reference/layout) to generate a complete GitOps repository structure. See the [Generating Flux Manifests](/guides/flux-workflow/) guide for the full workflow.
 
 ## Error Handling
 
@@ -118,6 +118,6 @@ if err != nil {
 
 ## Next Steps
 
-- [Generating Flux Manifests](flux-workflow) for the complete workflow
+- [Generating Flux Manifests](/guides/flux-workflow/) for the complete workflow
 - [API Reference](/api-reference) for all package documentation
 - [Examples](/examples) for working code samples

--- a/site/content/guides/patching.md
+++ b/site/content/guides/patching.md
@@ -187,4 +187,4 @@ for _, r := range reports {
 
 - [Patch reference](/api-reference/patch) for API details
 - [Patch examples](/examples/patches) for working samples
-- [Kurel packages](kurel-packages) for patch-based package customization
+- [Kurel packages](/guides/kurel-packages/) for patch-based package customization


### PR DESCRIPTION
## Summary

Fixes 30+ broken links across package READMEs, guides, and docs that work when browsing the GitHub repo but 404 on the Hugo-built site (www.gokure.dev).

**Root cause:** Relative links written for GitHub navigation don't resolve correctly when those files are mounted into Hugo's flat content tree via `site/scripts/inject-frontmatter.sh`.

### Fix categories

- **Pattern A — Package README cross-references (12 links):** Replace relative directory paths (`../fluxcd/`, `fluxcd/`) with absolute site paths (`/api-reference/flux-engine/`)
- **Pattern B — Links to non-page files (10 links):** Replace with GitHub blob URLs for files not mounted as Hugo pages (DESIGN.md, .yaml examples, Makefile, mise.toml)
- **Pattern C — Cross-section guide links (8 links):** Use absolute paths with leading `/` to prevent Hugo from resolving relative to the current page URL
- **Pattern D — Other broken references (3 links):** Fix ARCHITECTURE.md and README.md fragment links

### Also

- Removes the deferred `stack/argocd` entry from `pkg/stack/README.md` (no site page exists)
- Removes the internal `CLAUDE.md` reference from `docs/github-workflows.md` See Also section

### Files changed (19)

| Category | Files |
|----------|-------|
| Package READMEs | `pkg/cli`, `pkg/io`, `pkg/kubernetes`, `pkg/kubernetes/fluxcd`, `pkg/launcher`, `pkg/patch`, `pkg/stack`, `pkg/stack/fluxcd`, `pkg/stack/generators` |
| Docs | `docs/github-workflows.md`, `docs/quickstart.md` |
| Examples | `examples/generators/README.md`, `examples/validation/README.md` |
| Site content | `site/content/guides/{flux-workflow,generators,kurel-packages,library-usage,patching}.md`, `site/content/concepts/domain-model.md` |

## Test plan

- [x] `hugo build` passes with zero errors
- [x] `make check` passes (lint, vet, tests)
- [ ] Spot-check fixed links on deployed site after merge
- [ ] Re-run broken link checker against www.gokure.dev to confirm all 30 are resolved

Closes #211