### PR TITLE
fix: check remote tags before releasing

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -184,7 +184,12 @@ validate_git_state() {
 
 check_tag_exists() {
     if git rev-parse "refs/tags/$1" >/dev/null 2>&1; then
-        die "Tag $1 already exists"
+        die "Tag $1 already exists locally"
+    fi
+    remote_tags=$(git ls-remote --tags origin "refs/tags/$1") \
+        || die "Failed to query remote tags — check network connectivity"
+    if [ -n "$remote_tags" ]; then
+        die "Tag $1 already exists on remote"
     fi
 }
 


### PR DESCRIPTION
## Summary

Fixes #275.

`check_tag_exists()` only verified local tags via `git rev-parse`. In shallow clones or when another contributor pushed a tag, the local check passes but `git push --atomic` fails later with a confusing error.

This adds a `git ls-remote --tags origin` check to catch remote-only tags early, with a clear error message for both local and remote conflicts.

## Changes

- Query remote tags with `git ls-remote --tags origin "refs/tags/$tag"` after the local check
- Fail with a descriptive error if the tag exists on the remote
- Fail with a descriptive error if the remote query itself fails (network issues)