### PR TITLE
fix: resolve broken dependency-updates link on contributing guide page

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -269,7 +269,7 @@ When an update requires a blocked dependency (e.g., newer Go version):
 
 Reference: [GitHub Docs - Dependabot PR Commands](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-pull-request-comment-commands)
 
-For the full dependency update process (review, bundling, version tracking), see [docs/dependency-updates.md](docs/dependency-updates.md).
+For the full dependency update process (review, bundling, version tracking), see [Dependency Updates](/contributing/dependency-updates/).
 
 ## Makefile Targets Reference
 


### PR DESCRIPTION
## Summary

- Fixes broken link on [contributing guide page](https://www.gokure.dev/dev/contributing/guide/) pointing to `docs/dependency-updates/` (404)
- The relative link `docs/dependency-updates.md` in `DEVELOPMENT.md` resolved incorrectly when mounted as `contributing/guide.md` on the docs site
- Replaced with absolute site path `/contributing/dependency-updates/` which the render-link template correctly resolves via `relURL`

## Test plan

- [ ] Verify the link on `https://www.gokure.dev/dev/contributing/guide/` navigates to the dependency updates page
- [ ] Confirm CI checks pass (lint, test, build, rebase-check)