### PR TITLE
build: trigger versioned docs deployment on stable release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,31 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  deploy-docs:
+    name: Deploy versioned docs
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: "!contains(github.ref_name, '-')"
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Trigger versioned docs deployment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF##*/}"
+          # Extract minor version: v0.1.0 → v0.1
+          MINOR="${TAG%.*}"
+          echo "Triggering docs deployment: tag=${TAG}, slot=${MINOR}"
+          gh workflow run deploy-docs.yml \
+            --repo "${{ github.repository }}" \
+            --ref "${TAG}" \
+            -f version_slot="${MINOR}" \
+            -f version_label="${TAG}" \
+            -f set_latest=true
+
   post-release:
     needs: goreleaser
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `deploy-docs` job to `release.yml` that triggers `deploy-docs.yml` via `workflow_dispatch` for stable releases
- Filters for stable tags only (`!contains(github.ref_name, '-')`)
- Extracts minor version from tag (e.g., `v0.1.0` → `v0.1`) for the version slot
- Sets `set_latest=true` so root `/` is updated to the latest stable
- Runs parallel with `post-release`

## Test plan

- [ ] Create a stable release tag → verify `deploy-docs.yml` is triggered with correct inputs
- [ ] Create a pre-release tag (e.g., `-beta.1`) → verify `deploy-docs` job is skipped

Depends on: #226
Closes #217