### PR TITLE
test: move gotk network tests to integration build tag

### DIFF
--- a/pkg/stack/fluxcd/bootstrap_generator_integration_test.go
+++ b/pkg/stack/fluxcd/bootstrap_generator_integration_test.go
@@ -1,0 +1,44 @@
+//go:build integration
+
+package fluxcd_test
+
+import (
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+	fluxstack "github.com/go-kure/kure/pkg/stack/fluxcd"
+)
+
+func TestGenerateGotkBootstrap(t *testing.T) {
+	bg := fluxstack.NewBootstrapGenerator()
+
+	config := &stack.BootstrapConfig{
+		Enabled:  true,
+		FluxMode: "gotk",
+	}
+
+	rootNode := &stack.Node{Name: "test-cluster"}
+
+	// gotk mode downloads manifests from GitHub — requires network access
+	_, _ = bg.GenerateBootstrap(config, rootNode)
+}
+
+func TestGenerateGotkBootstrapWithOptions(t *testing.T) {
+	bg := fluxstack.NewBootstrapGenerator()
+
+	config := &stack.BootstrapConfig{
+		Enabled:         true,
+		FluxMode:        "gotk",
+		FluxVersion:     "v2.0.0",
+		Registry:        "ghcr.io/fluxcd",
+		ImagePullSecret: "my-secret",
+		Components:      []string{"source-controller", "kustomize-controller"},
+		SourceURL:       "oci://registry.example.com/flux-system",
+		SourceRef:       "latest",
+	}
+
+	rootNode := &stack.Node{Name: "test-cluster"}
+
+	// gotk mode downloads manifests from GitHub — requires network access
+	_, _ = bg.GenerateBootstrap(config, rootNode)
+}

--- a/pkg/stack/fluxcd/bootstrap_generator_test.go
+++ b/pkg/stack/fluxcd/bootstrap_generator_test.go
@@ -156,23 +156,6 @@ func TestGenerateFluxOperatorBootstrapNoSourceURL(t *testing.T) {
 	}
 }
 
-func TestGenerateGotkBootstrap(t *testing.T) {
-	bg := fluxstack.NewBootstrapGenerator()
-
-	config := &stack.BootstrapConfig{
-		Enabled:  true,
-		FluxMode: "gotk",
-		// Note: gotk mode generates real Flux components which may fail
-		// in a test environment without proper setup
-	}
-
-	rootNode := &stack.Node{Name: "test-cluster"}
-
-	// gotk mode may fail due to network or version requirements
-	// we just test that it doesn't panic
-	_, _ = bg.GenerateBootstrap(config, rootNode)
-}
-
 func TestGenerateBootstrapDefaultMode(t *testing.T) {
 	bg := fluxstack.NewBootstrapGenerator()
 
@@ -201,27 +184,6 @@ func TestGenerateBootstrapDefaultMode(t *testing.T) {
 		t.Errorf("expected FluxInstance for default mode, got %s",
 			resources[0].GetObjectKind().GroupVersionKind().Kind)
 	}
-}
-
-func TestGenerateGotkBootstrapWithOptions(t *testing.T) {
-	bg := fluxstack.NewBootstrapGenerator()
-
-	config := &stack.BootstrapConfig{
-		Enabled:         true,
-		FluxMode:        "gotk",
-		FluxVersion:     "v2.0.0",
-		Registry:        "ghcr.io/fluxcd",
-		ImagePullSecret: "my-secret",
-		Components:      []string{"source-controller", "kustomize-controller"},
-		SourceURL:       "oci://registry.example.com/flux-system",
-		SourceRef:       "latest",
-	}
-
-	rootNode := &stack.Node{Name: "test-cluster"}
-
-	// gotk mode attempts to generate real manifests
-	// It may fail in tests without network access
-	_, _ = bg.GenerateBootstrap(config, rootNode)
 }
 
 func TestFluxOperatorSourceKindGitRepository(t *testing.T) {

--- a/pkg/stack/workflow_test.go
+++ b/pkg/stack/workflow_test.go
@@ -80,7 +80,7 @@ func TestWorkflowInterface(t *testing.T) {
 					Type: provider,
 					Bootstrap: &stack.BootstrapConfig{
 						Enabled:  true,
-						FluxMode: "gotk",
+						FluxMode: "flux-operator",
 					},
 				},
 			}


### PR DESCRIPTION
## Summary

- `TestGenerateGotkBootstrap` and `TestGenerateGotkBootstrapWithOptions` moved to a new `bootstrap_generator_integration_test.go` file with `//go:build integration` — these tests download `manifests.tar.gz` from GitHub at runtime and should not run in the unit test suite
- `TestWorkflowInterface` updated to use `FluxMode: "flux-operator"` instead of `"gotk"` — the test is validating the interface contract, not the specific bootstrap mode; `flux-operator` generates resources locally without any network calls

## Background

CI run go-kure/kure#24066364618 (scheduled, 2026-04-07) failed because GitHub was temporarily unreachable from the runner. The gotk tests either failed fast (connection refused → `t.Errorf`) or hung long enough to exhaust the 30s `-timeout` shared across the package, triggering a panic. All previous scheduled runs passed because GitHub is normally reachable.

## Test plan

- [ ] `mise run test` passes without network access
- [ ] `go test -tags=integration ./pkg/stack/fluxcd/...` runs the gotk tests when network is available