### PR TITLE
chore: align golangci-lint config with Wharf standard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,157 +1,49 @@
-# golangci-lint configuration for Kure project
-# This configuration is tailored to be practical while maintaining code quality
+# golangci-lint configuration for Kure
+# Aligned with Wharf standard (meta/standards/golangci-lint.md)
 
 run:
-  timeout: 10m
-  tests: true
+  timeout: 5m
   modules-download-mode: readonly
+
+linters:
+  enable:
+    # Default linters (always enabled)
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    # Additional linters
+    - bodyclose
+    - durationcheck
+    - errorlint
+    - exhaustive
+    - gofmt
+    - goimports
+    - misspell
+    - nilerr
+    - unconvert
+    - whitespace
 
 linters-settings:
   errcheck:
-    # Don't check error returns in defer statements or test files
     check-type-assertions: false
     check-blank: false
-    exclude-functions:
-      - io.Copy
-      - io.WriteString
-      - fmt.Print
-      - fmt.Printf
-      - fmt.Println
-      - fmt.Fprint
-      - fmt.Fprintf
-      - fmt.Fprintln
-      - (*os.File).Close
 
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment  # Stylistic; not a correctness issue
-      - shadow          # Too many pre-existing shadows in tests
+  exhaustive:
+    default-signifies-exhaustive: true
 
-  staticcheck:
-    # Enable all checks except ones that require major refactoring
-    checks: ["all", "-SA6005", "-SA9003", "-SA5011"]
-
-  unused:
-    # Allow unused functions in certain directories (like deepcopy utilities)
-    go: "1.24"
-    
-  gocyclo:
-    # Increase complexity threshold to be more lenient
-    min-complexity: 15
-
-  funlen:
-    lines: 100
-    statements: 50
-
-  gocognit:
-    min-complexity: 15
-
-  maintidx:
-    threshold: 20
-
-  nestif:
-    min-complexity: 5
-
-  misspell:
-    locale: US
-
-  revive:
-    confidence: 0.8
-    rules:
-      - name: exported-function-comment
-        disabled: true
-      - name: exported-type-comment
-        disabled: true
-      - name: exported-var-comment
-        disabled: true
-
-linters:
-  disable:
-    # Disable linters that require major refactoring or are too strict for existing code
-    - errcheck          # Too many unchecked errors in existing code
-    - unused            # Many utility functions are kept for future use
-    - ineffassign       # Some assignments are intentional for readability
-    - gosec             # Security linter can be overly strict for development code
-    - exhaustive        # Enum exhaustiveness not critical for this codebase
-    - exhaustruct       # Struct exhaustiveness too strict
-    - forbidigo         # No forbidden identifiers needed
-    - forcetypeassert   # Type assertions are carefully used
-    - gochecknoglobals  # Some globals are necessary
-    - gochecknoinits    # Init functions are used appropriately
-    - gocritic          # Too many opinionated suggestions
-    - godox             # TODO comments are acceptable during development
-    - goconst           # String constants can be overly strict
-    - unconvert         # Some conversions are for clarity
-    - misspell          # Spelling preferences (cancelled vs canceled)
-    - gomoddirectives   # Module directives are managed carefully
-    - gomodguard        # No module restrictions needed
-    - goprintffuncname  # Printf function names are fine
-    - gosimple          # Some simplifications reduce readability
-    - prealloc          # Preallocation not always beneficial
-    - unparam           # Unused parameters might be needed for interfaces
-    - whitespace        # Whitespace style is handled by gofmt
-    - wsl               # Whitespace linting too strict
-
-  enable:
-    # Enable essential linters that catch real bugs and enforce basic standards
-    - gofmt
-    - goimports
-    - govet
-    - staticcheck
-    - nakedret
-    - typecheck
-
-  fast: false
+  goimports:
+    local-prefixes: github.com/go-kure/kure
 
 issues:
-  # Maximum issues count per one linter
-  max-issues-per-linter: 50
-  
-  # Maximum count of issues with the same text
-  max-same-issues: 10
+  exclude-use-default: false
+  max-issues-per-linter: 0
+  max-same-issues: 0
 
   exclude-rules:
-    # Exclude test files from some checks
+    # Test files have relaxed rules
     - path: _test\.go
       linters:
-        - gocyclo
-        - funlen
-        - gocognit
-        - maintidx
-
-    # unusedwrite is noisy in tests where structs are built for setup/fixture purposes
-    - path: _test\.go
-      text: "unusedwrite"
-      linters:
-        - govet
-
-    # Exclude generated files
-    - path: ".*\\.pb\\.go"
-      linters:
-        - all
-
-    # Exclude vendor directories
-    - path: vendor/
-      linters:
-        - all
-
-    # Allow long lines in certain contexts
-    - linters:
-        - lll
-      source: "^//go:generate "
-
-  # Exclude specific issue text patterns
-  exclude:
-    # Ignore common false positives
-    - "Error return value of .*(Close|Log|Print).*is not checked"
-    - "exported .* should have comment or be unexported"
-    - "should have comment or be unexported"
-    - "comment on exported .* should be of the form"
-
-severity:
-  default-severity: warning
-  rules:
-    - linters:
-        - typecheck
-      severity: error
+        - errcheck

--- a/cmd/demo/main_test.go
+++ b/cmd/demo/main_test.go
@@ -28,7 +28,7 @@ func TestPtr(t *testing.T) {
 	result := ptr(value)
 
 	if result == nil {
-		t.Error("ptr() returned nil")
+		t.Fatal("ptr() returned nil")
 	}
 
 	if *result != value {
@@ -600,9 +600,7 @@ func TestMainFunction(t *testing.T) {
 	done := make(chan bool)
 	go func() {
 		defer func() {
-			if r := recover(); r != nil {
-				// Expected if some demos fail due to missing files
-			}
+			recover() // Expected if some demos fail due to missing files
 			done <- true
 		}()
 		main()

--- a/internal/fluxcd/image_test.go
+++ b/internal/fluxcd/image_test.go
@@ -56,8 +56,8 @@ func TestAutomationHelperFunctions(t *testing.T) {
 		t.Errorf("selector not set")
 	}
 
-	strat := CreateUpdateStrategy(imagev1.UpdateStrategySetters, "./manifests")
-	SetImageUpdateAutomationUpdateStrategy(auto, strat)
+	strategy := CreateUpdateStrategy(imagev1.UpdateStrategySetters, "./manifests")
+	SetImageUpdateAutomationUpdateStrategy(auto, strategy)
 	if auto.Spec.Update == nil || auto.Spec.Update.Path != "./manifests" {
 		t.Errorf("update strategy not set")
 	}

--- a/internal/fluxcd/source.go
+++ b/internal/fluxcd/source.go
@@ -23,7 +23,6 @@ func CreateGitRepository(name string, namespace string, spec sourcev1.GitReposit
 		Spec: spec,
 	}
 	return obj
-
 }
 
 // CreateHelmRepository returns a new HelmRepository resource using the given

--- a/internal/gvk/parsing.go
+++ b/internal/gvk/parsing.go
@@ -1,6 +1,7 @@
 package gvk
 
 import (
+	stderrors "errors"
 	"io"
 
 	"gopkg.in/yaml.v3"
@@ -24,9 +25,7 @@ var DefaultParseOptions = ParseOptions{
 
 // ParseSingle parses a single GVK-enabled type from YAML data
 func ParseSingle[T any](data []byte, registry *Registry[T], options *ParseOptions) (*TypedWrapper[T], error) {
-	if options == nil {
-		options = &DefaultParseOptions
-	}
+	_ = options // reserved for future use
 
 	wrapper := NewTypedWrapper(registry)
 	if err := yaml.Unmarshal(data, wrapper); err != nil {
@@ -38,9 +37,7 @@ func ParseSingle[T any](data []byte, registry *Registry[T], options *ParseOption
 
 // ParseMultiple parses multiple GVK-enabled types from YAML data (separated by ---)
 func ParseMultiple[T any](data []byte, registry *Registry[T], options *ParseOptions) ([]*TypedWrapper[T], error) {
-	if options == nil {
-		options = &DefaultParseOptions
-	}
+	_ = options // reserved for future use
 
 	var wrappers []*TypedWrapper[T]
 
@@ -65,9 +62,7 @@ func ParseMultiple[T any](data []byte, registry *Registry[T], options *ParseOpti
 
 // ParseStream parses a stream of YAML documents
 func ParseStream[T any](reader io.Reader, registry *Registry[T], options *ParseOptions) ([]*TypedWrapper[T], error) {
-	if options == nil {
-		options = &DefaultParseOptions
-	}
+	_ = options // reserved for future use
 
 	var wrappers []*TypedWrapper[T]
 	decoder := yaml.NewDecoder(reader)
@@ -75,7 +70,7 @@ func ParseStream[T any](reader io.Reader, registry *Registry[T], options *ParseO
 	for {
 		var node yaml.Node
 		if err := decoder.Decode(&node); err != nil {
-			if err == io.EOF {
+			if stderrors.Is(err, io.EOF) {
 				break
 			}
 			return nil, errors.Errorf("failed to decode YAML document: %w", err)

--- a/internal/kubernetes/daemonset.go
+++ b/internal/kubernetes/daemonset.go
@@ -130,11 +130,11 @@ func SetDaemonSetNodeSelector(ds *appsv1.DaemonSet, ns map[string]string) error 
 }
 
 // SetDaemonSetUpdateStrategy sets the update strategy.
-func SetDaemonSetUpdateStrategy(ds *appsv1.DaemonSet, strat appsv1.DaemonSetUpdateStrategy) error {
+func SetDaemonSetUpdateStrategy(ds *appsv1.DaemonSet, strategy appsv1.DaemonSetUpdateStrategy) error {
 	if ds == nil {
 		return errors.ErrNilDaemonSet
 	}
-	ds.Spec.UpdateStrategy = strat
+	ds.Spec.UpdateStrategy = strategy
 	return nil
 }
 

--- a/internal/kubernetes/daemonset_test.go
+++ b/internal/kubernetes/daemonset_test.go
@@ -159,8 +159,8 @@ func TestDaemonSetFunctions(t *testing.T) {
 		t.Errorf("node selector not set")
 	}
 
-	strat := appsv1.DaemonSetUpdateStrategy{Type: appsv1.RollingUpdateDaemonSetStrategyType}
-	if err := SetDaemonSetUpdateStrategy(ds, strat); err != nil {
+	strategy := appsv1.DaemonSetUpdateStrategy{Type: appsv1.RollingUpdateDaemonSetStrategyType}
+	if err := SetDaemonSetUpdateStrategy(ds, strategy); err != nil {
 		t.Fatalf("SetDaemonSetUpdateStrategy returned error: %v", err)
 	}
 	if ds.Spec.UpdateStrategy.Type != appsv1.RollingUpdateDaemonSetStrategyType {

--- a/internal/kubernetes/statefulset.go
+++ b/internal/kubernetes/statefulset.go
@@ -143,11 +143,11 @@ func SetStatefulSetNodeSelector(sts *appsv1.StatefulSet, ns map[string]string) e
 }
 
 // SetStatefulSetUpdateStrategy sets the update strategy for the StatefulSet.
-func SetStatefulSetUpdateStrategy(sts *appsv1.StatefulSet, strat appsv1.StatefulSetUpdateStrategy) error {
+func SetStatefulSetUpdateStrategy(sts *appsv1.StatefulSet, strategy appsv1.StatefulSetUpdateStrategy) error {
 	if sts == nil {
 		return errors.ErrNilStatefulSet
 	}
-	sts.Spec.UpdateStrategy = strat
+	sts.Spec.UpdateStrategy = strategy
 	return nil
 }
 

--- a/internal/kubernetes/statefulset_test.go
+++ b/internal/kubernetes/statefulset_test.go
@@ -167,8 +167,8 @@ func TestStatefulSetFunctions(t *testing.T) {
 		t.Errorf("node selector not set")
 	}
 
-	strat := appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType}
-	if err := SetStatefulSetUpdateStrategy(sts, strat); err != nil {
+	strategy := appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType}
+	if err := SetStatefulSetUpdateStrategy(sts, strategy); err != nil {
 		t.Fatalf("SetStatefulSetUpdateStrategy returned error: %v", err)
 	}
 	if sts.Spec.UpdateStrategy.Type != appsv1.RollingUpdateStatefulSetStrategyType {

--- a/internal/validation/validators_test.go
+++ b/internal/validation/validators_test.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	stderrors "errors"
 	"testing"
 
 	"github.com/go-kure/kure/pkg/errors"
@@ -73,7 +74,7 @@ func TestValidateNotNil(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 
-			if tt.wantErr && err != tt.errType {
+			if tt.wantErr && !stderrors.Is(err, tt.errType) {
 				t.Errorf("expected error %v, got %v", tt.errType, err)
 			}
 		})
@@ -141,7 +142,7 @@ func TestValidateDeployment(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validator.ValidateDeployment(tt.deployment)
 
-			if tt.wantErr && err != errors.ErrNilDeployment {
+			if tt.wantErr && !stderrors.Is(err, errors.ErrNilDeployment) {
 				t.Errorf("expected ErrNilDeployment, got %v", err)
 			}
 
@@ -176,7 +177,7 @@ func TestValidateService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validator.ValidateService(tt.service)
 
-			if tt.wantErr && err != errors.ErrNilService {
+			if tt.wantErr && !stderrors.Is(err, errors.ErrNilService) {
 				t.Errorf("expected ErrNilService, got %v", err)
 			}
 
@@ -191,7 +192,7 @@ func TestValidateConfigMap(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateConfigMap(nil)
-	if err != errors.ErrNilConfigMap {
+	if !stderrors.Is(err, errors.ErrNilConfigMap) {
 		t.Errorf("expected ErrNilConfigMap, got %v", err)
 	}
 
@@ -205,7 +206,7 @@ func TestValidateSecret(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateSecret(nil)
-	if err != errors.ErrNilSecret {
+	if !stderrors.Is(err, errors.ErrNilSecret) {
 		t.Errorf("expected ErrNilSecret, got %v", err)
 	}
 
@@ -219,7 +220,7 @@ func TestValidateServiceAccount(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateServiceAccount(nil)
-	if err != errors.ErrNilServiceAccount {
+	if !stderrors.Is(err, errors.ErrNilServiceAccount) {
 		t.Errorf("expected ErrNilServiceAccount, got %v", err)
 	}
 
@@ -233,7 +234,7 @@ func TestValidateNamespace(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateNamespace(nil)
-	if err != errors.ErrNilNamespace {
+	if !stderrors.Is(err, errors.ErrNilNamespace) {
 		t.Errorf("expected ErrNilNamespace, got %v", err)
 	}
 
@@ -247,7 +248,7 @@ func TestValidateIngress(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateIngress(nil)
-	if err != errors.ErrNilIngress {
+	if !stderrors.Is(err, errors.ErrNilIngress) {
 		t.Errorf("expected ErrNilIngress, got %v", err)
 	}
 
@@ -261,7 +262,7 @@ func TestValidateStatefulSet(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateStatefulSet(nil)
-	if err != errors.ErrNilStatefulSet {
+	if !stderrors.Is(err, errors.ErrNilStatefulSet) {
 		t.Errorf("expected ErrNilStatefulSet, got %v", err)
 	}
 
@@ -275,7 +276,7 @@ func TestValidateDaemonSet(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateDaemonSet(nil)
-	if err != errors.ErrNilDaemonSet {
+	if !stderrors.Is(err, errors.ErrNilDaemonSet) {
 		t.Errorf("expected ErrNilDaemonSet, got %v", err)
 	}
 
@@ -289,7 +290,7 @@ func TestValidateJob(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateJob(nil)
-	if err != errors.ErrNilJob {
+	if !stderrors.Is(err, errors.ErrNilJob) {
 		t.Errorf("expected ErrNilJob, got %v", err)
 	}
 
@@ -303,7 +304,7 @@ func TestValidateCronJob(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateCronJob(nil)
-	if err != errors.ErrNilCronJob {
+	if !stderrors.Is(err, errors.ErrNilCronJob) {
 		t.Errorf("expected ErrNilCronJob, got %v", err)
 	}
 
@@ -319,7 +320,7 @@ func TestValidateRole(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateRole(nil)
-	if err != errors.ErrNilRole {
+	if !stderrors.Is(err, errors.ErrNilRole) {
 		t.Errorf("expected ErrNilRole, got %v", err)
 	}
 
@@ -333,7 +334,7 @@ func TestValidateClusterRole(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateClusterRole(nil)
-	if err != errors.ErrNilClusterRole {
+	if !stderrors.Is(err, errors.ErrNilClusterRole) {
 		t.Errorf("expected ErrNilClusterRole, got %v", err)
 	}
 
@@ -347,7 +348,7 @@ func TestValidateRoleBinding(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateRoleBinding(nil)
-	if err != errors.ErrNilRoleBinding {
+	if !stderrors.Is(err, errors.ErrNilRoleBinding) {
 		t.Errorf("expected ErrNilRoleBinding, got %v", err)
 	}
 
@@ -361,7 +362,7 @@ func TestValidateClusterRoleBinding(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateClusterRoleBinding(nil)
-	if err != errors.ErrNilClusterRoleBinding {
+	if !stderrors.Is(err, errors.ErrNilClusterRoleBinding) {
 		t.Errorf("expected ErrNilClusterRoleBinding, got %v", err)
 	}
 
@@ -377,7 +378,7 @@ func TestValidatePodSpec(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidatePodSpec(nil)
-	if err != errors.ErrNilPodSpec {
+	if !stderrors.Is(err, errors.ErrNilPodSpec) {
 		t.Errorf("expected ErrNilPodSpec, got %v", err)
 	}
 
@@ -391,7 +392,7 @@ func TestValidateContainer(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateContainer(nil)
-	if err != errors.ErrNilContainer {
+	if !stderrors.Is(err, errors.ErrNilContainer) {
 		t.Errorf("expected ErrNilContainer, got %v", err)
 	}
 
@@ -405,7 +406,7 @@ func TestValidateInitContainer(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateInitContainer(nil)
-	if err != errors.ErrNilInitContainer {
+	if !stderrors.Is(err, errors.ErrNilInitContainer) {
 		t.Errorf("expected ErrNilInitContainer, got %v", err)
 	}
 
@@ -419,7 +420,7 @@ func TestValidateEphemeralContainer(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateEphemeralContainer(nil)
-	if err != errors.ErrNilEphemeralContainer {
+	if !stderrors.Is(err, errors.ErrNilEphemeralContainer) {
 		t.Errorf("expected ErrNilEphemeralContainer, got %v", err)
 	}
 
@@ -433,7 +434,7 @@ func TestValidateVolume(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateVolume(nil)
-	if err != errors.ErrNilVolume {
+	if !stderrors.Is(err, errors.ErrNilVolume) {
 		t.Errorf("expected ErrNilVolume, got %v", err)
 	}
 
@@ -447,7 +448,7 @@ func TestValidateImagePullSecret(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateImagePullSecret(nil)
-	if err != errors.ErrNilImagePullSecret {
+	if !stderrors.Is(err, errors.ErrNilImagePullSecret) {
 		t.Errorf("expected ErrNilImagePullSecret, got %v", err)
 	}
 
@@ -461,7 +462,7 @@ func TestValidateToleration(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateToleration(nil)
-	if err != errors.ErrNilToleration {
+	if !stderrors.Is(err, errors.ErrNilToleration) {
 		t.Errorf("expected ErrNilToleration, got %v", err)
 	}
 
@@ -475,7 +476,7 @@ func TestValidateServicePort(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateServicePort(nil)
-	if err != errors.ErrNilServicePort {
+	if !stderrors.Is(err, errors.ErrNilServicePort) {
 		t.Errorf("expected ErrNilServicePort, got %v", err)
 	}
 
@@ -489,7 +490,7 @@ func TestValidatePodDisruptionBudget(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidatePodDisruptionBudget(nil)
-	if err != errors.ErrNilPodDisruptionBudget {
+	if !stderrors.Is(err, errors.ErrNilPodDisruptionBudget) {
 		t.Errorf("expected ErrNilPodDisruptionBudget, got %v", err)
 	}
 
@@ -503,7 +504,7 @@ func TestValidateKustomization(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateKustomization(nil)
-	if err != errors.ErrNilKustomization {
+	if !stderrors.Is(err, errors.ErrNilKustomization) {
 		t.Errorf("expected ErrNilKustomization, got %v", err)
 	}
 
@@ -517,7 +518,7 @@ func TestValidateFluxInstance(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateFluxInstance(nil)
-	if err != errors.ErrNilFluxInstance {
+	if !stderrors.Is(err, errors.ErrNilFluxInstance) {
 		t.Errorf("expected ErrNilFluxInstance, got %v", err)
 	}
 
@@ -531,7 +532,7 @@ func TestValidateIPAddressPool(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateIPAddressPool(nil)
-	if err != errors.ErrNilIPAddressPool {
+	if !stderrors.Is(err, errors.ErrNilIPAddressPool) {
 		t.Errorf("expected ErrNilIPAddressPool, got %v", err)
 	}
 
@@ -545,7 +546,7 @@ func TestValidateBGPPeer(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateBGPPeer(nil)
-	if err != errors.ErrNilBGPPeer {
+	if !stderrors.Is(err, errors.ErrNilBGPPeer) {
 		t.Errorf("expected ErrNilBGPPeer, got %v", err)
 	}
 
@@ -559,7 +560,7 @@ func TestValidateBGPAdvertisement(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateBGPAdvertisement(nil)
-	if err != errors.ErrNilBGPAdvertisement {
+	if !stderrors.Is(err, errors.ErrNilBGPAdvertisement) {
 		t.Errorf("expected ErrNilBGPAdvertisement, got %v", err)
 	}
 
@@ -573,7 +574,7 @@ func TestValidateL2Advertisement(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateL2Advertisement(nil)
-	if err != errors.ErrNilL2Advertisement {
+	if !stderrors.Is(err, errors.ErrNilL2Advertisement) {
 		t.Errorf("expected ErrNilL2Advertisement, got %v", err)
 	}
 
@@ -587,7 +588,7 @@ func TestValidateBFDProfile(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateBFDProfile(nil)
-	if err != errors.ErrNilBFDProfile {
+	if !stderrors.Is(err, errors.ErrNilBFDProfile) {
 		t.Errorf("expected ErrNilBFDProfile, got %v", err)
 	}
 
@@ -741,7 +742,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateHorizontalPodAutoscaler(nil)
-	if err != errors.ErrNilHorizontalPodAutoscaler {
+	if !stderrors.Is(err, errors.ErrNilHorizontalPodAutoscaler) {
 		t.Errorf("expected ErrNilHorizontalPodAutoscaler, got %v", err)
 	}
 
@@ -755,7 +756,7 @@ func TestValidateCertificate(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateCertificate(nil)
-	if err != errors.ErrNilCertificate {
+	if !stderrors.Is(err, errors.ErrNilCertificate) {
 		t.Errorf("expected ErrNilCertificate, got %v", err)
 	}
 }
@@ -764,7 +765,7 @@ func TestValidateIssuer(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateIssuer(nil)
-	if err != errors.ErrNilIssuer {
+	if !stderrors.Is(err, errors.ErrNilIssuer) {
 		t.Errorf("expected ErrNilIssuer, got %v", err)
 	}
 }
@@ -773,7 +774,7 @@ func TestValidateClusterIssuer(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateClusterIssuer(nil)
-	if err != errors.ErrNilClusterIssuer {
+	if !stderrors.Is(err, errors.ErrNilClusterIssuer) {
 		t.Errorf("expected ErrNilClusterIssuer, got %v", err)
 	}
 }
@@ -782,7 +783,7 @@ func TestValidateACMEIssuer(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateACMEIssuer(nil)
-	if err != errors.ErrNilACMEIssuer {
+	if !stderrors.Is(err, errors.ErrNilACMEIssuer) {
 		t.Errorf("expected ErrNilACMEIssuer, got %v", err)
 	}
 }
@@ -791,7 +792,7 @@ func TestValidateSecretStore(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateSecretStore(nil)
-	if err != errors.ErrNilSecretStore {
+	if !stderrors.Is(err, errors.ErrNilSecretStore) {
 		t.Errorf("expected ErrNilSecretStore, got %v", err)
 	}
 }
@@ -800,7 +801,7 @@ func TestValidateClusterSecretStore(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateClusterSecretStore(nil)
-	if err != errors.ErrNilClusterSecretStore {
+	if !stderrors.Is(err, errors.ErrNilClusterSecretStore) {
 		t.Errorf("expected ErrNilClusterSecretStore, got %v", err)
 	}
 }
@@ -809,7 +810,7 @@ func TestValidateExternalSecret(t *testing.T) {
 	validator := NewValidator()
 
 	err := validator.ValidateExternalSecret(nil)
-	if err != errors.ErrNilExternalSecret {
+	if !stderrors.Is(err, errors.ErrNilExternalSecret) {
 		t.Errorf("expected ErrNilExternalSecret, got %v", err)
 	}
 }

--- a/pkg/cli/factory_test.go
+++ b/pkg/cli/factory_test.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"io"
 	"os"
 	"strings"
 	"testing"
@@ -142,28 +141,15 @@ func TestIOStreamsUsage(t *testing.T) {
 	factory := NewFactory(globalOpts)
 	streams := factory.IOStreams()
 
-	// Test writing to Out
-	if writer, ok := streams.Out.(io.Writer); ok {
-		// For testing, we can't actually write to stdout, but we can verify the interface
-		_ = writer
-	} else {
-		t.Error("Out stream doesn't implement io.Writer")
+	// Verify streams are non-nil (they are already the correct types: io.Writer, io.Reader)
+	if streams.Out == nil {
+		t.Error("Out stream is nil")
 	}
-
-	// Test reading from In
-	if reader, ok := streams.In.(io.Reader); ok {
-		// For testing, we can't actually read from stdin, but we can verify the interface
-		_ = reader
-	} else {
-		t.Error("In stream doesn't implement io.Reader")
+	if streams.In == nil {
+		t.Error("In stream is nil")
 	}
-
-	// Test writing to ErrOut
-	if writer, ok := streams.ErrOut.(io.Writer); ok {
-		// For testing, we can't actually write to stderr, but we can verify the interface
-		_ = writer
-	} else {
-		t.Error("ErrOut stream doesn't implement io.Writer")
+	if streams.ErrOut == nil {
+		t.Error("ErrOut stream is nil")
 	}
 }
 

--- a/pkg/cli/printer.go
+++ b/pkg/cli/printer.go
@@ -56,7 +56,7 @@ func (p *yamlPrinter) Print(objects []runtime.Object, writer io.Writer) error {
 
 	for i, obj := range objects {
 		if i > 0 {
-			fmt.Fprintln(writer, "---")
+			_, _ = fmt.Fprintln(writer, "---")
 		}
 
 		data, err := yaml.Marshal(obj)
@@ -77,7 +77,7 @@ type jsonPrinter struct{}
 
 func (p *jsonPrinter) Print(objects []runtime.Object, writer io.Writer) error {
 	if len(objects) == 0 {
-		fmt.Fprint(writer, "{}\n")
+		_, _ = fmt.Fprint(writer, "{}\n")
 		return nil
 	}
 
@@ -100,7 +100,7 @@ func (p *tablePrinter) Print(objects []runtime.Object, writer io.Writer) error {
 	}
 
 	w := tabwriter.NewWriter(writer, 0, 0, 2, ' ', 0)
-	defer w.Flush()
+	defer func() { _ = w.Flush() }()
 
 	// Print headers
 	if !p.options.NoHeaders {
@@ -111,7 +111,7 @@ func (p *tablePrinter) Print(objects []runtime.Object, writer io.Writer) error {
 		if p.options.ShowLabels {
 			headers = append(headers, "LABELS")
 		}
-		fmt.Fprintln(w, joinTabs(headers))
+		_, _ = fmt.Fprintln(w, joinTabs(headers))
 	}
 
 	// Print objects
@@ -138,7 +138,7 @@ func (p *tablePrinter) Print(objects []runtime.Object, writer io.Writer) error {
 				row = append(row, labels)
 			}
 
-			fmt.Fprintln(w, joinTabs(row))
+			_, _ = fmt.Fprintln(w, joinTabs(row))
 		}
 	}
 
@@ -154,7 +154,7 @@ func (p *namePrinter) Print(objects []runtime.Object, writer io.Writer) error {
 			GetName() string
 			GetKind() string
 		}); ok {
-			fmt.Fprintf(writer, "%s/%s\n", namedObj.GetKind(), namedObj.GetName())
+			_, _ = fmt.Fprintf(writer, "%s/%s\n", namedObj.GetKind(), namedObj.GetName())
 		}
 	}
 	return nil

--- a/pkg/cmd/kure/generate/app.go
+++ b/pkg/cmd/kure/generate/app.go
@@ -1,6 +1,7 @@
 package generate
 
 import (
+	stderrors "errors"
 	"fmt"
 	"io"
 	"os"
@@ -136,7 +137,7 @@ func (o *AppOptions) Run() error {
 	globalOpts := o.Factory.GlobalOptions()
 
 	if globalOpts.Verbose {
-		fmt.Fprintf(o.IOStreams.ErrOut, "Processing %d app config files\n", len(o.ConfigFiles))
+		_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Processing %d app config files\n", len(o.ConfigFiles))
 	}
 
 	// Load all applications
@@ -146,7 +147,7 @@ func (o *AppOptions) Run() error {
 	}
 
 	if len(apps) == 0 {
-		fmt.Fprintf(o.IOStreams.ErrOut, "No applications found in config files\n")
+		_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "No applications found in config files\n")
 		return nil
 	}
 
@@ -162,7 +163,7 @@ func (o *AppOptions) Run() error {
 	}
 
 	if globalOpts.Verbose {
-		fmt.Fprintf(o.IOStreams.ErrOut, "Generated %d resources for %d applications\n", len(resources), len(apps))
+		_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Generated %d resources for %d applications\n", len(resources), len(apps))
 	}
 
 	return nil
@@ -213,7 +214,7 @@ func (o *AppOptions) loadApplicationsFromFile(configFile string) ([]*stack.Appli
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	var apps []*stack.Application
 	dec := yaml.NewDecoder(file)
@@ -221,7 +222,7 @@ func (o *AppOptions) loadApplicationsFromFile(configFile string) ([]*stack.Appli
 	for {
 		var wrapper stack.ApplicationWrapper
 		if err := dec.Decode(&wrapper); err != nil {
-			if err == io.EOF {
+			if stderrors.Is(err, io.EOF) {
 				break
 			}
 			return nil, err

--- a/pkg/cmd/kure/generate/bootstrap.go
+++ b/pkg/cmd/kure/generate/bootstrap.go
@@ -136,7 +136,7 @@ func (o *BootstrapOptions) Run() error {
 	globalOpts := o.Factory.GlobalOptions()
 
 	if globalOpts.Verbose {
-		fmt.Fprintf(o.IOStreams.ErrOut, "Processing bootstrap config: %s\n", o.ConfigFile)
+		_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Processing bootstrap config: %s\n", o.ConfigFile)
 	}
 
 	// Load cluster configuration
@@ -162,11 +162,11 @@ func (o *BootstrapOptions) Run() error {
 	}
 
 	if globalOpts.Verbose {
-		fmt.Fprintf(o.IOStreams.ErrOut, "Generated bootstrap manifests: %s\n", o.OutputDir)
+		_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Generated bootstrap manifests: %s\n", o.OutputDir)
 		if cluster.GitOps != nil && cluster.GitOps.Bootstrap != nil {
-			fmt.Fprintf(o.IOStreams.ErrOut, "GitOps type: %s\n", o.GitOpsType)
+			_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "GitOps type: %s\n", o.GitOpsType)
 			if o.GitOpsType == "flux" {
-				fmt.Fprintf(o.IOStreams.ErrOut, "Flux mode: %s\n", cluster.GitOps.Bootstrap.FluxMode)
+				_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Flux mode: %s\n", cluster.GitOps.Bootstrap.FluxMode)
 			}
 		}
 	}
@@ -180,7 +180,7 @@ func (o *BootstrapOptions) loadClusterConfig() (*stack.Cluster, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	dec := yaml.NewDecoder(file)
 	var cluster stack.Cluster
@@ -318,13 +318,13 @@ func (o *BootstrapOptions) writeOutput(ml *layout.ManifestLayout, cluster *stack
 
 // printToStdout prints the manifests to stdout for dry-run
 func (o *BootstrapOptions) printToStdout(ml *layout.ManifestLayout) error {
-	fmt.Fprintf(o.IOStreams.Out, "# Generated bootstrap manifests for: %s\n", ml.Name)
-	fmt.Fprintf(o.IOStreams.Out, "# GitOps type: %s\n", o.GitOpsType)
+	_, _ = fmt.Fprintf(o.IOStreams.Out, "# Generated bootstrap manifests for: %s\n", ml.Name)
+	_, _ = fmt.Fprintf(o.IOStreams.Out, "# GitOps type: %s\n", o.GitOpsType)
 	if o.GitOpsType == "flux" {
-		fmt.Fprintf(o.IOStreams.Out, "# Flux mode: %s\n", o.FluxMode)
+		_, _ = fmt.Fprintf(o.IOStreams.Out, "# Flux mode: %s\n", o.FluxMode)
 	}
-	fmt.Fprintf(o.IOStreams.Out, "# Namespace: %s\n", ml.Namespace)
-	fmt.Fprintf(o.IOStreams.Out, "# Resources: %d\n", len(ml.Resources))
+	_, _ = fmt.Fprintf(o.IOStreams.Out, "# Namespace: %s\n", ml.Namespace)
+	_, _ = fmt.Fprintf(o.IOStreams.Out, "# Resources: %d\n", len(ml.Resources))
 
 	// Print basic info about resources
 	for _, resource := range ml.Resources {
@@ -333,7 +333,7 @@ func (o *BootstrapOptions) printToStdout(ml *layout.ManifestLayout) error {
 			GetName() string
 			GetNamespace() string
 		}); ok {
-			fmt.Fprintf(o.IOStreams.Out, "# - %s/%s (%s)\n",
+			_, _ = fmt.Fprintf(o.IOStreams.Out, "# - %s/%s (%s)\n",
 				namedObj.GetKind(), namedObj.GetName(), namedObj.GetNamespace())
 		}
 	}

--- a/pkg/cmd/kure/generate/cluster.go
+++ b/pkg/cmd/kure/generate/cluster.go
@@ -144,7 +144,7 @@ func (o *ClusterOptions) Run() error {
 	globalOpts := o.Factory.GlobalOptions()
 
 	if globalOpts.Verbose {
-		fmt.Fprintf(o.IOStreams.ErrOut, "Processing cluster config: %s\n", o.ConfigFile)
+		_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Processing cluster config: %s\n", o.ConfigFile)
 	}
 
 	// Load cluster configuration
@@ -171,7 +171,7 @@ func (o *ClusterOptions) Run() error {
 	}
 
 	if globalOpts.Verbose {
-		fmt.Fprintf(o.IOStreams.ErrOut, "Generated cluster manifests: %s\n", o.OutputDir)
+		_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Generated cluster manifests: %s\n", o.OutputDir)
 	}
 
 	return nil
@@ -183,7 +183,7 @@ func (o *ClusterOptions) loadClusterConfig() (*stack.Cluster, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	dec := yaml.NewDecoder(file)
 	var cluster stack.Cluster
@@ -232,7 +232,10 @@ func (o *ClusterOptions) loadNodeApps(node *stack.Node) error {
 	entries, err := os.ReadDir(nodeDir)
 	if err != nil {
 		// Directory might not exist for some nodes
-		return nil
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
 	}
 
 	for _, entry := range entries {
@@ -260,7 +263,7 @@ func (o *ClusterOptions) loadAppConfig(node *stack.Node, configPath string) erro
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	dec := yaml.NewDecoder(file)
 	for {
@@ -368,9 +371,9 @@ func (o *ClusterOptions) writeOutput(ml *layout.ManifestLayout) error {
 func (o *ClusterOptions) printToStdout(ml *layout.ManifestLayout) error {
 	// This is a simplified version - in a real implementation,
 	// you'd want to serialize all the resources in the layout
-	fmt.Fprintf(o.IOStreams.Out, "# Generated cluster manifests for: %s\n", ml.Name)
-	fmt.Fprintf(o.IOStreams.Out, "# Namespace: %s\n", ml.Namespace)
-	fmt.Fprintf(o.IOStreams.Out, "# Resources: %d\n", len(ml.Resources))
+	_, _ = fmt.Fprintf(o.IOStreams.Out, "# Generated cluster manifests for: %s\n", ml.Name)
+	_, _ = fmt.Fprintf(o.IOStreams.Out, "# Namespace: %s\n", ml.Namespace)
+	_, _ = fmt.Fprintf(o.IOStreams.Out, "# Resources: %d\n", len(ml.Resources))
 
 	// Print basic info about resources
 	for _, resource := range ml.Resources {
@@ -379,7 +382,7 @@ func (o *ClusterOptions) printToStdout(ml *layout.ManifestLayout) error {
 			GetName() string
 			GetNamespace() string
 		}); ok {
-			fmt.Fprintf(o.IOStreams.Out, "# - %s/%s (%s)\n",
+			_, _ = fmt.Fprintf(o.IOStreams.Out, "# - %s/%s (%s)\n",
 				namedObj.GetKind(), namedObj.GetName(), namedObj.GetNamespace())
 		}
 	}

--- a/pkg/cmd/kure/initialize/init.go
+++ b/pkg/cmd/kure/initialize/init.go
@@ -149,14 +149,14 @@ func (o *InitOptions) Run() error {
 	}
 
 	// Print summary
-	fmt.Fprintf(o.IOStreams.ErrOut, "Initialized kure project %q in %s\n", o.ProjectName, o.OutputDir)
-	fmt.Fprintf(o.IOStreams.ErrOut, "  created cluster.yaml\n")
-	fmt.Fprintf(o.IOStreams.ErrOut, "  created apps/example.yaml\n")
-	fmt.Fprintf(o.IOStreams.ErrOut, "  created apps/\n")
-	fmt.Fprintf(o.IOStreams.ErrOut, "  created infra/\n")
-	fmt.Fprintf(o.IOStreams.ErrOut, "\nNext steps:\n")
-	fmt.Fprintf(o.IOStreams.ErrOut, "  Edit apps/example.yaml or add more app configs under apps/\n")
-	fmt.Fprintf(o.IOStreams.ErrOut, "  Run: kure generate cluster cluster.yaml\n")
+	_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Initialized kure project %q in %s\n", o.ProjectName, o.OutputDir)
+	_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "  created cluster.yaml\n")
+	_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "  created apps/example.yaml\n")
+	_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "  created apps/\n")
+	_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "  created infra/\n")
+	_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "\nNext steps:\n")
+	_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "  Edit apps/example.yaml or add more app configs under apps/\n")
+	_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "  Run: kure generate cluster cluster.yaml\n")
 
 	return nil
 }

--- a/pkg/cmd/kure/patch.go
+++ b/pkg/cmd/kure/patch.go
@@ -186,7 +186,7 @@ func (o *PatchOptions) Run() error {
 	}
 
 	if globalOpts.Verbose {
-		fmt.Fprintf(o.IOStreams.ErrOut, "Applying %d patches to %s\n", len(o.PatchFiles), o.BaseFile)
+		_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Applying %d patches to %s\n", len(o.PatchFiles), o.BaseFile)
 	}
 
 	// Load base resources
@@ -207,7 +207,7 @@ func (o *PatchOptions) Run() error {
 	}
 
 	if globalOpts.Verbose {
-		fmt.Fprintf(o.IOStreams.ErrOut, "Successfully applied patches to %d resources\n", len(documentSet.Documents))
+		_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Successfully applied patches to %d resources\n", len(documentSet.Documents))
 	}
 
 	return nil
@@ -218,7 +218,7 @@ func (o *PatchOptions) runCombined() error {
 	globalOpts := o.Factory.GlobalOptions()
 
 	if globalOpts.Verbose {
-		fmt.Fprintf(o.IOStreams.ErrOut, "Combined mode: applying %d patches to %s\n", len(o.PatchFiles), o.BaseFile)
+		_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Combined mode: applying %d patches to %s\n", len(o.PatchFiles), o.BaseFile)
 	}
 
 	// Validate group-by value
@@ -244,7 +244,7 @@ func (o *PatchOptions) runCombined() error {
 	// Apply each patch file sequentially to the same document set
 	for _, patchFile := range o.PatchFiles {
 		if globalOpts.Verbose {
-			fmt.Fprintf(o.IOStreams.ErrOut, "Applying patch: %s\n", patchFile)
+			_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Applying patch: %s\n", patchFile)
 		}
 
 		file, err := os.Open(patchFile)
@@ -253,7 +253,7 @@ func (o *PatchOptions) runCombined() error {
 		}
 
 		patchSpecs, err := patch.LoadPatchFile(file)
-		file.Close()
+		_ = file.Close()
 		if err != nil {
 			return fmt.Errorf("failed to load patch file %s: %w", patchFile, err)
 		}
@@ -346,7 +346,7 @@ func (o *PatchOptions) runDiff() error {
 	globalOpts := o.Factory.GlobalOptions()
 
 	if globalOpts.Verbose {
-		fmt.Fprintf(o.IOStreams.ErrOut, "Diff mode: comparing %d patches against %s\n", len(o.PatchFiles), o.BaseFile)
+		_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Diff mode: comparing %d patches against %s\n", len(o.PatchFiles), o.BaseFile)
 	}
 
 	// Load base resources
@@ -370,7 +370,7 @@ func (o *PatchOptions) runDiff() error {
 	// Apply each patch file sequentially to the copied set
 	for _, patchFile := range o.PatchFiles {
 		if globalOpts.Verbose {
-			fmt.Fprintf(o.IOStreams.ErrOut, "Applying patch: %s\n", patchFile)
+			_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Applying patch: %s\n", patchFile)
 		}
 
 		file, err := os.Open(patchFile)
@@ -379,7 +379,7 @@ func (o *PatchOptions) runDiff() error {
 		}
 
 		patchSpecs, err := patch.LoadPatchFile(file)
-		file.Close()
+		_ = file.Close()
 		if err != nil {
 			return fmt.Errorf("failed to load patch file %s: %w", patchFile, err)
 		}
@@ -460,7 +460,7 @@ func (o *PatchOptions) runDiff() error {
 	}
 
 	if diffText == "" {
-		fmt.Fprintf(o.IOStreams.Out, "No changes detected.\n")
+		_, _ = fmt.Fprintf(o.IOStreams.Out, "No changes detected.\n")
 		return nil
 	}
 
@@ -484,7 +484,7 @@ func (o *PatchOptions) writeDocumentSetToBuffer(docSet *patch.YAMLDocumentSet, b
 		if err := encoder.Encode(doc.Node); err != nil {
 			return fmt.Errorf("failed to encode document %d: %w", i, err)
 		}
-		encoder.Close()
+		_ = encoder.Close()
 
 		content := docBuf.String()
 		content = strings.TrimSuffix(content, "\n")
@@ -500,7 +500,7 @@ func (o *PatchOptions) printColoredDiff(diffText string) {
 	useColor := os.Getenv("TERM") != "" && os.Getenv("NO_COLOR") == ""
 
 	if !useColor {
-		fmt.Fprint(o.IOStreams.Out, diffText)
+		_, _ = fmt.Fprint(o.IOStreams.Out, diffText)
 		return
 	}
 
@@ -517,15 +517,15 @@ func (o *PatchOptions) printColoredDiff(diffText string) {
 	for _, line := range lines {
 		switch {
 		case strings.HasPrefix(line, "---") || strings.HasPrefix(line, "+++"):
-			fmt.Fprintf(o.IOStreams.Out, "%s%s%s\n", colorYellow, line, colorReset)
+			_, _ = fmt.Fprintf(o.IOStreams.Out, "%s%s%s\n", colorYellow, line, colorReset)
 		case strings.HasPrefix(line, "@@"):
-			fmt.Fprintf(o.IOStreams.Out, "%s%s%s\n", colorCyan, line, colorReset)
+			_, _ = fmt.Fprintf(o.IOStreams.Out, "%s%s%s\n", colorCyan, line, colorReset)
 		case strings.HasPrefix(line, "-"):
-			fmt.Fprintf(o.IOStreams.Out, "%s%s%s\n", colorRed, line, colorReset)
+			_, _ = fmt.Fprintf(o.IOStreams.Out, "%s%s%s\n", colorRed, line, colorReset)
 		case strings.HasPrefix(line, "+"):
-			fmt.Fprintf(o.IOStreams.Out, "%s%s%s\n", colorGreen, line, colorReset)
+			_, _ = fmt.Fprintf(o.IOStreams.Out, "%s%s%s\n", colorGreen, line, colorReset)
 		default:
-			fmt.Fprintf(o.IOStreams.Out, "%s\n", line)
+			_, _ = fmt.Fprintf(o.IOStreams.Out, "%s\n", line)
 		}
 	}
 }
@@ -558,7 +558,7 @@ func (o *PatchOptions) runValidation() error {
 	globalOpts := o.Factory.GlobalOptions()
 
 	if globalOpts.Verbose {
-		fmt.Fprintf(o.IOStreams.ErrOut, "Validating %d patch files\n", len(o.PatchFiles))
+		_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Validating %d patch files\n", len(o.PatchFiles))
 	}
 
 	for _, patchFile := range o.PatchFiles {
@@ -567,11 +567,11 @@ func (o *PatchOptions) runValidation() error {
 		}
 
 		if globalOpts.Verbose {
-			fmt.Fprintf(o.IOStreams.ErrOut, "✓ %s\n", patchFile)
+			_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "✓ %s\n", patchFile)
 		}
 	}
 
-	fmt.Fprintf(o.IOStreams.Out, "All patch files are valid\n")
+	_, _ = fmt.Fprintf(o.IOStreams.Out, "All patch files are valid\n")
 	return nil
 }
 
@@ -581,7 +581,7 @@ func (o *PatchOptions) validatePatchFile(patchFile string) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	_, err = patch.LoadPatchFile(file)
 	return err
@@ -594,16 +594,16 @@ func (o *PatchOptions) runInteractive() error {
 	if err != nil {
 		return fmt.Errorf("failed to open base file: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	resources, err := patch.LoadResourcesFromMultiYAML(file)
 	if err != nil {
 		return fmt.Errorf("failed to load base resources: %w", err)
 	}
 
-	fmt.Fprintf(o.IOStreams.Out, "=== Interactive Patch Mode ===\n")
-	fmt.Fprintf(o.IOStreams.Out, "Loaded %d resources from %s\n", len(resources), o.BaseFile)
-	fmt.Fprintf(o.IOStreams.Out, "Type 'help' for available commands\n\n")
+	_, _ = fmt.Fprintf(o.IOStreams.Out, "=== Interactive Patch Mode ===\n")
+	_, _ = fmt.Fprintf(o.IOStreams.Out, "Loaded %d resources from %s\n", len(resources), o.BaseFile)
+	_, _ = fmt.Fprintf(o.IOStreams.Out, "Type 'help' for available commands\n\n")
 
 	// This would implement the interactive loop similar to the existing main.go
 	// For now, returning a placeholder
@@ -616,7 +616,7 @@ func (o *PatchOptions) loadBaseResources() (*patch.YAMLDocumentSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	return patch.LoadResourcesWithStructure(file)
 }
@@ -656,7 +656,7 @@ func (o *PatchOptions) applyPatchFile(patchableSet *patch.PatchableAppSet, patch
 	globalOpts := o.Factory.GlobalOptions()
 
 	if globalOpts.Verbose {
-		fmt.Fprintf(o.IOStreams.ErrOut, "Applying patch: %s\n", patchFile)
+		_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Applying patch: %s\n", patchFile)
 	}
 
 	// For now, use the WritePatchedFiles method from the existing patch system

--- a/pkg/cmd/shared/completion.go
+++ b/pkg/cmd/shared/completion.go
@@ -19,13 +19,13 @@ See each sub-command's help for details on how to use the generated script.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			switch args[0] {
 			case "bash":
-				cmd.Root().GenBashCompletion(os.Stdout)
+				_ = cmd.Root().GenBashCompletion(os.Stdout)
 			case "zsh":
-				cmd.Root().GenZshCompletion(os.Stdout)
+				_ = cmd.Root().GenZshCompletion(os.Stdout)
 			case "fish":
-				cmd.Root().GenFishCompletion(os.Stdout, true)
+				_ = cmd.Root().GenFishCompletion(os.Stdout, true)
 			case "powershell":
-				cmd.Root().GenPowerShellCompletion(os.Stdout)
+				_ = cmd.Root().GenPowerShellCompletion(os.Stdout)
 			}
 		},
 	}

--- a/pkg/cmd/shared/config.go
+++ b/pkg/cmd/shared/config.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/go-kure/kure/pkg/cmd/shared/options"
 	"github.com/spf13/viper"
+
+	"github.com/go-kure/kure/pkg/cmd/shared/options"
 )
 
 // InitConfig initializes Viper configuration for any CLI

--- a/pkg/cmd/shared/config_test.go
+++ b/pkg/cmd/shared/config_test.go
@@ -7,8 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/go-kure/kure/pkg/cmd/shared/options"
 	"github.com/spf13/viper"
+
+	"github.com/go-kure/kure/pkg/cmd/shared/options"
 )
 
 func TestInitConfig_WithConfigFile(t *testing.T) {

--- a/pkg/cmd/shared/options/global.go
+++ b/pkg/cmd/shared/options/global.go
@@ -78,7 +78,7 @@ func (o *GlobalOptions) Complete() error {
 
 	// Set debug logging if requested
 	if o.Debug {
-		os.Setenv("KURE_DEBUG", "1")
+		_ = os.Setenv("KURE_DEBUG", "1")
 		o.Verbose = true
 	}
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -458,8 +458,8 @@ func NewConfigError(source, field, value, reason string, validValues []string) *
 
 // IsKureError checks if an error is a Kure-specific error
 func IsKureError(err error) bool {
-	_, ok := err.(KureError)
-	return ok
+	var target KureError
+	return errors.As(err, &target)
 }
 
 // GetKureError extracts a KureError from an error chain

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -528,13 +528,13 @@ func TestParseErrors_Unwrap(t *testing.T) {
 		t.Fatalf("Expected 3 errors, got %d", len(unwrapped))
 	}
 
-	if unwrapped[0] != err1 {
+	if !errors.Is(unwrapped[0], err1) {
 		t.Errorf("Expected first error to be err1")
 	}
-	if unwrapped[1] != err2 {
+	if !errors.Is(unwrapped[1], err2) {
 		t.Errorf("Expected second error to be err2")
 	}
-	if unwrapped[2] != err3 {
+	if !errors.Is(unwrapped[2], err3) {
 		t.Errorf("Expected third error to be err3")
 	}
 }

--- a/pkg/errors/parse_test.go
+++ b/pkg/errors/parse_test.go
@@ -51,10 +51,10 @@ func TestParseErrors(t *testing.T) {
 			t.Errorf("Expected 2 unwrapped errors, got %d", len(unwrapped))
 		}
 
-		if unwrapped[0] != err1 {
+		if !errors.Is(unwrapped[0], err1) {
 			t.Errorf("First unwrapped error doesn't match")
 		}
-		if unwrapped[1] != err2 {
+		if !errors.Is(unwrapped[1], err2) {
 			t.Errorf("Second unwrapped error doesn't match")
 		}
 	})

--- a/pkg/io/printer.go
+++ b/pkg/io/printer.go
@@ -114,9 +114,9 @@ func (rp *ResourcePrinter) printNames(resources []*client.Object, w io.Writer) e
 
 		resourceName := fmt.Sprintf("%s/%s", kind, name)
 		if namespace != "" {
-			fmt.Fprintf(w, "%s (namespace: %s)\n", resourceName, namespace)
+			_, _ = fmt.Fprintf(w, "%s (namespace: %s)\n", resourceName, namespace)
 		} else {
-			fmt.Fprintf(w, "%s\n", resourceName)
+			_, _ = fmt.Fprintf(w, "%s\n", resourceName)
 		}
 	}
 	return nil

--- a/pkg/io/runtime.go
+++ b/pkg/io/runtime.go
@@ -2,6 +2,7 @@ package io
 
 import (
 	"bytes"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"os"
@@ -25,7 +26,6 @@ type ParseOptions struct {
 }
 
 func parse(yamlbytes []byte, opts ParseOptions) ([]client.Object, error) {
-
 	// Parsing approach adapted from
 	// https://dx13.co.uk/articles/2021/01/15/kubernetes-types-using-go/
 
@@ -42,7 +42,7 @@ func parse(yamlbytes []byte, opts ParseOptions) ([]client.Object, error) {
 	for {
 		var raw runtime.RawExtension
 		if err := decoder.Decode(&raw); err != nil {
-			if err == io.EOF {
+			if stderrors.Is(err, io.EOF) {
 				break
 			}
 			errs = append(errs, errors.NewParseError("YAML document", "failed to decode document", 0, 0, err))

--- a/pkg/io/table.go
+++ b/pkg/io/table.go
@@ -258,7 +258,7 @@ func (stp *SimpleTablePrinter) Print(resources []*client.Object, w io.Writer) er
 
 	// Create tabwriter for aligned output
 	tw := tabwriter.NewWriter(w, 0, 8, 2, ' ', 0)
-	defer tw.Flush()
+	defer func() { _ = tw.Flush() }()
 
 	// Print headers
 	if !stp.noHeaders {
@@ -266,7 +266,7 @@ func (stp *SimpleTablePrinter) Print(resources []*client.Object, w io.Writer) er
 		for i, col := range visibleColumns {
 			headers[i] = col.Header
 		}
-		fmt.Fprintln(tw, strings.Join(headers, "\t"))
+		_, _ = fmt.Fprintln(tw, strings.Join(headers, "\t"))
 	}
 
 	// Sort resources by name for consistent output
@@ -299,7 +299,7 @@ func (stp *SimpleTablePrinter) Print(resources []*client.Object, w io.Writer) er
 			row[i] = col.Accessor(obj)
 		}
 
-		fmt.Fprintln(tw, strings.Join(row, "\t"))
+		_, _ = fmt.Fprintln(tw, strings.Join(row, "\t"))
 	}
 
 	return nil

--- a/pkg/kubernetes/coverage_test.go
+++ b/pkg/kubernetes/coverage_test.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	stderrors "errors"
 	"sync"
 	"testing"
 
@@ -142,7 +143,7 @@ func TestGetGroupVersionKind_EdgeCases(t *testing.T) {
 func TestGetGroupVersionKind_ErrorScenarios(t *testing.T) {
 	t.Run("nil object", func(t *testing.T) {
 		gvk, err := GetGroupVersionKind(nil)
-		if err != errors.ErrNilObject {
+		if !stderrors.Is(err, errors.ErrNilObject) {
 			t.Errorf("expected ErrNilObject, got %v", err)
 		}
 		if gvk != (schema.GroupVersionKind{}) {
@@ -342,7 +343,7 @@ func TestValidatePackageRef_EdgeCases(t *testing.T) {
 		}
 
 		err := ValidatePackageRef(gvk)
-		if err != errors.ErrGVKNotAllowed {
+		if !stderrors.Is(err, errors.ErrGVKNotAllowed) {
 			t.Errorf("expected ErrGVKNotAllowed, got %v", err)
 		}
 	})
@@ -355,7 +356,7 @@ func TestValidatePackageRef_EdgeCases(t *testing.T) {
 		}
 
 		err := ValidatePackageRef(gvk)
-		if err != errors.ErrGVKNotAllowed {
+		if !stderrors.Is(err, errors.ErrGVKNotAllowed) {
 			t.Errorf("expected ErrGVKNotAllowed, got %v", err)
 		}
 	})
@@ -364,7 +365,7 @@ func TestValidatePackageRef_EdgeCases(t *testing.T) {
 		gvk := &schema.GroupVersionKind{}
 
 		err := ValidatePackageRef(gvk)
-		if err != errors.ErrGVKNotAllowed {
+		if !stderrors.Is(err, errors.ErrGVKNotAllowed) {
 			t.Errorf("expected ErrGVKNotAllowed for empty GVK, got %v", err)
 		}
 	})

--- a/pkg/kubernetes/deployment_test.go
+++ b/pkg/kubernetes/deployment_test.go
@@ -258,8 +258,8 @@ func TestDeploymentFunctions(t *testing.T) {
 		t.Errorf("replicas not set")
 	}
 
-	strat := appsv1.DeploymentStrategy{Type: appsv1.RollingUpdateDeploymentStrategyType}
-	if err := SetDeploymentStrategy(dep, strat); err != nil {
+	strategy := appsv1.DeploymentStrategy{Type: appsv1.RollingUpdateDeploymentStrategyType}
+	if err := SetDeploymentStrategy(dep, strategy); err != nil {
 		t.Fatalf("SetDeploymentStrategy returned error: %v", err)
 	}
 	if dep.Spec.Strategy.Type != appsv1.RollingUpdateDeploymentStrategyType {

--- a/pkg/kubernetes/fluxcd/create.go
+++ b/pkg/kubernetes/fluxcd/create.go
@@ -188,16 +188,20 @@ func ResourceSet(cfg *ResourceSetConfig) *fluxv1.ResourceSet {
 }
 
 // ResourceSetInputProvider converts the config to a ResourceSetInputProvider object.
-func ResourceSetInputProvider(cfg *ResourceSetInputProviderConfig) *fluxv1.ResourceSetInputProvider {
+func ResourceSetInputProvider(cfg *ResourceSetInputProviderConfig) (*fluxv1.ResourceSetInputProvider, error) {
 	if cfg == nil {
-		return nil
+		return nil, nil
 	}
 	obj := intfluxcd.CreateResourceSetInputProvider(cfg.Name, cfg.Namespace, fluxv1.ResourceSetInputProviderSpec{})
-	intfluxcd.SetResourceSetInputProviderType(obj, cfg.Type)
-	if cfg.URL != "" {
-		intfluxcd.SetResourceSetInputProviderURL(obj, cfg.URL)
+	if err := intfluxcd.SetResourceSetInputProviderType(obj, cfg.Type); err != nil {
+		return nil, err
 	}
-	return obj
+	if cfg.URL != "" {
+		if err := intfluxcd.SetResourceSetInputProviderURL(obj, cfg.URL); err != nil {
+			return nil, err
+		}
+	}
+	return obj, nil
 }
 
 // FluxInstance converts the config to a FluxInstance object.

--- a/pkg/kubernetes/fluxcd/create_test.go
+++ b/pkg/kubernetes/fluxcd/create_test.go
@@ -554,7 +554,10 @@ func TestResourceSetInputProvider_Success(t *testing.T) {
 		URL:       "https://api.example.com/config",
 	}
 
-	provider := ResourceSetInputProvider(cfg)
+	provider, err := ResourceSetInputProvider(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if provider == nil {
 		t.Fatal("expected non-nil ResourceSetInputProvider")
@@ -742,7 +745,11 @@ func TestAllConstructorsWithNilConfig(t *testing.T) {
 			}
 		}},
 		{"ResourceSetInputProvider", func(t *testing.T) {
-			if ResourceSetInputProvider(nil) != nil {
+			obj, err := ResourceSetInputProvider(nil)
+			if err != nil {
+				t.Errorf("unexpected error for nil config: %v", err)
+			}
+			if obj != nil {
 				t.Error("ResourceSetInputProvider should return nil for nil config")
 			}
 		}},

--- a/pkg/kubernetes/fluxcd/update_test.go
+++ b/pkg/kubernetes/fluxcd/update_test.go
@@ -400,7 +400,10 @@ func TestSetResourceSetInputProviderSpec(t *testing.T) {
 		Type:      "http",
 	}
 
-	provider := ResourceSetInputProvider(cfg)
+	provider, err := ResourceSetInputProvider(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if provider == nil {
 		t.Fatal("failed to create ResourceSetInputProvider")
 	}
@@ -685,13 +688,16 @@ func TestResourceSetInputProviderHelpers(t *testing.T) {
 		Type:      "http",
 	}
 
-	provider := ResourceSetInputProvider(cfg)
+	provider, err := ResourceSetInputProvider(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if provider == nil {
 		t.Fatal("failed to create ResourceSetInputProvider")
 	}
 
 	// Test SetResourceSetInputProviderType (via the function that delegates)
-	err := SetResourceSetInputProviderType(provider, "oci")
+	err = SetResourceSetInputProviderType(provider, "oci")
 	if err != nil {
 		t.Errorf("SetResourceSetInputProviderType failed: %v", err)
 	}

--- a/pkg/kubernetes/scheme_test.go
+++ b/pkg/kubernetes/scheme_test.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	stderrors "errors"
 	"testing"
 
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
@@ -614,10 +615,10 @@ func TestRegisterSchemes_ErrorCaching(t *testing.T) {
 	err3 := RegisterSchemes()
 
 	// All errors should be identical (either all nil or all the same error)
-	if err1 != err2 {
+	if !stderrors.Is(err1, err2) {
 		t.Errorf("RegisterSchemes returned different errors: first=%v, second=%v", err1, err2)
 	}
-	if err2 != err3 {
+	if !stderrors.Is(err2, err3) {
 		t.Errorf("RegisterSchemes returned different errors: second=%v, third=%v", err2, err3)
 	}
 }

--- a/pkg/kubernetes/utilities.go
+++ b/pkg/kubernetes/utilities.go
@@ -40,8 +40,7 @@ func IsGVKAllowed(gvk schema.GroupVersionKind, allowed []schema.GroupVersionKind
 
 // Helper function to convert to client.Object
 func ToClientObject(obj client.Object) *client.Object {
-	// iThis is not a Redundant type conversion
-	clientObj := client.Object(obj)
+	clientObj := obj
 	return &clientObj
 }
 

--- a/pkg/kubernetes/utilities_test.go
+++ b/pkg/kubernetes/utilities_test.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	stderrors "errors"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -75,7 +76,7 @@ func TestGetGroupVersionKind_Success(t *testing.T) {
 func TestGetGroupVersionKind_NilObject(t *testing.T) {
 	gvk, err := GetGroupVersionKind(nil)
 
-	if err != errors.ErrNilObject {
+	if !stderrors.Is(err, errors.ErrNilObject) {
 		t.Errorf("expected ErrNilObject, got: %v", err)
 	}
 
@@ -369,7 +370,7 @@ func TestValidatePackageRef_InvalidGVK(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidatePackageRef(tt.gvk)
-			if err != errors.ErrGVKNotAllowed {
+			if !stderrors.Is(err, errors.ErrGVKNotAllowed) {
 				t.Errorf("expected ErrGVKNotAllowed, got: %v", err)
 			}
 		})
@@ -438,7 +439,7 @@ func TestUtilities_Integration(t *testing.T) {
 	// Convert to client object
 	clientObjPtr := ToClientObject(pod)
 	if clientObjPtr == nil {
-		t.Error("expected non-nil client object pointer")
+		t.Fatal("expected non-nil client object pointer")
 	}
 
 	clientObj := *clientObjPtr

--- a/pkg/launcher/benchmark_test.go
+++ b/pkg/launcher/benchmark_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-kure/kure/pkg/logger"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/go-kure/kure/pkg/logger"
 )
 
 // BenchmarkVariableResolution benchmarks variable resolution performance

--- a/pkg/launcher/builder_test.go
+++ b/pkg/launcher/builder_test.go
@@ -4,18 +4,20 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/go-kure/kure/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/go-kure/kure/pkg/logger"
 )
 
 func TestBuilder(t *testing.T) {
@@ -134,7 +136,7 @@ func TestBuilder(t *testing.T) {
 		for {
 			var doc map[string]interface{}
 			if err := decoder.Decode(&doc); err != nil {
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					break
 				}
 				t.Fatalf("Failed to decode YAML: %v", err)

--- a/pkg/launcher/cli.go
+++ b/pkg/launcher/cli.go
@@ -10,10 +10,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-kure/kure/pkg/errors"
-	"github.com/go-kure/kure/pkg/logger"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
+
+	"github.com/go-kure/kure/pkg/errors"
+	"github.com/go-kure/kure/pkg/logger"
 )
 
 // CLI provides command-line interface for the launcher
@@ -317,7 +318,7 @@ func (c *CLI) debugVariablesCommand(opts *LauncherOptions) *cobra.Command {
 			// Show variable graph
 			resolver := c.resolver.(*variableResolver)
 			graph := resolver.DebugVariableGraph(def.Parameters)
-			fmt.Fprintln(c.outputWriter, graph)
+			_, _ = fmt.Fprintln(c.outputWriter, graph)
 
 			return nil
 		},
@@ -351,7 +352,7 @@ func (c *CLI) debugPatchesCommand(opts *LauncherOptions) *cobra.Command {
 			// Show patch graph
 			processor := c.processor.(*patchProcessor)
 			graph := processor.DebugPatchGraph(def.Patches)
-			fmt.Fprintln(c.outputWriter, graph)
+			_, _ = fmt.Fprintln(c.outputWriter, graph)
 
 			return nil
 		},
@@ -383,19 +384,19 @@ func (c *CLI) debugResourcesCommand(opts *LauncherOptions) *cobra.Command {
 			}
 
 			// Show resource details
-			fmt.Fprintf(c.outputWriter, "Package: %s\n", def.Metadata.Name)
-			fmt.Fprintf(c.outputWriter, "Resources: %d\n\n", len(def.Resources))
+			_, _ = fmt.Fprintf(c.outputWriter, "Package: %s\n", def.Metadata.Name)
+			_, _ = fmt.Fprintf(c.outputWriter, "Resources: %d\n\n", len(def.Resources))
 
 			for i, resource := range def.Resources {
-				fmt.Fprintf(c.outputWriter, "[%d] %s/%s\n", i+1, resource.Kind, resource.GetName())
-				fmt.Fprintf(c.outputWriter, "    Namespace: %s\n", resource.GetNamespace())
+				_, _ = fmt.Fprintf(c.outputWriter, "[%d] %s/%s\n", i+1, resource.Kind, resource.GetName())
+				_, _ = fmt.Fprintf(c.outputWriter, "    Namespace: %s\n", resource.GetNamespace())
 				if len(resource.Metadata.Labels) > 0 {
-					fmt.Fprintf(c.outputWriter, "    Labels:\n")
+					_, _ = fmt.Fprintf(c.outputWriter, "    Labels:\n")
 					for k, v := range resource.Metadata.Labels {
-						fmt.Fprintf(c.outputWriter, "      %s: %s\n", k, v)
+						_, _ = fmt.Fprintf(c.outputWriter, "      %s: %s\n", k, v)
 					}
 				}
-				fmt.Fprintln(c.outputWriter)
+				_, _ = fmt.Fprintln(c.outputWriter)
 			}
 
 			return nil
@@ -501,25 +502,25 @@ func (c *CLI) runValidate(ctx context.Context, packagePath, valuesFile, schemaFi
 
 	// Text output
 	if len(result.Errors) > 0 {
-		fmt.Fprintf(c.outputWriter, "Errors (%d):\n", len(result.Errors))
+		_, _ = fmt.Fprintf(c.outputWriter, "Errors (%d):\n", len(result.Errors))
 		for _, e := range result.Errors {
-			fmt.Fprintf(c.outputWriter, "  ✗ %s\n", e.Error())
+			_, _ = fmt.Fprintf(c.outputWriter, "  ✗ %s\n", e.Error())
 		}
-		fmt.Fprintln(c.outputWriter)
+		_, _ = fmt.Fprintln(c.outputWriter)
 	}
 
 	if len(result.Warnings) > 0 {
-		fmt.Fprintf(c.outputWriter, "Warnings (%d):\n", len(result.Warnings))
+		_, _ = fmt.Fprintf(c.outputWriter, "Warnings (%d):\n", len(result.Warnings))
 		for _, w := range result.Warnings {
-			fmt.Fprintf(c.outputWriter, "  ⚠ %s\n", w.String())
+			_, _ = fmt.Fprintf(c.outputWriter, "  ⚠ %s\n", w.String())
 		}
-		fmt.Fprintln(c.outputWriter)
+		_, _ = fmt.Fprintln(c.outputWriter)
 	}
 
 	if result.IsValid() {
-		fmt.Fprintln(c.outputWriter, "✓ Package is valid")
+		_, _ = fmt.Fprintln(c.outputWriter, "✓ Package is valid")
 	} else {
-		fmt.Fprintln(c.outputWriter, "✗ Package has errors")
+		_, _ = fmt.Fprintln(c.outputWriter, "✗ Package has errors")
 		if opts.StrictMode {
 			return errors.New("validation failed")
 		}
@@ -547,38 +548,38 @@ func (c *CLI) runInfo(ctx context.Context, packagePath, outputFormat string, sho
 		return encoder.Encode(def)
 
 	default: // text
-		fmt.Fprintf(c.outputWriter, "Package: %s\n", def.Metadata.Name)
-		fmt.Fprintf(c.outputWriter, "Version: %s\n", def.Metadata.Version)
+		_, _ = fmt.Fprintf(c.outputWriter, "Package: %s\n", def.Metadata.Name)
+		_, _ = fmt.Fprintf(c.outputWriter, "Version: %s\n", def.Metadata.Version)
 		if def.Metadata.Description != "" {
-			fmt.Fprintf(c.outputWriter, "Description: %s\n", def.Metadata.Description)
+			_, _ = fmt.Fprintf(c.outputWriter, "Description: %s\n", def.Metadata.Description)
 		}
-		fmt.Fprintln(c.outputWriter)
+		_, _ = fmt.Fprintln(c.outputWriter)
 
 		if len(def.Parameters) > 0 {
-			fmt.Fprintf(c.outputWriter, "Parameters (%d):\n", len(def.Parameters))
+			_, _ = fmt.Fprintf(c.outputWriter, "Parameters (%d):\n", len(def.Parameters))
 			for k, v := range def.Parameters {
-				fmt.Fprintf(c.outputWriter, "  %s: %v\n", k, formatValue(v))
+				_, _ = fmt.Fprintf(c.outputWriter, "  %s: %v\n", k, formatValue(v))
 			}
-			fmt.Fprintln(c.outputWriter)
+			_, _ = fmt.Fprintln(c.outputWriter)
 		}
 
-		fmt.Fprintf(c.outputWriter, "Resources (%d):\n", len(def.Resources))
+		_, _ = fmt.Fprintf(c.outputWriter, "Resources (%d):\n", len(def.Resources))
 		for _, r := range def.Resources {
-			fmt.Fprintf(c.outputWriter, "  - %s/%s", r.Kind, r.GetName())
+			_, _ = fmt.Fprintf(c.outputWriter, "  - %s/%s", r.Kind, r.GetName())
 			if ns := r.GetNamespace(); ns != "" {
-				fmt.Fprintf(c.outputWriter, " (namespace: %s)", ns)
+				_, _ = fmt.Fprintf(c.outputWriter, " (namespace: %s)", ns)
 			}
-			fmt.Fprintln(c.outputWriter)
+			_, _ = fmt.Fprintln(c.outputWriter)
 		}
 
 		if len(def.Patches) > 0 {
-			fmt.Fprintf(c.outputWriter, "\nPatches (%d):\n", len(def.Patches))
+			_, _ = fmt.Fprintf(c.outputWriter, "\nPatches (%d):\n", len(def.Patches))
 			for _, p := range def.Patches {
-				fmt.Fprintf(c.outputWriter, "  - %s", p.Name)
+				_, _ = fmt.Fprintf(c.outputWriter, "  - %s", p.Name)
 				if p.Metadata != nil && p.Metadata.Description != "" {
-					fmt.Fprintf(c.outputWriter, ": %s", p.Metadata.Description)
+					_, _ = fmt.Fprintf(c.outputWriter, ": %s", p.Metadata.Description)
 				}
-				fmt.Fprintln(c.outputWriter)
+				_, _ = fmt.Fprintln(c.outputWriter)
 			}
 		}
 	}

--- a/pkg/launcher/cli_test.go
+++ b/pkg/launcher/cli_test.go
@@ -8,9 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/go-kure/kure/pkg/launcher"
 	"github.com/go-kure/kure/pkg/logger"
-	"gopkg.in/yaml.v3"
 )
 
 func TestCLI_BuildCommand(t *testing.T) {

--- a/pkg/launcher/errors.go
+++ b/pkg/launcher/errors.go
@@ -276,7 +276,8 @@ func IsCriticalError(err error) bool {
 	}
 
 	// Check for specific critical error patterns
-	if fileErr, ok := err.(*errors.FileError); ok {
+	var fileErr *errors.FileError
+	if stderrors.As(err, &fileErr) {
 		if fileErr.Operation == "read" || fileErr.Operation == "load" {
 			return true
 		}

--- a/pkg/launcher/extensions.go
+++ b/pkg/launcher/extensions.go
@@ -6,9 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/go-kure/kure/pkg/errors"
 	"github.com/go-kure/kure/pkg/logger"
-	"gopkg.in/yaml.v3"
 )
 
 // extensionLoader implements the ExtensionLoader interface

--- a/pkg/launcher/extensions_test.go
+++ b/pkg/launcher/extensions_test.go
@@ -7,11 +7,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-kure/kure/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/go-kure/kure/pkg/logger"
 )
 
 func TestExtensionLoader(t *testing.T) {

--- a/pkg/launcher/integration_test.go
+++ b/pkg/launcher/integration_test.go
@@ -9,9 +9,10 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/go-kure/kure/pkg/launcher"
 	"github.com/go-kure/kure/pkg/logger"
-	"gopkg.in/yaml.v3"
 )
 
 // Integration tests for the complete launcher workflow

--- a/pkg/launcher/loader.go
+++ b/pkg/launcher/loader.go
@@ -6,22 +6,21 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"sync"
 
-	"github.com/go-kure/kure/pkg/errors"
-	"github.com/go-kure/kure/pkg/io"
-	"github.com/go-kure/kure/pkg/logger"
 	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/kure/pkg/errors"
+	"github.com/go-kure/kure/pkg/io"
+	"github.com/go-kure/kure/pkg/logger"
 )
 
 // packageLoader implements the PackageLoader interface
 type packageLoader struct {
 	logger logger.Logger
-	mu     sync.RWMutex
 }
 
 // NewPackageLoader creates a new package loader
@@ -207,7 +206,7 @@ func (l *packageLoader) LoadResources(ctx context.Context, path string, _ *Launc
 		// Find all YAML files
 		err := filepath.Walk(loc, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
-				return nil // Skip files with errors
+				return err
 			}
 
 			// Skip directories and non-YAML files
@@ -345,7 +344,7 @@ func (l *packageLoader) LoadPatches(ctx context.Context, path string, _ *Launche
 	// Find all patch files
 	err := filepath.Walk(patchDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return nil // Skip files with errors
+			return err
 		}
 
 		// Skip directories and non-patch files

--- a/pkg/launcher/loader_test.go
+++ b/pkg/launcher/loader_test.go
@@ -6,9 +6,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/go-kure/kure/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-kure/kure/pkg/logger"
 )
 
 func TestPackageLoader(t *testing.T) {

--- a/pkg/launcher/patch_processor.go
+++ b/pkg/launcher/patch_processor.go
@@ -378,30 +378,6 @@ func (p *patchProcessor) addToValues(prefix string, value interface{}, values ma
 	}
 }
 
-// addToVariables recursively adds parameters to variable map
-func (p *patchProcessor) addToVariables(prefix string, value interface{}, vars map[string]string) {
-	switch v := value.(type) {
-	case string:
-		vars[prefix] = v
-	case bool:
-		vars[prefix] = strconv.FormatBool(v)
-	case int, int32, int64:
-		vars[prefix] = fmt.Sprintf("%d", v)
-	case float32, float64:
-		vars[prefix] = fmt.Sprintf("%v", v)
-	case map[string]interface{}:
-		for k, val := range v {
-			key := prefix + "." + k
-			p.addToVariables(key, val, vars)
-		}
-	case []interface{}:
-		for i, val := range v {
-			key := fmt.Sprintf("%s[%d]", prefix, i)
-			p.addToVariables(key, val, vars)
-		}
-	}
-}
-
 // parsePatch parses patch content into PatchSpecs
 func (p *patchProcessor) parsePatch(patchDef Patch, varCtx *patch.VariableContext) ([]patch.PatchSpec, error) {
 	reader := strings.NewReader(patchDef.Content)

--- a/pkg/launcher/patch_processor_test.go
+++ b/pkg/launcher/patch_processor_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-kure/kure/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/go-kure/kure/pkg/logger"
 )
 
 func TestPatchProcessor(t *testing.T) {

--- a/pkg/launcher/resolver_test.go
+++ b/pkg/launcher/resolver_test.go
@@ -5,9 +5,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-kure/kure/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-kure/kure/pkg/logger"
 )
 
 func TestResolver(t *testing.T) {

--- a/pkg/launcher/schema.go
+++ b/pkg/launcher/schema.go
@@ -8,8 +8,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/go-kure/kure/pkg/logger"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/go-kure/kure/pkg/logger"
 )
 
 // SchemaGenerator generates JSON schemas for package validation
@@ -235,11 +236,6 @@ func (g *schemaGenerator) generateParametersSchema() *JSONSchema {
 		Properties:  map[string]*JSONSchema{},
 		// Allow additional properties for flexibility
 	}
-}
-
-// generateResourcesSchema generates schema for resources section
-func (g *schemaGenerator) generateResourcesSchema() *JSONSchema {
-	return g.generateResourcesSchemaWithOptions(false)
 }
 
 // generateResourcesSchemaWithOptions generates schema for resources section with K8s option
@@ -977,10 +973,7 @@ func validateRecursive(data interface{}, schema *JSONSchema, path string, errors
 
 	case "string":
 		if str, ok := data.(string); ok {
-			// Check pattern
-			if schema.Pattern != "" {
-				// Pattern validation would go here
-			}
+			// TODO: pattern validation (schema.Pattern)
 
 			// Check length
 			if schema.MinLength != nil && len(str) < *schema.MinLength {

--- a/pkg/launcher/schema_test.go
+++ b/pkg/launcher/schema_test.go
@@ -5,12 +5,13 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/go-kure/kure/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/go-kure/kure/pkg/logger"
 )
 
 func TestSchemaGenerator(t *testing.T) {

--- a/pkg/launcher/validator.go
+++ b/pkg/launcher/validator.go
@@ -7,10 +7,11 @@ import (
 	"strings"
 
 	"github.com/blang/semver/v4"
-	"github.com/go-kure/kure/pkg/errors"
-	"github.com/go-kure/kure/pkg/logger"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/go-kure/kure/pkg/errors"
+	"github.com/go-kure/kure/pkg/logger"
 )
 
 // validator implements the Validator interface
@@ -278,9 +279,6 @@ func (v *validator) validateResources(ctx context.Context, resources []Resource,
 			w.Field = fmt.Sprintf("resources[%d].%s", i, w.Field)
 			result.Warnings = append(result.Warnings, w)
 		}
-
-		if !resResult.IsValid() {
-		}
 	}
 }
 
@@ -301,9 +299,6 @@ func (v *validator) validatePatches(ctx context.Context, patches []Patch, result
 		for _, w := range patchResult.Warnings {
 			w.Field = fmt.Sprintf("patches[%d].%s", i, w.Field)
 			result.Warnings = append(result.Warnings, w)
-		}
-
-		if !patchResult.IsValid() {
 		}
 	}
 }
@@ -595,9 +590,7 @@ func (v *validator) findPatchCycles(patches []Patch) [][]string {
 		path = append(path, node)
 
 		for _, dep := range deps[node] {
-			if dfs(dep) {
-				// Don't return immediately to find all cycles
-			}
+			dfs(dep) // Don't return immediately to find all cycles
 		}
 
 		path = path[:len(path)-1]

--- a/pkg/launcher/validator_test.go
+++ b/pkg/launcher/validator_test.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-kure/kure/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/go-kure/kure/pkg/logger"
 )
 
 func TestValidator(t *testing.T) {

--- a/pkg/patch/apply.go
+++ b/pkg/patch/apply.go
@@ -15,13 +15,13 @@ func ApplyPatch(basePath, patchPath string) ([]*unstructured.Unstructured, error
 	if err != nil {
 		return nil, err
 	}
-	defer baseFile.Close()
+	defer func() { _ = baseFile.Close() }()
 
 	patchFile, err := os.Open(filepath.Clean(patchPath))
 	if err != nil {
 		return nil, err
 	}
-	defer patchFile.Close()
+	defer func() { _ = patchFile.Close() }()
 
 	set, err := LoadPatchableAppSet([]io.Reader{baseFile}, patchFile)
 	if err != nil {

--- a/pkg/patch/set.go
+++ b/pkg/patch/set.go
@@ -206,7 +206,7 @@ func (s *PatchableAppSet) WritePatchedFilesWithOptions(originalPath string, patc
 		}
 
 		patches, err := LoadPatchFile(patchReader)
-		patchReader.Close()
+		_ = patchReader.Close()
 		if err != nil {
 			return fmt.Errorf("failed to load patches from %s: %w", patchFile, err)
 		}

--- a/pkg/stack/generators/fluxhelm/internal/fluxhelm_test.go
+++ b/pkg/stack/generators/fluxhelm/internal/fluxhelm_test.go
@@ -588,6 +588,8 @@ func TestGenerateSourceInferred(t *testing.T) {
 				if _, ok := (*obj).(*sourcev1.OCIRepository); !ok {
 					t.Errorf("Expected OCIRepository, got %T", *obj)
 				}
+			default:
+				t.Errorf("Unexpected source type: %s", tt.wantType)
 			}
 		})
 	}

--- a/pkg/stack/generators/fluxhelm/v1alpha1_test.go
+++ b/pkg/stack/generators/fluxhelm/v1alpha1_test.go
@@ -673,15 +673,6 @@ func findHelmRelease(objs []*client.Object) *helmv2.HelmRelease {
 	return nil
 }
 
-func findHelmRepository(objs []*client.Object) *sourcev1.HelmRepository {
-	for _, obj := range objs {
-		if hr, ok := (*obj).(*sourcev1.HelmRepository); ok {
-			return hr
-		}
-	}
-	return nil
-}
-
 func TestConfigV1Alpha1_Generate_EmptyValues(t *testing.T) {
 	cfg := &ConfigV1Alpha1{
 		BaseMetadata: generators.BaseMetadata{

--- a/pkg/stack/generators/kurelpackage/v1alpha1_test.go
+++ b/pkg/stack/generators/kurelpackage/v1alpha1_test.go
@@ -7,7 +7,6 @@ import (
 
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-kure/kure/pkg/stack"
 )
@@ -1023,11 +1022,7 @@ data:
 	if obj.GetObjectKind().GroupVersionKind().Kind != "ConfigMap" {
 		t.Errorf("expected ConfigMap, got %s", obj.GetObjectKind().GroupVersionKind().Kind)
 	}
-	co, ok := obj.(client.Object)
-	if !ok {
-		t.Fatal("expected client.Object")
-	}
-	if co.GetName() != "test-cm" {
-		t.Errorf("object name = %q, want %q", co.GetName(), "test-cm")
+	if obj.GetName() != "test-cm" {
+		t.Errorf("object name = %q, want %q", obj.GetName(), "test-cm")
 	}
 }

--- a/pkg/stack/layout/tar.go
+++ b/pkg/stack/layout/tar.go
@@ -19,7 +19,7 @@ import (
 // forward slashes and output is deterministic (sorted file names).
 func (ml *ManifestLayout) WriteToTar(w io.Writer) error {
 	tw := tar.NewWriter(w)
-	defer tw.Close()
+	defer func() { _ = tw.Close() }()
 	return ml.writeToTarRecursive(tw, "")
 }
 

--- a/pkg/stack/layout/tar_test.go
+++ b/pkg/stack/layout/tar_test.go
@@ -3,6 +3,7 @@ package layout
 import (
 	"archive/tar"
 	"bytes"
+	"errors"
 	"io"
 	"sort"
 	"testing"
@@ -145,7 +146,7 @@ func extractTarFiles(t *testing.T, buf *bytes.Buffer) map[string][]byte {
 	tr := tar.NewReader(buf)
 	for {
 		hdr, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/pkg/stack/layout/walker.go
+++ b/pkg/stack/layout/walker.go
@@ -3,9 +3,10 @@ package layout
 import (
 	"path/filepath"
 
-	"github.com/go-kure/kure/pkg/stack"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/kure/pkg/stack"
 )
 
 // WalkCluster traverses a stack.Cluster and builds a ManifestLayout tree that

--- a/pkg/stack/v1alpha1/node.go
+++ b/pkg/stack/v1alpha1/node.go
@@ -1,9 +1,10 @@
 package v1alpha1
 
 import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/go-kure/kure/internal/gvk"
 	"github.com/go-kure/kure/pkg/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // NodeConfig represents a versioned node configuration

--- a/pkg/stack/v1alpha1/node_test.go
+++ b/pkg/stack/v1alpha1/node_test.go
@@ -3,8 +3,9 @@ package v1alpha1
 import (
 	"testing"
 
-	"github.com/go-kure/kure/internal/gvk"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/go-kure/kure/internal/gvk"
 )
 
 func TestNodeConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replace kure's custom `.golangci.yml` with the Wharf standard config (`meta/standards/golangci-lint.md`), matching crane's setup
- Fix all resulting lint issues across 66 files (364 insertions, 563 deletions — net reduction)

## Changes

**Config replacement:** The old config explicitly disabled 24 linters (including 8 required by the standard) and only enabled 6. The new config enables all 16 standard linters.

**Lint fixes by category:**

| Linter | Fixes | Strategy |
|--------|-------|----------|
| errcheck | ~60 | `_, _ =` for fmt output; `defer func() { _ = f.Close() }()` for Close/Flush |
| errorlint | ~60 | `errors.Is` / `errors.As` instead of `==` / type assertions |
| goimports | ~25 | Auto-fixed import grouping with `local-prefixes: github.com/go-kure/kure` |
| staticcheck | ~10 | `t.Fatal` for nil guard (SA5011), remove empty branches (SA9003), `strings.EqualFold` (SA6005) |
| misspell | ~12 | Renamed `strat` → `strategy` |
| unused | ~7 | Deleted dead functions/fields |
| gosimple | ~5 | Removed redundant type assertions (S1040) |
| nilerr | ~3 | Return errors instead of nil from `filepath.Walk` callbacks |
| ineffassign | ~3 | Removed dead assignments |
| exhaustive | ~3 | Added default/missing cases to switch statements |
| whitespace | ~2 | Removed unnecessary blank lines |
| unconvert | 1 | Removed unnecessary type conversion |

## Test plan

- [x] `golangci-lint run ./...` — passes with zero issues
- [x] `go test ./...` — all tests pass
- [x] `go vet ./...` — passes
- [x] `go build ./...` — passes