### PR TITLE
fix: use json.Marshal for HelmRelease values encoding

### DIFF
--- a/pkg/stack/generators/fluxhelm/internal/fluxhelm.go
+++ b/pkg/stack/generators/fluxhelm/internal/fluxhelm.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/fluxcd/pkg/apis/kustomize"
 	"github.com/fluxcd/pkg/apis/meta"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	"gopkg.in/yaml.v3"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -380,9 +380,9 @@ func (c *Config) generateHelmRelease() (client.Object, error) {
 
 	// Set values if provided
 	if c.Values != nil {
-		// Convert values to YAML for the JSON raw field
+		// Convert values to JSON for the apiextensionsv1.JSON raw field
 		valuesJSON := &apiextensionsv1.JSON{}
-		raw, err := yaml.Marshal(c.Values)
+		raw, err := json.Marshal(c.Values)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal Helm values: %w", err)
 		}

--- a/pkg/stack/generators/fluxhelm/internal/fluxhelm_test.go
+++ b/pkg/stack/generators/fluxhelm/internal/fluxhelm_test.go
@@ -7,7 +7,6 @@ import (
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	"gopkg.in/yaml.v3"
 )
 
 func TestGenerateResources(t *testing.T) {
@@ -405,7 +404,7 @@ func TestGenerateHelmRelease(t *testing.T) {
 		t.Errorf("SourceRef kind = %s, want HelmRepository", release.Spec.Chart.Spec.SourceRef.Kind)
 	}
 
-	// Test values - the values are stored as YAML in the Raw field
+	// Test values - the values are stored as JSON in the Raw field
 	if release.Spec.Values == nil {
 		t.Fatal("Values is nil")
 	}
@@ -413,7 +412,7 @@ func TestGenerateHelmRelease(t *testing.T) {
 		t.Fatal("Values Raw data is empty")
 	}
 	// Just verify the values were set - detailed parsing isn't crucial for this test
-	// since the values are YAML marshaled in the implementation
+	// since the values are JSON marshaled in the implementation
 
 	// Test timeout
 	if release.Spec.Timeout == nil || release.Spec.Timeout.Duration != 10*time.Minute {
@@ -753,8 +752,8 @@ func TestComplexValues(t *testing.T) {
 	}
 
 	var parsedValues map[string]interface{}
-	if err := yaml.Unmarshal(release.Spec.Values.Raw, &parsedValues); err != nil {
-		t.Fatalf("Failed to parse values YAML: %v", err)
+	if err := json.Unmarshal(release.Spec.Values.Raw, &parsedValues); err != nil {
+		t.Fatalf("Failed to parse values JSON: %v", err)
 	}
 
 	// Check nested values


### PR DESCRIPTION
## Summary

- Fix `apiextensionsv1.JSON.Raw` encoding: replace `yaml.Marshal` with `json.Marshal` in `fluxhelm` generator
- The `Raw` field expects JSON bytes, but was receiving YAML — this works for simple values but breaks for YAML-specific constructs (block scalars, unquoted special-char keys, timestamps)
- Remove unused `gopkg.in/yaml.v3` dependency from both source and test files

## Test plan

- [x] `mise run verify` passes (tidy, lint, test)
- [x] `TestComplexValues` updated to use `json.Unmarshal` matching the new encoding
- [x] All existing tests pass unchanged (simple values are valid in both formats)

Closes #232