### PR TITLE
feat: add HelmRelease targetNamespace and releaseName fields

### DIFF
--- a/pkg/stack/generators/fluxhelm/internal/fluxhelm.go
+++ b/pkg/stack/generators/fluxhelm/internal/fluxhelm.go
@@ -33,6 +33,10 @@ type Config struct {
 	Name      string `yaml:"name" json:"name"`
 	Namespace string `yaml:"namespace,omitempty" json:"namespace,omitempty"`
 
+	// HelmRelease metadata overrides
+	TargetNamespace string `yaml:"targetNamespace,omitempty" json:"targetNamespace,omitempty"`
+	ReleaseName     string `yaml:"releaseName,omitempty" json:"releaseName,omitempty"`
+
 	// Chart configuration
 	Chart   ChartConfig `yaml:"chart" json:"chart"`
 	Version string      `yaml:"version,omitempty" json:"version,omitempty"`
@@ -411,6 +415,14 @@ func (c *Config) generateHelmRelease() (client.Object, error) {
 
 	// Set suspend
 	hr.Spec.Suspend = c.Suspend
+
+	// Set target namespace and release name overrides
+	if c.TargetNamespace != "" {
+		hr.Spec.TargetNamespace = c.TargetNamespace
+	}
+	if c.ReleaseName != "" {
+		hr.Spec.ReleaseName = c.ReleaseName
+	}
 
 	// Set release options
 	if c.Release.CreateNamespace {

--- a/pkg/stack/generators/fluxhelm/v1alpha1.go
+++ b/pkg/stack/generators/fluxhelm/v1alpha1.go
@@ -24,6 +24,10 @@ func init() {
 type ConfigV1Alpha1 struct {
 	generators.BaseMetadata `yaml:",inline" json:",inline"`
 
+	// HelmRelease metadata overrides
+	TargetNamespace string `yaml:"targetNamespace,omitempty" json:"targetNamespace,omitempty"`
+	ReleaseName     string `yaml:"releaseName,omitempty" json:"releaseName,omitempty"`
+
 	// Chart configuration
 	Chart   internal.ChartConfig `yaml:"chart" json:"chart"`
 	Version string               `yaml:"version,omitempty" json:"version,omitempty"`
@@ -59,19 +63,21 @@ func (c *ConfigV1Alpha1) GetKind() string {
 func (c *ConfigV1Alpha1) Generate(app *stack.Application) ([]*client.Object, error) {
 	// Delegate to the internal implementation
 	return internal.GenerateResources(&internal.Config{
-		Name:           c.Name,
-		Namespace:      c.Namespace,
-		Chart:          c.Chart,
-		Version:        c.Version,
-		Values:         c.Values,
-		Source:         c.Source,
-		Release:        c.Release,
-		Interval:       c.Interval,
-		Timeout:        c.Timeout,
-		MaxHistory:     c.MaxHistory,
-		ServiceAccount: c.ServiceAccount,
-		Suspend:        c.Suspend,
-		DependsOn:      c.DependsOn,
-		PostRenderers:  c.PostRenderers,
+		Name:            c.Name,
+		Namespace:       c.Namespace,
+		TargetNamespace: c.TargetNamespace,
+		ReleaseName:     c.ReleaseName,
+		Chart:           c.Chart,
+		Version:         c.Version,
+		Values:          c.Values,
+		Source:          c.Source,
+		Release:         c.Release,
+		Interval:        c.Interval,
+		Timeout:         c.Timeout,
+		MaxHistory:      c.MaxHistory,
+		ServiceAccount:  c.ServiceAccount,
+		Suspend:         c.Suspend,
+		DependsOn:       c.DependsOn,
+		PostRenderers:   c.PostRenderers,
 	})
 }


### PR DESCRIPTION
## Summary
- Add `TargetNamespace` and `ReleaseName` string fields to FluxHelm generator `Config` and `ConfigV1Alpha1`
- Wire both fields into the generated HelmRelease `spec.targetNamespace` and `spec.releaseName`
- Add unit tests for both internal and public API layers

## Context
Opsmaster has 43 HelmReleases in flux-system with `targetNamespace` set. This is the standard pattern for centralized GitOps where all HelmReleases live in flux-system but target different namespaces.

Closes #268

## Test plan
- [x] `TestGenerateHelmReleaseTargetNamespaceAndReleaseName` — verifies both fields set and defaults empty
- [x] `TestConfigV1Alpha1_Generate_WithTargetNamespaceAndReleaseName` — integration test through public API
- [x] `make check` passes (lint + test + build)