### PR TITLE
feat: expose valuesFrom in FluxHelm ReleaseConfig

### DIFF
--- a/pkg/stack/generators/fluxhelm/v1alpha1.go
+++ b/pkg/stack/generators/fluxhelm/v1alpha1.go
@@ -29,9 +29,10 @@ type ConfigV1Alpha1 struct {
 	ReleaseName     string `yaml:"releaseName,omitempty" json:"releaseName,omitempty"`
 
 	// Chart configuration
-	Chart   internal.ChartConfig `yaml:"chart" json:"chart"`
-	Version string               `yaml:"version,omitempty" json:"version,omitempty"`
-	Values  interface{}          `yaml:"values,omitempty" json:"values,omitempty"`
+	Chart      internal.ChartConfig       `yaml:"chart" json:"chart"`
+	Version    string                     `yaml:"version,omitempty" json:"version,omitempty"`
+	Values     interface{}                `yaml:"values,omitempty" json:"values,omitempty"`
+	ValuesFrom []internal.ValuesReference `yaml:"valuesFrom,omitempty" json:"valuesFrom,omitempty"`
 
 	// Source configuration
 	Source internal.SourceConfig `yaml:"source" json:"source"`
@@ -70,6 +71,7 @@ func (c *ConfigV1Alpha1) Generate(app *stack.Application) ([]*client.Object, err
 		Chart:           c.Chart,
 		Version:         c.Version,
 		Values:          c.Values,
+		ValuesFrom:      c.ValuesFrom,
 		Source:          c.Source,
 		Release:         c.Release,
 		Interval:        c.Interval,


### PR DESCRIPTION
## Summary
- Add `ValuesReference` type with Kind, Name, ValuesKey, TargetPath, Optional fields
- Add `ValuesFrom []ValuesReference` to `Config` and `ConfigV1Alpha1`
- Wire into `spec.valuesFrom` on generated HelmRelease

## Context
The low-level helper `AddHelmReleaseValuesFrom` existed but was not wired into the generator. Helm values sourced from ConfigMaps/Secrets are common in production (external-secrets-generated credentials, environment-specific overrides).

Closes #234

## Test plan
- [x] `TestGenerateHelmReleaseValuesFrom` — verifies ConfigMap + Secret refs with all fields
- [x] `TestConfigV1Alpha1_Generate_WithValuesFrom` — integration test through public API
- [x] `make check` passes