### PR TITLE
fix(ci): disable setup-go built-in cache to prevent double-caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
       with:
         go-version: ${{ steps.go-version.outputs.version }}
         check-latest: true
+        cache: false
 
     - name: Cache Go modules
       uses: actions/cache@v5
@@ -171,6 +172,7 @@ jobs:
       with:
         go-version: ${{ steps.go-version.outputs.version }}
         check-latest: true
+        cache: false
 
     - name: Cache Go modules
       uses: actions/cache@v5
@@ -239,6 +241,7 @@ jobs:
       with:
         go-version: ${{ steps.go-version.outputs.version }}
         check-latest: true
+        cache: false
 
     - name: Install govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -302,6 +305,7 @@ jobs:
       with:
         go-version: ${{ steps.go-version.outputs.version }}
         check-latest: true
+        cache: false
 
     - name: Download coverage artifact
       uses: actions/download-artifact@v8
@@ -379,6 +383,7 @@ jobs:
       with:
         go-version: ${{ steps.go-version.outputs.version }}
         check-latest: true
+        cache: false
 
     - name: Cache Go modules
       uses: actions/cache@v5
@@ -462,6 +467,7 @@ jobs:
       with:
         go-version: ${{ steps.go-version.outputs.version }}
         check-latest: true
+        cache: false
 
     - name: Cache Go modules
       uses: actions/cache@v5
@@ -536,6 +542,7 @@ jobs:
       with:
         go-version: ${{ steps.go-version.outputs.version }}
         check-latest: true
+        cache: false
 
     - name: Install Hugo CLI
       run: |

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -438,11 +438,19 @@ env:
 
 ### Caching
 
-Most workflows use Go module caching:
+The `actions/setup-go@v6` action has built-in caching enabled by default, but CI
+jobs disable it (`cache: false`) to avoid double-caching with the explicit
+`actions/cache@v5` steps that follow. Each job uses tuned cache keys and paths:
 
 ```yaml
+- name: Set up Go
+  uses: actions/setup-go@v6
+  with:
+    go-version: ${{ steps.go-version.outputs.version }}
+    cache: false          # explicit actions/cache step below
+
 - name: Cache Go modules
-  uses: actions/cache@v4
+  uses: actions/cache@v5
   with:
     path: |
       ~/.cache/go-build


### PR DESCRIPTION
## Summary

- Add `cache: false` to all 7 `actions/setup-go@v6` blocks in `ci.yml`
- Update `docs/github-workflows.md` caching section to document the pattern and fix `actions/cache` version reference (v4 → v5)

## Problem

`actions/setup-go@v6` defaults to `cache: true`, which saves/restores `~/go/pkg/mod`. The explicit `actions/cache@v5` steps also target the same path. This double-caching causes:
- tar "Cannot open: File exists" errors during cache restore
- Jobs hanging on "Post Cache Go modules" during cache upload

## Test plan

- [ ] Verify `grep -c 'cache: false' .github/workflows/ci.yml` returns 7
- [ ] Verify explicit `actions/cache@v5` steps are unchanged (5 total)
- [ ] CI passes without "File exists" errors or hanging post-steps
- [ ] `release.yml` and `deploy-docs.yml` are unaffected (no double-cache there)