### PR TITLE
build: add manage-docs admin workflow

### DIFF
--- a/.github/workflows/manage-docs.yml
+++ b/.github/workflows/manage-docs.yml
@@ -1,0 +1,94 @@
+name: Manage Docs
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Action to perform'
+        required: true
+        type: choice
+        options:
+          - remove-version
+          - set-latest
+          - rebuild-version
+      version_slot:
+        description: 'Target version slot (e.g., v0.1, dev)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: manage-docs
+  cancel-in-progress: false
+
+jobs:
+  remove-version:
+    name: Remove version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: inputs.action == 'remove-version'
+
+    steps:
+    - name: Checkout go-kure.github.io
+      uses: actions/checkout@v6
+      with:
+        repository: go-kure/go-kure.github.io
+        token: ${{ secrets.DEPLOY_TOKEN }}
+
+    - name: Remove version directory
+      run: |
+        SLOT="${{ inputs.version_slot }}"
+        if [[ ! -d "$SLOT" ]]; then
+          echo "::error::Directory /${SLOT}/ does not exist"
+          exit 1
+        fi
+        echo "Removing /${SLOT}/..."
+        rm -rf "$SLOT"
+
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add -A
+        git commit -m "docs: remove /${SLOT}/ version"
+        git push
+
+  set-latest:
+    name: Set latest version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: inputs.action == 'set-latest'
+
+    steps:
+    - name: Trigger deploy-docs with set_latest
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        SLOT="${{ inputs.version_slot }}"
+        # For set-latest, use the slot as the version label
+        echo "Setting /${SLOT}/ as latest (deploying to root)..."
+        gh workflow run deploy-docs.yml \
+          --repo "${{ github.repository }}" \
+          -f version_slot="${SLOT}" \
+          -f version_label="${SLOT}" \
+          -f set_latest=true
+
+  rebuild-version:
+    name: Rebuild version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: inputs.action == 'rebuild-version'
+
+    steps:
+    - name: Trigger deploy-docs rebuild
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        SLOT="${{ inputs.version_slot }}"
+        echo "Rebuilding /${SLOT}/..."
+        gh workflow run deploy-docs.yml \
+          --repo "${{ github.repository }}" \
+          -f version_slot="${SLOT}" \
+          -f version_label="${SLOT}" \
+          -f set_latest=false


### PR DESCRIPTION
## Summary

- Create `manage-docs.yml` workflow for exceptional documentation operations
- Three actions via `workflow_dispatch`:
  - **remove-version**: delete a version's docs directory from the deploy target
  - **set-latest**: change which version is served at root `/` (rollback scenario)
  - **rebuild-version**: re-trigger a docs build for a specific version

## Test plan

- [ ] `remove-version` with an existing version slot removes the directory
- [ ] `set-latest` triggers `deploy-docs.yml` with `set_latest=true`
- [ ] `rebuild-version` triggers `deploy-docs.yml` with `set_latest=false`

Depends on: #226
Closes #218