### PR TITLE
fix: isolate TestEnsureConfigDir from host environment

### DIFF
--- a/pkg/cli/config_test.go
+++ b/pkg/cli/config_test.go
@@ -235,11 +235,10 @@ func TestGetConfigPath(t *testing.T) {
 }
 
 func TestEnsureConfigDir(t *testing.T) {
-	// This test is tricky because it affects the real home directory
-	// We'll just verify it doesn't error when the directory is accessible
+	t.Setenv("HOME", t.TempDir())
+	viper.Reset()
 	err := EnsureConfigDir()
-	// Only fail if it's not a permission error (which is expected in some test environments)
-	if err != nil && !os.IsPermission(err) {
+	if err != nil {
 		t.Errorf("EnsureConfigDir failed: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Use `t.TempDir()` for `HOME` and `viper.Reset()` to prevent `TestEnsureConfigDir` failures in read-only container environments (EROFS) and from stale viper state leaked by `TestGetConfigPath`
- The prior test guarded only against `os.IsPermission(err)`, missing `EROFS` errors from `readOnlyRootFilesystem: true` containers
- `viper.Reset()` is needed because `TestGetConfigPath` sets `viper.SetConfigFile("/test/config.yaml")` and the global state leaks to subsequent tests

## Test plan
- [x] `go test -v -run TestEnsureConfigDir ./pkg/cli/` passes
- [x] `go test -v ./pkg/cli/` full suite passes (28/28)
- [ ] CI passes on `ubuntu-latest`