### PR TITLE
docs: add doc.go examples for CRD builder packages

### DIFF
--- a/internal/certmanager/example_test.go
+++ b/internal/certmanager/example_test.go
@@ -1,0 +1,65 @@
+package certmanager_test
+
+import (
+	"fmt"
+
+	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/go-kure/kure/internal/certmanager"
+)
+
+// This example demonstrates composing a ClusterIssuer with an ACME
+// configuration and a matching Certificate, which is a common pattern
+// for automated TLS in Kubernetes.
+func Example_composeClusterIssuerAndCertificate() {
+	// --- ClusterIssuer with ACME (Let's Encrypt) ---
+	privateKey := cmmeta.SecretKeySelector{
+		LocalObjectReference: cmmeta.LocalObjectReference{Name: "letsencrypt-account-key"},
+		Key:                  "tls.key",
+	}
+	acme := certmanager.CreateACMEIssuer(
+		"https://acme-v02.api.letsencrypt.org/directory",
+		"admin@example.com",
+		privateKey,
+	)
+
+	solver := certmanager.CreateACMEHTTP01Solver(corev1.ServiceTypeClusterIP, "nginx")
+	certmanager.AddACMEIssuerSolver(acme, solver)
+
+	issuer := certmanager.CreateClusterIssuer("letsencrypt-prod", certv1.IssuerSpec{})
+	_ = certmanager.SetClusterIssuerACME(issuer, acme)
+	_ = certmanager.AddClusterIssuerLabel(issuer, "env", "production")
+
+	// --- Certificate referencing the ClusterIssuer ---
+	cert := certmanager.CreateCertificate("app-tls", "default", certv1.CertificateSpec{
+		SecretName: "app-tls-secret",
+	})
+	_ = certmanager.SetCertificateIssuerRef(cert, cmmeta.ObjectReference{
+		Name:  issuer.Name,
+		Kind:  "ClusterIssuer",
+		Group: "cert-manager.io",
+	})
+	_ = certmanager.AddCertificateDNSName(cert, "app.example.com")
+	_ = certmanager.AddCertificateDNSName(cert, "www.example.com")
+	_ = certmanager.AddCertificateLabel(cert, "env", "production")
+
+	fmt.Println("Issuer:", issuer.Name)
+	fmt.Println("Issuer Kind:", issuer.Kind)
+	fmt.Println("ACME Server:", issuer.Spec.ACME.Server)
+	fmt.Println("Certificate:", cert.Name)
+	fmt.Println("Certificate Namespace:", cert.Namespace)
+	fmt.Println("Secret:", cert.Spec.SecretName)
+	fmt.Println("DNS Names:", cert.Spec.DNSNames)
+	fmt.Println("Issuer Ref:", cert.Spec.IssuerRef.Name)
+	// Output:
+	// Issuer: letsencrypt-prod
+	// Issuer Kind: ClusterIssuer
+	// ACME Server: https://acme-v02.api.letsencrypt.org/directory
+	// Certificate: app-tls
+	// Certificate Namespace: default
+	// Secret: app-tls-secret
+	// DNS Names: [app.example.com www.example.com]
+	// Issuer Ref: letsencrypt-prod
+}

--- a/internal/externalsecrets/example_test.go
+++ b/internal/externalsecrets/example_test.go
@@ -1,0 +1,56 @@
+package externalsecrets_test
+
+import (
+	"fmt"
+
+	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+
+	"github.com/go-kure/kure/internal/externalsecrets"
+)
+
+// This example demonstrates composing a SecretStore backed by AWS
+// Secrets Manager and an ExternalSecret that syncs credentials into
+// a Kubernetes Secret.
+func Example_composeSecretStoreAndExternalSecret() {
+	// --- SecretStore (AWS Secrets Manager) ---
+	store := externalsecrets.CreateSecretStore("aws-store", "default", esv1.SecretStoreSpec{})
+	externalsecrets.SetSecretStoreProvider(store, &esv1.SecretStoreProvider{
+		AWS: &esv1.AWSProvider{
+			Service: esv1.AWSServiceSecretsManager,
+			Region:  "eu-west-1",
+		},
+	})
+	externalsecrets.AddSecretStoreLabel(store, "env", "production")
+
+	// --- ExternalSecret referencing the store ---
+	es := externalsecrets.CreateExternalSecret("db-credentials", "default", esv1.ExternalSecretSpec{})
+	externalsecrets.SetExternalSecretSecretStoreRef(es, esv1.SecretStoreRef{
+		Name: store.Name,
+		Kind: "SecretStore",
+	})
+	externalsecrets.AddExternalSecretData(es, esv1.ExternalSecretData{
+		SecretKey: "username",
+		RemoteRef: esv1.ExternalSecretDataRemoteRef{Key: "prod/db/username"},
+	})
+	externalsecrets.AddExternalSecretData(es, esv1.ExternalSecretData{
+		SecretKey: "password",
+		RemoteRef: esv1.ExternalSecretDataRemoteRef{Key: "prod/db/password"},
+	})
+	externalsecrets.AddExternalSecretLabel(es, "app", "backend")
+
+	fmt.Println("Store:", store.Name)
+	fmt.Println("Store Kind:", store.Kind)
+	fmt.Println("Store Namespace:", store.Namespace)
+	fmt.Println("ExternalSecret:", es.Name)
+	fmt.Println("ExternalSecret Namespace:", es.Namespace)
+	fmt.Println("Store Ref:", es.Spec.SecretStoreRef.Name)
+	fmt.Println("Data Keys:", es.Spec.Data[0].SecretKey, es.Spec.Data[1].SecretKey)
+	// Output:
+	// Store: aws-store
+	// Store Kind: SecretStore
+	// Store Namespace: default
+	// ExternalSecret: db-credentials
+	// ExternalSecret Namespace: default
+	// Store Ref: aws-store
+	// Data Keys: username password
+}

--- a/internal/metallb/example_test.go
+++ b/internal/metallb/example_test.go
@@ -1,0 +1,60 @@
+package metallb_test
+
+import (
+	"fmt"
+
+	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
+
+	"github.com/go-kure/kure/internal/metallb"
+)
+
+// This example demonstrates composing a full MetalLB BGP setup:
+// an IPAddressPool with a public range, a BGPPeer for the upstream
+// router, and a BGPAdvertisement tying them together.
+func Example_composeBGPSetup() {
+	// --- IPAddressPool ---
+	pool := metallb.CreateIPAddressPool("public-pool", "metallb-system", metallbv1beta1.IPAddressPoolSpec{})
+	_ = metallb.AddIPAddressPoolAddress(pool, "203.0.113.0/24")
+	_ = metallb.SetIPAddressPoolAutoAssign(pool, true)
+
+	// --- BGPPeer ---
+	peer := metallb.CreateBGPPeer("upstream-router", "metallb-system", metallbv1beta1.BGPPeerSpec{
+		MyASN:   64512,
+		ASN:     64513,
+		Address: "10.0.0.1",
+	})
+	_ = metallb.SetBGPPeerPort(peer, 179)
+	_ = metallb.SetBGPPeerEBGPMultiHop(peer, true)
+	_ = metallb.SetBGPPeerBFDProfile(peer, "default-bfd")
+
+	// --- BGPAdvertisement linking the pool and the peer ---
+	advert := metallb.CreateBGPAdvertisement("public-advert", "metallb-system", metallbv1beta1.BGPAdvertisementSpec{})
+	_ = metallb.AddBGPAdvertisementIPAddressPool(advert, pool.Name)
+	_ = metallb.AddBGPAdvertisementPeer(advert, peer.Name)
+	_ = metallb.SetBGPAdvertisementLocalPref(advert, 100)
+	_ = metallb.AddBGPAdvertisementCommunity(advert, "65535:65281")
+
+	fmt.Println("Pool:", pool.Name)
+	fmt.Println("Pool Namespace:", pool.Namespace)
+	fmt.Println("Pool Addresses:", pool.Spec.Addresses)
+	fmt.Println("Peer:", peer.Name)
+	fmt.Println("Peer ASN:", peer.Spec.ASN)
+	fmt.Println("Peer Address:", peer.Spec.Address)
+	fmt.Println("Peer Port:", peer.Spec.Port)
+	fmt.Println("Advertisement:", advert.Name)
+	fmt.Println("Advertisement Pools:", advert.Spec.IPAddressPools)
+	fmt.Println("Advertisement Peers:", advert.Spec.Peers)
+	fmt.Println("Advertisement LocalPref:", advert.Spec.LocalPref)
+	// Output:
+	// Pool: public-pool
+	// Pool Namespace: metallb-system
+	// Pool Addresses: [203.0.113.0/24]
+	// Peer: upstream-router
+	// Peer ASN: 64513
+	// Peer Address: 10.0.0.1
+	// Peer Port: 179
+	// Advertisement: public-advert
+	// Advertisement Pools: [public-pool]
+	// Advertisement Peers: [upstream-router]
+	// Advertisement LocalPref: 100
+}


### PR DESCRIPTION
## Summary
- Added `example_test.go` to `internal/certmanager` with ClusterIssuer + Certificate composition example
- Added `example_test.go` to `internal/externalsecrets` with SecretStore + ExternalSecret composition example
- Added `example_test.go` to `internal/metallb` with BGP setup example (BGPPeer + BGPAdvertisement + IPAddressPool)
- All examples compile and pass `go test`

Fixes #294