### PR TITLE
feat: add PSAViolationError with field paths

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -146,6 +146,7 @@ const (
 	ErrorTypeFile          ErrorType = "file"
 	ErrorTypeConfiguration ErrorType = "configuration"
 	ErrorTypeInternal      ErrorType = "internal"
+	ErrorTypePSA           ErrorType = "psa"
 )
 
 // KureError is the base interface for all Kure-specific errors
@@ -468,6 +469,29 @@ func NewConfigError(source, field, value, reason string, validValues []string) *
 		Source:      source,
 		Field:       field,
 		ValidValues: validValues,
+	}
+}
+
+// PSAViolationError represents a Pod Security Standards violation with field path information.
+type PSAViolationError struct {
+	*BaseError
+	Field string `json:"field"` // path relative to PodSpec
+	Level string `json:"level"` // "baseline" or "restricted"
+}
+
+func NewPSAViolationError(field, level, message string) *PSAViolationError {
+	return &PSAViolationError{
+		BaseError: &BaseError{
+			ErrType: ErrorTypePSA,
+			Message: message,
+			Help:    fmt.Sprintf("ensure PodSpec complies with the %s Pod Security Standards level", level),
+			ErrContext: map[string]any{
+				"field": field,
+				"level": level,
+			},
+		},
+		Field: field,
+		Level: level,
 	}
 }
 

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -280,6 +280,60 @@ func TestConfigError(t *testing.T) {
 	}
 }
 
+func TestPSAViolationError(t *testing.T) {
+	err := kerrors.NewPSAViolationError(
+		"containers[0].securityContext.allowPrivilegeEscalation",
+		"restricted",
+		"container \"app\": allowPrivilegeEscalation must be false at restricted level",
+	)
+
+	// Test type
+	if err.Type() != kerrors.ErrorTypePSA {
+		t.Errorf("Expected PSA error type, got %v", err.Type())
+	}
+
+	// Test message
+	if !strings.Contains(err.Error(), "allowPrivilegeEscalation") {
+		t.Errorf("Expected message to contain allowPrivilegeEscalation, got %q", err.Error())
+	}
+
+	// Test Field and Level
+	if err.Field != "containers[0].securityContext.allowPrivilegeEscalation" {
+		t.Errorf("Expected Field, got %q", err.Field)
+	}
+	if err.Level != "restricted" {
+		t.Errorf("Expected Level restricted, got %q", err.Level)
+	}
+
+	// Test suggestion
+	suggestion := err.Suggestion()
+	if !strings.Contains(suggestion, "restricted") {
+		t.Errorf("Expected suggestion to mention restricted, got %q", suggestion)
+	}
+
+	// Test context
+	ctx := err.Context()
+	if ctx["field"] != "containers[0].securityContext.allowPrivilegeEscalation" {
+		t.Errorf("Expected field in context, got %v", ctx["field"])
+	}
+	if ctx["level"] != "restricted" {
+		t.Errorf("Expected level in context, got %v", ctx["level"])
+	}
+
+	// Test KureError interface
+	if !kerrors.IsKureError(err) {
+		t.Error("Expected error to be identified as KureError")
+	}
+
+	// Test IsType
+	if !kerrors.IsType(err, kerrors.ErrorTypePSA) {
+		t.Error("Expected error to match PSA type")
+	}
+	if kerrors.IsType(err, kerrors.ErrorTypeValidation) {
+		t.Error("Expected error to NOT match validation type")
+	}
+}
+
 func TestErrorTypeChecking(t *testing.T) {
 	validationErr := kerrors.NewValidationError("field", "value", "component", nil)
 	resourceErr := kerrors.ResourceNotFoundError("Pod", "missing", "", nil)

--- a/pkg/kubernetes/psa.go
+++ b/pkg/kubernetes/psa.go
@@ -1,6 +1,8 @@
 package kubernetes
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/go-kure/kure/pkg/errors"
@@ -120,8 +122,9 @@ func SecurityContextForLevel(level PSALevel) (*corev1.SecurityContext, error) {
 }
 
 // ValidateContainerPSA checks whether a container's SecurityContext is
-// compliant with the given PSA level. Returns nil when compliant, or an error
-// describing the first violation found.
+// compliant with the given PSA level. Returns nil when compliant, or a
+// *errors.PSAViolationError describing the first violation found.
+// Field paths are relative to the container (no container prefix).
 func ValidateContainerPSA(container *corev1.Container, level PSALevel) error {
 	if container == nil {
 		return errors.ErrNilContainer
@@ -131,9 +134,9 @@ func ValidateContainerPSA(container *corev1.Container, level PSALevel) error {
 	case PSAPrivileged:
 		return nil
 	case PSABaseline:
-		return validateContainerBaseline(container)
+		return validateContainerBaseline(container, "", string(level))
 	case PSARestricted:
-		return validateContainerRestricted(container)
+		return validateContainerRestricted(container, "", string(level))
 	default:
 		return errors.NewValidationError("level", string(level), "PSA", []string{
 			string(PSARestricted), string(PSABaseline), string(PSAPrivileged),
@@ -143,7 +146,9 @@ func ValidateContainerPSA(container *corev1.Container, level PSALevel) error {
 
 // ValidatePodSpecPSA checks whether a PodSpec is compliant with the given PSA
 // level. It validates both the pod-level security context and all containers
-// (including init and ephemeral containers).
+// (including init and ephemeral containers). Returns nil when compliant, or a
+// *errors.PSAViolationError describing the first violation found.
+// Field paths are relative to the PodSpec.
 func ValidatePodSpecPSA(spec *corev1.PodSpec, level PSALevel) error {
 	if spec == nil {
 		return errors.ErrNilPodSpec
@@ -153,36 +158,45 @@ func ValidatePodSpecPSA(spec *corev1.PodSpec, level PSALevel) error {
 	case PSAPrivileged:
 		return nil
 	case PSABaseline:
-		if err := validatePodSpecBaseline(spec); err != nil {
-			return err
-		}
+		return validatePodSpecBaseline(spec, string(level))
 	case PSARestricted:
-		if err := validatePodSpecRestricted(spec); err != nil {
-			return err
-		}
+		return validatePodSpecRestricted(spec, string(level))
 	default:
 		return errors.NewValidationError("level", string(level), "PSA", []string{
 			string(PSARestricted), string(PSABaseline), string(PSAPrivileged),
 		})
 	}
-
-	return nil
 }
 
-func validateContainerBaseline(c *corev1.Container) error {
+func psaField(prefix, suffix string) string {
+	if prefix == "" {
+		return suffix
+	}
+	return prefix + "." + suffix
+}
+
+func validateContainerBaseline(c *corev1.Container, fieldPrefix, level string) error {
 	sc := c.SecurityContext
 	if sc == nil {
 		return nil
 	}
 
 	if sc.Privileged != nil && *sc.Privileged {
-		return errors.Errorf("container %q: privileged mode is not allowed at baseline level", c.Name)
+		return errors.NewPSAViolationError(
+			psaField(fieldPrefix, "securityContext.privileged"),
+			level,
+			fmt.Sprintf("container %q: privileged mode is not allowed at %s level", c.Name, level),
+		)
 	}
 
 	if sc.Capabilities != nil {
 		for _, cap := range sc.Capabilities.Add {
 			if !isBaselineAllowedCapability(cap) {
-				return errors.Errorf("container %q: capability %q is not allowed at baseline level", c.Name, cap)
+				return errors.NewPSAViolationError(
+					psaField(fieldPrefix, "securityContext.capabilities.add"),
+					level,
+					fmt.Sprintf("container %q: capability %q is not allowed at %s level", c.Name, cap, level),
+				)
 			}
 		}
 	}
@@ -190,61 +204,81 @@ func validateContainerBaseline(c *corev1.Container) error {
 	return nil
 }
 
-func validateContainerRestricted(c *corev1.Container) error {
-	if err := validateContainerBaseline(c); err != nil {
+func validateContainerRestricted(c *corev1.Container, fieldPrefix, level string) error {
+	if err := validateContainerBaseline(c, fieldPrefix, level); err != nil {
 		return err
 	}
 
 	sc := c.SecurityContext
 	if sc == nil {
-		return errors.Errorf("container %q: security context must be set at restricted level", c.Name)
+		return errors.NewPSAViolationError(
+			psaField(fieldPrefix, "securityContext"),
+			level,
+			fmt.Sprintf("container %q: security context must be set at %s level", c.Name, level),
+		)
 	}
 
 	if sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation {
-		return errors.Errorf("container %q: allowPrivilegeEscalation must be false at restricted level", c.Name)
+		return errors.NewPSAViolationError(
+			psaField(fieldPrefix, "securityContext.allowPrivilegeEscalation"),
+			level,
+			fmt.Sprintf("container %q: allowPrivilegeEscalation must be false at %s level", c.Name, level),
+		)
 	}
 
 	if sc.RunAsNonRoot == nil || !*sc.RunAsNonRoot {
-		return errors.Errorf("container %q: runAsNonRoot must be true at restricted level", c.Name)
+		return errors.NewPSAViolationError(
+			psaField(fieldPrefix, "securityContext.runAsNonRoot"),
+			level,
+			fmt.Sprintf("container %q: runAsNonRoot must be true at %s level", c.Name, level),
+		)
 	}
 
 	if sc.Capabilities == nil || !hasDropAll(sc.Capabilities.Drop) {
-		return errors.Errorf("container %q: must drop ALL capabilities at restricted level", c.Name)
+		return errors.NewPSAViolationError(
+			psaField(fieldPrefix, "securityContext.capabilities"),
+			level,
+			fmt.Sprintf("container %q: must drop ALL capabilities at %s level", c.Name, level),
+		)
 	}
 
 	if sc.SeccompProfile == nil ||
 		(sc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault &&
 			sc.SeccompProfile.Type != corev1.SeccompProfileTypeLocalhost) {
-		return errors.Errorf("container %q: seccompProfile must be RuntimeDefault or Localhost at restricted level", c.Name)
+		return errors.NewPSAViolationError(
+			psaField(fieldPrefix, "securityContext.seccompProfile"),
+			level,
+			fmt.Sprintf("container %q: seccompProfile must be RuntimeDefault or Localhost at %s level", c.Name, level),
+		)
 	}
 
 	return nil
 }
 
-func validatePodSpecBaseline(spec *corev1.PodSpec) error {
+func validatePodSpecBaseline(spec *corev1.PodSpec, level string) error {
 	if spec.HostNetwork {
-		return errors.New("hostNetwork is not allowed at baseline level")
+		return errors.NewPSAViolationError("hostNetwork", level, fmt.Sprintf("hostNetwork is not allowed at %s level", level))
 	}
 	if spec.HostPID {
-		return errors.New("hostPID is not allowed at baseline level")
+		return errors.NewPSAViolationError("hostPID", level, fmt.Sprintf("hostPID is not allowed at %s level", level))
 	}
 	if spec.HostIPC {
-		return errors.New("hostIPC is not allowed at baseline level")
+		return errors.NewPSAViolationError("hostIPC", level, fmt.Sprintf("hostIPC is not allowed at %s level", level))
 	}
 
 	for i := range spec.Containers {
-		if err := validateContainerBaseline(&spec.Containers[i]); err != nil {
+		if err := validateContainerBaseline(&spec.Containers[i], fmt.Sprintf("containers[%d]", i), level); err != nil {
 			return err
 		}
 	}
 	for i := range spec.InitContainers {
-		if err := validateContainerBaseline(&spec.InitContainers[i]); err != nil {
+		if err := validateContainerBaseline(&spec.InitContainers[i], fmt.Sprintf("initContainers[%d]", i), level); err != nil {
 			return err
 		}
 	}
 	for i := range spec.EphemeralContainers {
 		c := containerFromEphemeral(&spec.EphemeralContainers[i])
-		if err := validateContainerBaseline(&c); err != nil {
+		if err := validateContainerBaseline(&c, fmt.Sprintf("ephemeralContainers[%d]", i), level); err != nil {
 			return err
 		}
 	}
@@ -252,35 +286,43 @@ func validatePodSpecBaseline(spec *corev1.PodSpec) error {
 	return nil
 }
 
-func validatePodSpecRestricted(spec *corev1.PodSpec) error {
-	if err := validatePodSpecBaseline(spec); err != nil {
+func validatePodSpecRestricted(spec *corev1.PodSpec, level string) error {
+	if err := validatePodSpecBaseline(spec, level); err != nil {
 		return err
 	}
 
 	sc := spec.SecurityContext
 	if sc == nil || sc.RunAsNonRoot == nil || !*sc.RunAsNonRoot {
-		return errors.New("pod runAsNonRoot must be true at restricted level")
+		return errors.NewPSAViolationError(
+			"securityContext.runAsNonRoot",
+			level,
+			fmt.Sprintf("pod runAsNonRoot must be true at %s level", level),
+		)
 	}
 
 	if sc.SeccompProfile == nil ||
 		(sc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault &&
 			sc.SeccompProfile.Type != corev1.SeccompProfileTypeLocalhost) {
-		return errors.New("pod seccompProfile must be RuntimeDefault or Localhost at restricted level")
+		return errors.NewPSAViolationError(
+			"securityContext.seccompProfile",
+			level,
+			fmt.Sprintf("pod seccompProfile must be RuntimeDefault or Localhost at %s level", level),
+		)
 	}
 
 	for i := range spec.Containers {
-		if err := validateContainerRestricted(&spec.Containers[i]); err != nil {
+		if err := validateContainerRestricted(&spec.Containers[i], fmt.Sprintf("containers[%d]", i), level); err != nil {
 			return err
 		}
 	}
 	for i := range spec.InitContainers {
-		if err := validateContainerRestricted(&spec.InitContainers[i]); err != nil {
+		if err := validateContainerRestricted(&spec.InitContainers[i], fmt.Sprintf("initContainers[%d]", i), level); err != nil {
 			return err
 		}
 	}
 	for i := range spec.EphemeralContainers {
 		c := containerFromEphemeral(&spec.EphemeralContainers[i])
-		if err := validateContainerRestricted(&c); err != nil {
+		if err := validateContainerRestricted(&c, fmt.Sprintf("ephemeralContainers[%d]", i), level); err != nil {
 			return err
 		}
 	}

--- a/pkg/kubernetes/psa_test.go
+++ b/pkg/kubernetes/psa_test.go
@@ -1,9 +1,12 @@
 package kubernetes
 
 import (
+	"errors"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+
+	kerrors "github.com/go-kure/kure/pkg/errors"
 )
 
 func TestRestrictedPodSecurityContext(t *testing.T) {
@@ -141,6 +144,7 @@ func TestValidateContainerPSA(t *testing.T) {
 		container *corev1.Container
 		level     PSALevel
 		wantErr   bool
+		wantField string // expected PSAViolationError.Field (empty = no check)
 	}{
 		{
 			name:      "nil container",
@@ -162,8 +166,9 @@ func TestValidateContainerPSA(t *testing.T) {
 			container: &corev1.Container{
 				Name: "test",
 			},
-			level:   PSARestricted,
-			wantErr: true,
+			level:     PSARestricted,
+			wantErr:   true,
+			wantField: "securityContext",
 		},
 		{
 			name: "restricted with privilege escalation",
@@ -176,8 +181,9 @@ func TestValidateContainerPSA(t *testing.T) {
 					SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 				},
 			},
-			level:   PSARestricted,
-			wantErr: true,
+			level:     PSARestricted,
+			wantErr:   true,
+			wantField: "securityContext.allowPrivilegeEscalation",
 		},
 		{
 			name: "restricted missing drop ALL",
@@ -189,8 +195,9 @@ func TestValidateContainerPSA(t *testing.T) {
 					SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 				},
 			},
-			level:   PSARestricted,
-			wantErr: true,
+			level:     PSARestricted,
+			wantErr:   true,
+			wantField: "securityContext.capabilities",
 		},
 		{
 			name: "baseline compliant container",
@@ -211,8 +218,9 @@ func TestValidateContainerPSA(t *testing.T) {
 					Privileged: boolPtr(true),
 				},
 			},
-			level:   PSABaseline,
-			wantErr: true,
+			level:     PSABaseline,
+			wantErr:   true,
+			wantField: "securityContext.privileged",
 		},
 		{
 			name: "baseline with disallowed capability",
@@ -224,8 +232,9 @@ func TestValidateContainerPSA(t *testing.T) {
 					},
 				},
 			},
-			level:   PSABaseline,
-			wantErr: true,
+			level:     PSABaseline,
+			wantErr:   true,
+			wantField: "securityContext.capabilities.add",
 		},
 		{
 			name: "baseline with allowed capability",
@@ -270,6 +279,15 @@ func TestValidateContainerPSA(t *testing.T) {
 			if !tt.wantErr && err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
+			if tt.wantField != "" {
+				var psaErr *kerrors.PSAViolationError
+				if !errors.As(err, &psaErr) {
+					t.Fatalf("expected *PSAViolationError, got %T", err)
+				}
+				if psaErr.Field != tt.wantField {
+					t.Errorf("Field = %q, want %q", psaErr.Field, tt.wantField)
+				}
+			}
 		})
 	}
 }
@@ -281,10 +299,11 @@ func TestValidatePodSpecPSA(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		spec    *corev1.PodSpec
-		level   PSALevel
-		wantErr bool
+		name      string
+		spec      *corev1.PodSpec
+		level     PSALevel
+		wantErr   bool
+		wantField string // expected PSAViolationError.Field (empty = no check)
 	}{
 		{
 			name:    "nil spec",
@@ -309,32 +328,36 @@ func TestValidatePodSpecPSA(t *testing.T) {
 				},
 				Containers: []corev1.Container{restrictedContainer},
 			},
-			level:   PSARestricted,
-			wantErr: true,
+			level:     PSARestricted,
+			wantErr:   true,
+			wantField: "securityContext.runAsNonRoot",
 		},
 		{
 			name: "baseline with hostNetwork",
 			spec: &corev1.PodSpec{
 				HostNetwork: true,
 			},
-			level:   PSABaseline,
-			wantErr: true,
+			level:     PSABaseline,
+			wantErr:   true,
+			wantField: "hostNetwork",
 		},
 		{
 			name: "baseline with hostPID",
 			spec: &corev1.PodSpec{
 				HostPID: true,
 			},
-			level:   PSABaseline,
-			wantErr: true,
+			level:     PSABaseline,
+			wantErr:   true,
+			wantField: "hostPID",
 		},
 		{
 			name: "baseline with hostIPC",
 			spec: &corev1.PodSpec{
 				HostIPC: true,
 			},
-			level:   PSABaseline,
-			wantErr: true,
+			level:     PSABaseline,
+			wantErr:   true,
+			wantField: "hostIPC",
 		},
 		{
 			name: "privileged allows anything",
@@ -362,8 +385,9 @@ func TestValidatePodSpecPSA(t *testing.T) {
 					}},
 				},
 			},
-			level:   PSARestricted,
-			wantErr: true,
+			level:     PSARestricted,
+			wantErr:   true,
+			wantField: "initContainers[0].securityContext.allowPrivilegeEscalation",
 		},
 		{
 			name: "baseline with non-compliant ephemeral container",
@@ -377,8 +401,9 @@ func TestValidatePodSpecPSA(t *testing.T) {
 					}},
 				},
 			},
-			level:   PSABaseline,
-			wantErr: true,
+			level:     PSABaseline,
+			wantErr:   true,
+			wantField: "ephemeralContainers[0].securityContext.privileged",
 		},
 		{
 			name: "restricted with non-compliant ephemeral container",
@@ -394,8 +419,22 @@ func TestValidatePodSpecPSA(t *testing.T) {
 					}},
 				},
 			},
-			level:   PSARestricted,
-			wantErr: true,
+			level:     PSARestricted,
+			wantErr:   true,
+			wantField: "ephemeralContainers[0].securityContext.allowPrivilegeEscalation",
+		},
+		{
+			name: "second container fails produces correct index",
+			spec: &corev1.PodSpec{
+				SecurityContext: RestrictedPodSecurityContext(),
+				Containers: []corev1.Container{
+					restrictedContainer,
+					{Name: "sidecar"},
+				},
+			},
+			level:     PSARestricted,
+			wantErr:   true,
+			wantField: "containers[1].securityContext",
 		},
 	}
 
@@ -407,6 +446,15 @@ func TestValidatePodSpecPSA(t *testing.T) {
 			}
 			if !tt.wantErr && err != nil {
 				t.Errorf("unexpected error: %v", err)
+			}
+			if tt.wantField != "" {
+				var psaErr *kerrors.PSAViolationError
+				if !errors.As(err, &psaErr) {
+					t.Fatalf("expected *PSAViolationError, got %T", err)
+				}
+				if psaErr.Field != tt.wantField {
+					t.Errorf("Field = %q, want %q", psaErr.Field, tt.wantField)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Add `ErrorTypePSA` and `PSAViolationError` type to `pkg/errors` carrying the violating field path (e.g. `containers[app].securityContext.privileged`)
- All PSA validate functions in `pkg/kubernetes/psa` now return `*PSAViolationError` with populated `Field`
- Enables downstream consumers (crane) to extract precise field locations for richer diagnostics

## Test plan

- [x] `TestPSAViolationError` in `pkg/errors/errors_test.go`
- [x] All `pkg/kubernetes/psa_test.go` cases assert `PSAViolationError.Field`
- [x] `mise run verify` passes (tidy, lint, test)