### PR TITLE
feat: add HealthChecks field to Bundle

### DIFF
--- a/pkg/stack/bundle.go
+++ b/pkg/stack/bundle.go
@@ -48,6 +48,9 @@ type Bundle struct {
 	Timeout string
 	// RetryInterval is the interval between retry attempts for failed reconciliations (e.g. "2m").
 	RetryInterval string
+	// HealthChecks lists resources whose health is monitored during reconciliation.
+	// When specified, the Kustomization waits for these resources to become ready.
+	HealthChecks []HealthCheck
 
 	// Internal fields for runtime hierarchy navigation (not serialized)
 	parent  *Bundle            `yaml:"-"` // Runtime parent reference for efficient traversal
@@ -68,6 +71,18 @@ type SourceRef struct {
 	Tag string
 	// Branch is the branch reference for Git sources.
 	Branch string
+}
+
+// HealthCheck defines a resource to be monitored for health during reconciliation.
+type HealthCheck struct {
+	// APIVersion of the resource (e.g. "apps/v1", "helm.toolkit.fluxcd.io/v2").
+	APIVersion string
+	// Kind of the resource (e.g. "Deployment", "HelmRelease").
+	Kind string
+	// Name of the resource.
+	Name string
+	// Namespace of the resource. When empty, defaults to the Kustomization namespace.
+	Namespace string
 }
 
 // NewBundle constructs a Bundle with the given name, resources and labels.

--- a/pkg/stack/fluxcd/resource_generator.go
+++ b/pkg/stack/fluxcd/resource_generator.go
@@ -165,6 +165,19 @@ func (g *ResourceGenerator) createKustomization(b *stack.Bundle) client.Object {
 		}
 	}
 
+	// Set health checks if specified
+	if len(b.HealthChecks) > 0 {
+		kust.Spec.HealthChecks = make([]metaapi.NamespacedObjectKindReference, 0, len(b.HealthChecks))
+		for _, hc := range b.HealthChecks {
+			kust.Spec.HealthChecks = append(kust.Spec.HealthChecks, metaapi.NamespacedObjectKindReference{
+				APIVersion: hc.APIVersion,
+				Kind:       hc.Kind,
+				Name:       hc.Name,
+				Namespace:  hc.Namespace,
+			})
+		}
+	}
+
 	// Add dependencies
 	for _, dep := range b.DependsOn {
 		kust.Spec.DependsOn = append(kust.Spec.DependsOn, metaapi.NamespacedObjectReference{

--- a/pkg/stack/v1alpha1/bundle.go
+++ b/pkg/stack/v1alpha1/bundle.go
@@ -64,6 +64,22 @@ type BundleSpec struct {
 	// Supports Go duration format (e.g., "2m", "30s", "5m")
 	// Valid range: 1s to 24h. Empty value uses system defaults.
 	RetryInterval string `yaml:"retryInterval,omitempty" json:"retryInterval,omitempty"`
+
+	// HealthChecks lists resources whose health is monitored during reconciliation.
+	// When specified, the Kustomization waits for these resources to become ready.
+	HealthChecks []HealthCheckReference `yaml:"healthChecks,omitempty" json:"healthChecks,omitempty"`
+}
+
+// HealthCheckReference defines a resource to be monitored for health during reconciliation.
+type HealthCheckReference struct {
+	// APIVersion of the resource (e.g. "apps/v1", "helm.toolkit.fluxcd.io/v2").
+	APIVersion string `yaml:"apiVersion,omitempty" json:"apiVersion,omitempty"`
+	// Kind of the resource (e.g. "Deployment", "HelmRelease").
+	Kind string `yaml:"kind" json:"kind"`
+	// Name of the resource.
+	Name string `yaml:"name" json:"name"`
+	// Namespace of the resource. Defaults to the Kustomization namespace.
+	Namespace string `yaml:"namespace,omitempty" json:"namespace,omitempty"`
 }
 
 // SourceRef defines a reference to a Flux source

--- a/pkg/stack/v1alpha1/converters.go
+++ b/pkg/stack/v1alpha1/converters.go
@@ -192,6 +192,16 @@ func ConvertBundleToV1Alpha1(b *stack.Bundle) *BundleConfig {
 		}
 	}
 
+	// Convert health checks
+	for _, hc := range b.HealthChecks {
+		config.Spec.HealthChecks = append(config.Spec.HealthChecks, HealthCheckReference{
+			APIVersion: hc.APIVersion,
+			Kind:       hc.Kind,
+			Name:       hc.Name,
+			Namespace:  hc.Namespace,
+		})
+	}
+
 	// Convert dependencies
 	for _, dep := range b.DependsOn {
 		if dep != nil {
@@ -252,6 +262,16 @@ func ConvertV1Alpha1ToBundle(config *BundleConfig) *stack.Bundle {
 			Tag:       config.Spec.SourceRef.Tag,
 			Branch:    config.Spec.SourceRef.Branch,
 		}
+	}
+
+	// Convert health checks
+	for _, hc := range config.Spec.HealthChecks {
+		b.HealthChecks = append(b.HealthChecks, stack.HealthCheck{
+			APIVersion: hc.APIVersion,
+			Kind:       hc.Kind,
+			Name:       hc.Name,
+			Namespace:  hc.Namespace,
+		})
 	}
 
 	// Note: We don't convert dependencies and applications here as they would require


### PR DESCRIPTION
## Summary
- Add `HealthCheck` type and `HealthChecks` field to `Bundle`, enabling users to specify resources monitored for health during Flux Kustomization reconciliation
- Wire health checks through the FluxCD resource generator into `kust.Spec.HealthChecks`
- Add `HealthCheckReference` type and field to the v1alpha1 `BundleSpec` with full round-trip conversion support

## Test plan
- [x] `TestWorkflowBundleHealthChecks` — verifies 2 health checks map to Kustomization spec
- [x] `TestWorkflowBundleHealthChecksEmpty` — verifies empty HealthChecks produces no spec entries
- [x] `TestHealthChecksRoundTrip` — verifies v1alpha1 converter preserves all fields both directions
- [x] `make check` passes (lint, vet, tests)

Closes #237