### PR TITLE
docs: document Cluster getter/setter duality

### DIFF
--- a/pkg/stack/cluster.go
+++ b/pkg/stack/cluster.go
@@ -5,7 +5,40 @@ import (
 )
 
 // Cluster describes a cluster configuration.
-// A cluster configuration is a set of configurations that are packaged in one or more package units
+// A cluster configuration is a set of configurations that are packaged in one
+// or more package units.
+//
+// # Dual Access Pattern
+//
+// Cluster exposes its fields (Name, Node, GitOps) as exported struct fields
+// and also provides getter/setter methods (GetName/SetName, GetNode/SetNode,
+// GetGitOps/SetGitOps). The getters and setters are thin wrappers that do not
+// add validation; both access paths read and write the same underlying fields.
+//
+// This dual access pattern exists intentionally:
+//
+//   - Exported fields allow direct, concise access that is idiomatic in Go,
+//     particularly useful in tests, internal code, and YAML
+//     serialization/deserialization (struct tags operate on exported fields).
+//   - Getter/setter methods provide an encapsulated API surface for library
+//     consumers (e.g. Crane) who may prefer method-based access or who want
+//     to program against a future interface without depending on concrete
+//     field layout.
+//
+// # Guidance for New Code
+//
+// Within the kure codebase (tests, internal packages, CLI commands), prefer
+// direct field access for brevity:
+//
+//	c.Name = "prod"
+//	fmt.Println(c.Node)
+//
+// When writing code that consumes the stack package as an external library,
+// prefer the getter/setter methods so that any future validation or
+// indirection can be introduced without breaking callers:
+//
+//	c.SetName("prod")
+//	node := c.GetNode()
 type Cluster struct {
 	Name   string        `yaml:"name"`
 	Node   *Node         `yaml:"node,omitempty"`

--- a/pkg/stack/doc.go
+++ b/pkg/stack/doc.go
@@ -101,4 +101,24 @@
 //
 //	// Write to disk using layout package
 //	layout.WriteCluster(cluster, "./clusters/prod", manifests)
+//
+// # Dual Access Pattern (Exported Fields and Getter/Setter Methods)
+//
+// Several types in this package, notably [Cluster] and [Node], expose their
+// data both as exported struct fields and through getter/setter methods.
+// The methods are intentionally thin wrappers without additional validation,
+// meaning both access paths are functionally equivalent.
+//
+// This design serves two audiences:
+//
+//   - Internal and test code benefits from direct field access, which is
+//     concise and idiomatic in Go.
+//   - External library consumers (e.g. Crane) can use getter/setter methods
+//     to decouple from the concrete field layout, making it easier to
+//     introduce validation or indirection in a future version without
+//     breaking callers.
+//
+// When writing new code inside the kure repository, prefer direct field
+// access. When consuming the stack package as a library, prefer the
+// getter/setter methods. See the [Cluster] type documentation for details.
 package stack


### PR DESCRIPTION
## Summary
- Documented the dual access pattern on the Cluster type (exported fields + getter/setter methods)
- Explained rationale: exported fields for direct access in tests/internal code; getters/setters for library consumers
- Added guidance on which style to prefer in new code

Fixes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)