### PR TITLE
feat: allow SourceRefName override in FluxHelm generator

### DIFF
--- a/pkg/stack/generators/fluxhelm/internal/fluxhelm.go
+++ b/pkg/stack/generators/fluxhelm/internal/fluxhelm.go
@@ -93,6 +93,13 @@ type SourceConfig struct {
 
 	// Common
 	Interval string `yaml:"interval,omitempty" json:"interval,omitempty"`
+
+	// RefName overrides the default source resource name ("{config.Name}-source").
+	// When set, the source resource and HelmRelease sourceRef use this name instead.
+	RefName string `yaml:"refName,omitempty" json:"refName,omitempty"`
+	// SkipGeneration prevents creation of the source resource (reference-only mode).
+	// The HelmRelease sourceRef still points to RefName (or the default name).
+	SkipGeneration bool `yaml:"skipGeneration,omitempty" json:"skipGeneration,omitempty"`
 }
 
 // CRDsPolicy defines the install/upgrade approach for CRDs bundled with a Helm chart.
@@ -218,8 +225,21 @@ func (c *Config) validateChartRef() error {
 	return nil
 }
 
+// sourceName returns the name for the source resource, using RefName if set
+// or falling back to the default "{config.Name}-source" convention.
+func (c *Config) sourceName() string {
+	if c.Source.RefName != "" {
+		return c.Source.RefName
+	}
+	return c.Name + "-source"
+}
+
 // generateSource creates the appropriate source resource based on type
 func (c *Config) generateSource() (*client.Object, error) {
+	if c.Source.SkipGeneration {
+		return nil, nil
+	}
+
 	switch c.Source.Type {
 	case HelmRepositorySource:
 		return c.generateHelmRepository()
@@ -260,7 +280,7 @@ func (c *Config) generateHelmRepository() (*client.Object, error) {
 			Kind:       "HelmRepository",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      c.Name + "-source",
+			Name:      c.sourceName(),
 			Namespace: c.Namespace,
 		},
 		Spec: sourcev1.HelmRepositorySpec{
@@ -297,7 +317,7 @@ func (c *Config) generateGitRepository() (*client.Object, error) {
 			Kind:       "GitRepository",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      c.Name + "-source",
+			Name:      c.sourceName(),
 			Namespace: c.Namespace,
 		},
 		Spec: sourcev1.GitRepositorySpec{
@@ -340,7 +360,7 @@ func (c *Config) generateOCIRepository() (*client.Object, error) {
 			Kind:       "OCIRepository",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      c.Name + "-source",
+			Name:      c.sourceName(),
 			Namespace: c.Namespace,
 		},
 		Spec: sourcev1.OCIRepositorySpec{
@@ -377,7 +397,7 @@ func (c *Config) generateBucket() (*client.Object, error) {
 			Kind:       "Bucket",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      c.Name + "-source",
+			Name:      c.sourceName(),
 			Namespace: c.Namespace,
 		},
 		Spec: sourcev1.BucketSpec{
@@ -434,13 +454,12 @@ func (c *Config) generateHelmRelease() (client.Object, error) {
 			hr.Spec.ChartRef.Namespace = c.ChartRef.Namespace
 		}
 	} else {
-		sourceName := c.Name + "-source"
 		hr.Spec.Chart = &helmv2.HelmChartTemplate{
 			Spec: helmv2.HelmChartTemplateSpec{
 				Chart:   c.Chart.Name,
 				Version: c.Chart.Version,
 				SourceRef: helmv2.CrossNamespaceObjectReference{
-					Name: sourceName,
+					Name: c.sourceName(),
 				},
 			},
 		}

--- a/pkg/stack/generators/fluxhelm/internal/fluxhelm_test.go
+++ b/pkg/stack/generators/fluxhelm/internal/fluxhelm_test.go
@@ -689,6 +689,89 @@ func TestGenerateHelmReleaseCRDsPolicy(t *testing.T) {
 	}
 }
 
+func TestGenerateResourcesSourceNameOverride(t *testing.T) {
+	config := &Config{
+		Name:      "trust-manager",
+		Namespace: "flux-system",
+		Chart: ChartConfig{
+			Name:    "trust-manager",
+			Version: "0.9.0",
+		},
+		Source: SourceConfig{
+			Type:    HelmRepositorySource,
+			URL:     "https://charts.jetstack.io",
+			RefName: "jetstack-repo",
+		},
+	}
+
+	objects, err := GenerateResources(config)
+	if err != nil {
+		t.Fatalf("GenerateResources() error = %v", err)
+	}
+
+	if len(objects) != 2 {
+		t.Fatalf("Expected 2 objects, got %d", len(objects))
+	}
+
+	// Verify source name is custom
+	source, ok := (*objects[0]).(*sourcev1.HelmRepository)
+	if !ok {
+		t.Fatalf("Expected HelmRepository, got %T", *objects[0])
+	}
+	if source.Name != "jetstack-repo" {
+		t.Errorf("Source name = %q, want %q", source.Name, "jetstack-repo")
+	}
+
+	// Verify HelmRelease sourceRef uses same custom name
+	release, ok := (*objects[1]).(*helmv2.HelmRelease)
+	if !ok {
+		t.Fatalf("Expected HelmRelease, got %T", *objects[1])
+	}
+	if release.Spec.Chart.Spec.SourceRef.Name != "jetstack-repo" {
+		t.Errorf("SourceRef.Name = %q, want %q", release.Spec.Chart.Spec.SourceRef.Name, "jetstack-repo")
+	}
+}
+
+func TestGenerateResourcesSkipSourceGeneration(t *testing.T) {
+	config := &Config{
+		Name:      "trust-manager",
+		Namespace: "flux-system",
+		Chart: ChartConfig{
+			Name:    "trust-manager",
+			Version: "0.9.0",
+		},
+		Source: SourceConfig{
+			Type:           HelmRepositorySource,
+			URL:            "https://charts.jetstack.io",
+			RefName:        "jetstack-repo",
+			SkipGeneration: true,
+		},
+	}
+
+	objects, err := GenerateResources(config)
+	if err != nil {
+		t.Fatalf("GenerateResources() error = %v", err)
+	}
+
+	// Only HelmRelease — no source resource generated
+	if len(objects) != 1 {
+		t.Fatalf("Expected 1 object (HelmRelease only), got %d", len(objects))
+	}
+
+	release, ok := (*objects[0]).(*helmv2.HelmRelease)
+	if !ok {
+		t.Fatalf("Expected HelmRelease, got %T", *objects[0])
+	}
+
+	// SourceRef should still reference the custom name
+	if release.Spec.Chart.Spec.SourceRef.Name != "jetstack-repo" {
+		t.Errorf("SourceRef.Name = %q, want %q", release.Spec.Chart.Spec.SourceRef.Name, "jetstack-repo")
+	}
+	if release.Spec.Chart.Spec.SourceRef.Kind != "HelmRepository" {
+		t.Errorf("SourceRef.Kind = %q, want %q", release.Spec.Chart.Spec.SourceRef.Kind, "HelmRepository")
+	}
+}
+
 func TestGenerateHelmReleaseDefaults(t *testing.T) {
 	config := &Config{
 		Name:      "minimal-release",

--- a/pkg/stack/generators/fluxhelm/v1alpha1_test.go
+++ b/pkg/stack/generators/fluxhelm/v1alpha1_test.go
@@ -631,6 +631,45 @@ func TestConfigV1Alpha1_Generate_WithCRDsPolicy(t *testing.T) {
 	}
 }
 
+func TestConfigV1Alpha1_Generate_WithSourceRefNameOverride(t *testing.T) {
+	cfg := &ConfigV1Alpha1{
+		BaseMetadata: generators.BaseMetadata{
+			Name:      "trust-manager",
+			Namespace: "flux-system",
+		},
+		Chart: internal.ChartConfig{
+			Name:    "trust-manager",
+			Version: "0.9.0",
+		},
+		Source: internal.SourceConfig{
+			Type:           internal.HelmRepositorySource,
+			URL:            "https://charts.jetstack.io",
+			RefName:        "jetstack-repo",
+			SkipGeneration: true,
+		},
+	}
+
+	app := stack.NewApplication("trust-manager", "flux-system", cfg)
+	objs, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	// Only HelmRelease, no source
+	if len(objs) != 1 {
+		t.Fatalf("Expected 1 object, got %d", len(objs))
+	}
+
+	helmRelease := findHelmRelease(objs)
+	if helmRelease == nil {
+		t.Fatal("Expected HelmRelease object")
+	}
+
+	if helmRelease.Spec.Chart.Spec.SourceRef.Name != "jetstack-repo" {
+		t.Errorf("SourceRef.Name = %q, want %q", helmRelease.Spec.Chart.Spec.SourceRef.Name, "jetstack-repo")
+	}
+}
+
 func TestConfigV1Alpha1_Generate_NoExplicitSource(t *testing.T) {
 	cfg := &ConfigV1Alpha1{
 		BaseMetadata: generators.BaseMetadata{


### PR DESCRIPTION
## Summary
- Add `RefName` and `SkipGeneration` fields to `SourceConfig`
- Add `sourceName()` helper replacing hardcoded `{name}-source` pattern at 5 locations
- When `SkipGeneration` is true, no source resource is emitted (reference-only mode)

## Context
Multiple HelmReleases often share the same HelmRepository (e.g. cert-manager and trust-manager both from Jetstack). Previously kure created duplicate identical source resources with different names. Now a second HelmRelease can reference an existing source by name without generating a duplicate.

Closes #233

## Test plan
- [x] `TestGenerateResourcesSourceNameOverride` — custom source name on both source and HelmRelease
- [x] `TestGenerateResourcesSkipSourceGeneration` — only HelmRelease emitted, sourceRef correct
- [x] `TestConfigV1Alpha1_Generate_WithSourceRefNameOverride` — integration test
- [x] Existing tests still pass (default `{name}-source` behavior unchanged)
- [x] `make check` passes