### PR TITLE
feat: Bundle.Children umbrella Kustomization pattern (#423)

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -174,7 +174,9 @@ func runAppWorkloads() error {
 	})
 }
 
-// runClusters processes all cluster configs from examples/demo/clusters/
+// runClusters processes all cluster configs from examples/demo/clusters/.
+// Per-cluster failures are logged but do not abort the walk, so one broken
+// example does not hide the output of the others.
 func runClusters() error {
 	clustersDir := "examples/demo/clusters"
 
@@ -184,7 +186,10 @@ func runClusters() error {
 		}
 
 		fmt.Printf("Processing cluster: %s\n", path)
-		return runClusterExample(path)
+		if err := runClusterExample(path); err != nil {
+			log.Printf("cluster %s failed: %v", path, err)
+		}
+		return nil
 	})
 }
 
@@ -205,27 +210,38 @@ func runClusterExample(clusterFile string) error {
 		return nil
 	}
 
-	// Create bundles and load app configs
-	rootBundle, err := stack.NewBundle(cl.Node.Name, nil, nil)
-	if err != nil {
-		return err
-	}
-	cl.Node.Bundle = rootBundle
-
 	// Determine base directory for loading app configs
 	baseDir := filepath.Dir(clusterFile)
-	for _, child := range cl.Node.Children {
-		child.SetParent(cl.Node)
-		childBundle, err := stack.NewBundle(child.Name, nil, nil)
+
+	// Umbrella path: when the cluster YAML provides a Bundle with Children,
+	// respect it as-is and load each child's workloads from <baseDir>/<childName>/.
+	// The umbrella itself holds no Applications — its job is to aggregate
+	// child readiness via spec.wait + spec.healthChecks.
+	if cl.Node.Bundle != nil && len(cl.Node.Bundle.Children) > 0 {
+		if err := loadUmbrellaChildrenApps(cl.Node.Bundle, baseDir); err != nil {
+			return err
+		}
+	} else {
+		// Create bundles and load app configs
+		rootBundle, err := stack.NewBundle(cl.Node.Name, nil, nil)
 		if err != nil {
 			return err
 		}
-		child.Bundle = childBundle
-		childBundle.SetParent(rootBundle)
+		cl.Node.Bundle = rootBundle
 
-		// Load app configs from child directory
-		if err := loadNodeApps(child, baseDir); err != nil {
-			return err
+		for _, child := range cl.Node.Children {
+			child.SetParent(cl.Node)
+			childBundle, err := stack.NewBundle(child.Name, nil, nil)
+			if err != nil {
+				return err
+			}
+			child.Bundle = childBundle
+			childBundle.SetParent(rootBundle)
+
+			// Load app configs from child directory
+			if err := loadNodeApps(child, baseDir); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -320,6 +336,66 @@ func loadNodeApps(node *stack.Node, baseDir string) error {
 	}
 
 	return nil
+}
+
+// loadUmbrellaChildrenApps attaches each umbrella child's workloads by reading
+// AppWorkload YAML files from baseDir/<child.Name>/ into child.Applications.
+// The parent pointer on each child is set so the flux engine can derive paths
+// relative to the umbrella.
+func loadUmbrellaChildrenApps(umbrella *stack.Bundle, baseDir string) error {
+	for _, child := range umbrella.Children {
+		if child == nil {
+			continue
+		}
+		child.SetParent(umbrella)
+		apps, err := loadApplicationsFromDir(filepath.Join(baseDir, child.Name))
+		if err != nil {
+			return err
+		}
+		child.Applications = apps
+	}
+	return nil
+}
+
+// loadApplicationsFromDir decodes each .yaml file in dir as one or more
+// stack.ApplicationWrapper documents and returns the corresponding Applications.
+func loadApplicationsFromDir(dir string) ([]*stack.Application, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var apps []*stack.Application
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		ext := filepath.Ext(entry.Name())
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+
+		fp := filepath.Join(dir, entry.Name())
+		f, err := os.Open(filepath.Clean(fp)) //nolint:gosec // G703: CLI tool reads user-specified file paths
+		if err != nil {
+			return nil, err
+		}
+
+		dec := yaml.NewDecoder(f)
+		for {
+			var wrapper stack.ApplicationWrapper
+			if err := dec.Decode(&wrapper); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				_ = f.Close()
+				return nil, err
+			}
+			apps = append(apps, wrapper.ToApplication())
+		}
+		_ = f.Close()
+	}
+	return apps, nil
 }
 
 // runMultiOCIDemo processes multi-OCI configurations from examples/demo/multi-oci/

--- a/examples/demo/clusters/umbrella/README.md
+++ b/examples/demo/clusters/umbrella/README.md
@@ -1,0 +1,65 @@
+# Umbrella Cluster Example
+
+Demonstrates the `Bundle.Children` umbrella pattern: one parent Flux
+Kustomization that waits on a set of child Kustomizations, each of which
+manages a subset of the platform.
+
+## Pattern
+
+An **umbrella** is a parent `Bundle` whose `children:` field nests other
+`Bundle`s (containment), as opposed to `dependsOn:` which expresses ordering
+between peer bundles.
+
+```yaml
+# cluster.yaml
+name: umbrella-demo
+node:
+  name: flux-system
+  bundle:
+    name: platform
+    children:
+      - name: platform-infra
+      - name: platform-services
+      - name: platform-apps
+```
+
+Each child is a directory next to `cluster.yaml` containing `AppWorkload`
+YAML documents. `cmd/demo` loads them via `loadUmbrellaChildrenApps` so the
+child bundles carry their own applications.
+
+## Containment vs ordering
+
+- **`children:`** — the parent *contains* the children. They render as
+  sub-layouts under the parent directory and, in Flux, as separate
+  `Kustomization` CRs that the parent Kustomization waits on via
+  `spec.wait: true` and `spec.healthChecks`.
+- **`dependsOn:`** — expresses pure ordering between two peer bundles
+  without nesting one inside the other.
+
+See `site/content/concepts/domain-model.md` for the full model.
+
+## Expected output
+
+Running `./bin/demo` produces:
+
+```
+out/umbrella-demo-repo/clusters/umbrella-demo/flux-system/
+├── flux-system-kustomization-platform.yaml       # parent CR (spec.wait + 3 healthChecks)
+├── flux-system-kustomization-platform-apps.yaml  # child CRs
+├── flux-system-kustomization-platform-infra.yaml
+├── flux-system-kustomization-platform-services.yaml
+├── kustomization.yaml                             # references the 4 CRs above
+├── platform-apps/                                 # child workloads + own kustomization.yaml
+│   ├── kustomization.yaml
+│   └── platform-apps-deployment-frontend.yaml
+├── platform-infra/
+│   ├── kustomization.yaml
+│   └── platform-infra-deployment-networking.yaml
+└── platform-services/
+    ├── kustomization.yaml
+    └── platform-services-deployment-cache.yaml
+```
+
+The parent `flux-system/kustomization.yaml` lists the four CR filenames
+exactly once each — no duplicates, no plain-subdirectory references to the
+umbrella children (they are applied through their own `Kustomization` CRs).

--- a/examples/demo/clusters/umbrella/cluster.yaml
+++ b/examples/demo/clusters/umbrella/cluster.yaml
@@ -1,0 +1,9 @@
+name: umbrella-demo
+node:
+  name: flux-system
+  bundle:
+    name: platform
+    children:
+      - name: platform-infra
+      - name: platform-services
+      - name: platform-apps

--- a/examples/demo/clusters/umbrella/platform-apps/frontend.yaml
+++ b/examples/demo/clusters/umbrella/platform-apps/frontend.yaml
@@ -1,0 +1,23 @@
+apiVersion: generators.gokure.dev/v1alpha1
+kind: AppWorkload
+metadata:
+  name: frontend
+  namespace: platform-apps
+spec:
+  workload: Deployment
+  containers:
+    - name: web
+      image: nginx:1.25-alpine
+      ports:
+        - name: http
+          containerPort: 80
+      env:
+        - name: BACKEND_CACHE
+          value: cache.platform-services.svc.cluster.local:6379
+      resources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 128Mi
+          cpu: 200m

--- a/examples/demo/clusters/umbrella/platform-infra/networking.yaml
+++ b/examples/demo/clusters/umbrella/platform-infra/networking.yaml
@@ -1,0 +1,22 @@
+apiVersion: generators.gokure.dev/v1alpha1
+kind: AppWorkload
+metadata:
+  name: networking
+  namespace: platform-infra
+spec:
+  workload: Deployment
+  containers:
+    - name: nginx-ingress
+      image: registry.k8s.io/ingress-nginx/controller:v1.10.0
+      ports:
+        - name: http
+          containerPort: 80
+        - name: https
+          containerPort: 443
+      resources:
+        requests:
+          memory: 90Mi
+          cpu: 100m
+        limits:
+          memory: 256Mi
+          cpu: 500m

--- a/examples/demo/clusters/umbrella/platform-services/cache.yaml
+++ b/examples/demo/clusters/umbrella/platform-services/cache.yaml
@@ -1,0 +1,20 @@
+apiVersion: generators.gokure.dev/v1alpha1
+kind: AppWorkload
+metadata:
+  name: cache
+  namespace: platform-services
+spec:
+  workload: Deployment
+  containers:
+    - name: redis
+      image: redis:7-alpine
+      ports:
+        - name: redis
+          containerPort: 6379
+      resources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 256Mi
+          cpu: 200m

--- a/pkg/stack/DESIGN.md
+++ b/pkg/stack/DESIGN.md
@@ -48,8 +48,30 @@ Cluster                    # Top-level configuration
 - **Features**:
   - Flux reconciliation settings (interval, timeout, retryInterval, source)
   - Interval validation (1s to 24h, Go duration format)
-  - Dependency management
+  - Dependency management (`DependsOn`) — ordering between sibling bundles
+  - Umbrella composition (`Children`) — a parent Kustomization aggregates
+    child readiness via `spec.wait: true` + auto `spec.healthChecks`. See
+    the "Umbrella Bundles" subsection below.
   - Label propagation
+
+##### Umbrella Bundles (Containment vs Ordering)
+
+`Bundle.DependsOn` and `Bundle.Children` answer different questions:
+
+- `DependsOn` expresses **ordering** between siblings: "reconcile X only after
+  Y is Ready". It does not change which resources either bundle applies.
+- `Children` expresses **containment**: the parent bundle is a wrapper around
+  its children. The parent's Flux Kustomization renders the child
+  Kustomization CRs in its own path, sets `spec.wait: true`, and uses
+  `spec.healthChecks` to aggregate each child's Ready condition into its own.
+  The parent becomes Ready iff all children are Ready — giving downstream
+  consumers a single stable anchor regardless of how many internal tiers the
+  umbrella contains.
+
+Children bundles must be **standalone**: a bundle referenced by `Children`
+cannot simultaneously be the `Bundle` of any `stack.Node`. `ValidateCluster`
+enforces this disjointness along with cycle detection, shared-ownership
+rejection, and multi-package rejection (initial patch restriction).
 
 #### 4. Application (`pkg/stack/application.go`)
 - **Purpose**: Single deployable application

--- a/pkg/stack/README.md
+++ b/pkg/stack/README.md
@@ -59,6 +59,14 @@ bundle.DependsOn = []string{"cert-manager"}
 bundle.Interval = "10m"
 ```
 
+Bundles also support an **umbrella pattern** via `Bundle.Children`. When a
+bundle has non-empty `Children`, its generated Flux Kustomization automatically
+gets `spec.wait: true` plus an entry in `spec.healthChecks` for each child,
+giving external consumers a single readiness anchor for a group of bundles.
+The child bundles' Flux Kustomization CRs are rendered into the parent
+bundle's directory. Children must be standalone bundles — they cannot
+simultaneously be attached as the `Bundle` of any `stack.Node`.
+
 ### Application
 
 An individual Kubernetes workload. Applications use the `ApplicationConfig` interface to generate their resources.

--- a/pkg/stack/builders.go
+++ b/pkg/stack/builders.go
@@ -149,6 +149,11 @@ func deepCopyBundle(b *Bundle) *Bundle {
 		newBundle.DependsOn = make([]*Bundle, len(b.DependsOn))
 		copy(newBundle.DependsOn, b.DependsOn)
 	}
+	// Same shallow-copy strategy for Children (umbrella) bundle references.
+	if b.Children != nil {
+		newBundle.Children = make([]*Bundle, len(b.Children))
+		copy(newBundle.Children, b.Children)
+	}
 	return newBundle
 }
 

--- a/pkg/stack/builders_test.go
+++ b/pkg/stack/builders_test.go
@@ -733,3 +733,30 @@ func TestMultipleDependencies(t *testing.T) {
 		}
 	}
 }
+
+func TestDeepCopyBundle_PreservesChildren(t *testing.T) {
+	child1 := &Bundle{Name: "child1"}
+	child2 := &Bundle{Name: "child2"}
+	original := &Bundle{
+		Name:     "umbrella",
+		Children: []*Bundle{child1, child2},
+	}
+
+	copyBundle := deepCopyBundle(original)
+
+	if copyBundle == nil {
+		t.Fatal("expected non-nil copy")
+	}
+	if len(copyBundle.Children) != 2 {
+		t.Fatalf("expected 2 children, got %d", len(copyBundle.Children))
+	}
+	// Pointers to children are shared (shallow copy).
+	if copyBundle.Children[0] != child1 || copyBundle.Children[1] != child2 {
+		t.Error("expected child pointers to be shared with original")
+	}
+	// Slice headers must be distinct: appending to the copy does not affect the original.
+	copyBundle.Children = append(copyBundle.Children, &Bundle{Name: "child3"})
+	if len(original.Children) != 2 {
+		t.Fatalf("appending to copy must not affect original; got %d", len(original.Children))
+	}
+}

--- a/pkg/stack/bundle.go
+++ b/pkg/stack/bundle.go
@@ -2,6 +2,7 @@ package stack
 
 import (
 	"fmt"
+	"slices"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -27,6 +28,13 @@ type Bundle struct {
 	ParentPath string
 	// DependsOn lists other bundles this bundle depends on
 	DependsOn []*Bundle
+	// Children holds bundles whose Flux Kustomization CRs are rendered into
+	// this bundle's tar path and whose readiness is aggregated into this
+	// bundle's HealthChecks. When non-empty, this bundle acts as an umbrella:
+	// it is Ready only when all Children are Ready. Children bundles must be
+	// standalone — they cannot simultaneously be the Bundle of a stack.Node.
+	// Setting Wait=false on a bundle with Children is a validation error.
+	Children []*Bundle
 	// Interval controls how often Flux reconciles the bundle.
 	Interval string
 	// SourceRef specifies the source for the bundle.
@@ -95,7 +103,9 @@ func NewBundle(name string, resources []*Application, labels map[string]string) 
 	return a, nil
 }
 
-// Validate performs basic sanity checks on the Bundle.
+// Validate performs basic sanity checks on the Bundle. When the bundle has
+// umbrella Children, Validate recursively walks the child subtree checking for
+// cycles, duplicate names, and Wait/DependsOn contradictions.
 func (a *Bundle) Validate() error {
 	if a == nil {
 		return errors.ErrNilBundle
@@ -108,7 +118,89 @@ func (a *Bundle) Validate() error {
 			return errors.ResourceValidationError("Bundle", a.Name, "applications", fmt.Sprintf("application at index %d is nil", i), nil)
 		}
 	}
+	visited := make(map[*Bundle]bool)
+	return a.validateChildren(visited)
+}
+
+// validateChildren performs recursive umbrella-children validation: cycle
+// detection, nil/self/duplicate/empty-name checks, Wait contradictions, and
+// DependsOn/Children disjointness. Cycle detection uses a visited pointer set
+// shared across the whole recursion.
+func (a *Bundle) validateChildren(visited map[*Bundle]bool) error {
+	if visited[a] {
+		return errors.ResourceValidationError("Bundle", a.Name, "children",
+			fmt.Sprintf("umbrella cycle detected at %q", a.Name), nil)
+	}
+	visited[a] = true
+	if a.Wait != nil && !*a.Wait && len(a.Children) > 0 {
+		return errors.ResourceValidationError("Bundle", a.Name, "wait",
+			"umbrella bundle (has Children) cannot set Wait=false", nil)
+	}
+	depNames := make(map[string]bool, len(a.DependsOn))
+	for _, dep := range a.DependsOn {
+		if dep != nil {
+			depNames[dep.Name] = true
+		}
+	}
+	childNames := make(map[string]bool, len(a.Children))
+	for i, c := range a.Children {
+		if c == nil {
+			return errors.ResourceValidationError("Bundle", a.Name, "children",
+				fmt.Sprintf("child at index %d is nil", i), nil)
+		}
+		if c == a {
+			return errors.ResourceValidationError("Bundle", a.Name, "children",
+				"bundle cannot be its own child", nil)
+		}
+		if c.Name == "" {
+			return errors.ResourceValidationError("Bundle", a.Name, "children",
+				fmt.Sprintf("child at index %d has empty name", i), nil)
+		}
+		if c.Name == a.Name {
+			return errors.ResourceValidationError("Bundle", a.Name, "children",
+				fmt.Sprintf("child name %q equals parent name", c.Name), nil)
+		}
+		if childNames[c.Name] {
+			return errors.ResourceValidationError("Bundle", a.Name, "children",
+				fmt.Sprintf("duplicate child name %q", c.Name), nil)
+		}
+		childNames[c.Name] = true
+		if depNames[c.Name] {
+			return errors.ResourceValidationError("Bundle", a.Name, "children",
+				fmt.Sprintf("child %q also appears in dependsOn", c.Name), nil)
+		}
+		if slices.Contains(c.DependsOn, a) {
+			return errors.ResourceValidationError("Bundle", a.Name, "children",
+				fmt.Sprintf("child %q depends on parent %q", c.Name, a.Name), nil)
+		}
+		if err := c.validateChildren(visited); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// IsUmbrella reports whether the bundle acts as an umbrella (has Children
+// that contribute their Flux Kustomizations into this bundle's directory).
+func (a *Bundle) IsUmbrella() bool {
+	return a != nil && len(a.Children) > 0
+}
+
+// InitializeUmbrella walks the umbrella Children subtree and sets each child's
+// runtime parent pointer (via SetParent) so that path-derivation code (e.g.
+// bundlePath) can walk upward from any child. Idempotent and safe to call
+// multiple times.
+func (a *Bundle) InitializeUmbrella() {
+	if a == nil {
+		return
+	}
+	for _, c := range a.Children {
+		if c == nil {
+			continue
+		}
+		c.SetParent(a)
+		c.InitializeUmbrella()
+	}
 }
 
 func (a *Bundle) Generate() ([]*client.Object, error) {

--- a/pkg/stack/bundle_test.go
+++ b/pkg/stack/bundle_test.go
@@ -516,6 +516,177 @@ func TestBundleGetPath(t *testing.T) {
 	}
 }
 
+func TestBundleValidateUmbrellaChildren(t *testing.T) {
+	truePtr := func() *bool { v := true; return &v }
+	falsePtr := func() *bool { v := false; return &v }
+
+	t.Run("happy umbrella passes", func(t *testing.T) {
+		child := &Bundle{Name: "child"}
+		parent := &Bundle{Name: "parent", Children: []*Bundle{child}}
+		if err := parent.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("umbrella with Wait=true passes", func(t *testing.T) {
+		child := &Bundle{Name: "c"}
+		parent := &Bundle{Name: "p", Wait: truePtr(), Children: []*Bundle{child}}
+		if err := parent.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("umbrella with Wait=false rejected", func(t *testing.T) {
+		child := &Bundle{Name: "c"}
+		parent := &Bundle{Name: "p", Wait: falsePtr(), Children: []*Bundle{child}}
+		if err := parent.Validate(); err == nil {
+			t.Fatal("expected Wait=false + Children to fail")
+		}
+	})
+
+	t.Run("nil child rejected", func(t *testing.T) {
+		parent := &Bundle{Name: "p", Children: []*Bundle{nil}}
+		if err := parent.Validate(); err == nil {
+			t.Fatal("expected nil child to fail")
+		}
+	})
+
+	t.Run("self-child rejected", func(t *testing.T) {
+		parent := &Bundle{Name: "p"}
+		parent.Children = []*Bundle{parent}
+		if err := parent.Validate(); err == nil {
+			t.Fatal("expected self-child to fail")
+		}
+	})
+
+	t.Run("empty child name rejected", func(t *testing.T) {
+		parent := &Bundle{Name: "p", Children: []*Bundle{{Name: ""}}}
+		if err := parent.Validate(); err == nil {
+			t.Fatal("expected empty child name to fail")
+		}
+	})
+
+	t.Run("child name equal to parent rejected", func(t *testing.T) {
+		parent := &Bundle{Name: "p", Children: []*Bundle{{Name: "p"}}}
+		if err := parent.Validate(); err == nil {
+			t.Fatal("expected child-name==parent-name to fail")
+		}
+	})
+
+	t.Run("duplicate child names rejected", func(t *testing.T) {
+		parent := &Bundle{Name: "p", Children: []*Bundle{{Name: "c"}, {Name: "c"}}}
+		if err := parent.Validate(); err == nil {
+			t.Fatal("expected duplicate child names to fail")
+		}
+	})
+
+	t.Run("DependsOn/Children overlap rejected", func(t *testing.T) {
+		shared := &Bundle{Name: "shared"}
+		parent := &Bundle{
+			Name:      "p",
+			DependsOn: []*Bundle{shared},
+			Children:  []*Bundle{shared},
+		}
+		if err := parent.Validate(); err == nil {
+			t.Fatal("expected child also in DependsOn to fail")
+		}
+	})
+
+	t.Run("child depending on parent rejected", func(t *testing.T) {
+		parent := &Bundle{Name: "p"}
+		child := &Bundle{Name: "c", DependsOn: []*Bundle{parent}}
+		parent.Children = []*Bundle{child}
+		if err := parent.Validate(); err == nil {
+			t.Fatal("expected child->parent DependsOn cycle to fail")
+		}
+	})
+
+	t.Run("direct child cycle rejected", func(t *testing.T) {
+		a := &Bundle{Name: "a"}
+		b := &Bundle{Name: "b"}
+		a.Children = []*Bundle{b}
+		b.Children = []*Bundle{a}
+		if err := a.Validate(); err == nil {
+			t.Fatal("expected a->b->a cycle to fail")
+		}
+	})
+
+	t.Run("deep cycle rejected", func(t *testing.T) {
+		a := &Bundle{Name: "a"}
+		b := &Bundle{Name: "b"}
+		c := &Bundle{Name: "c"}
+		a.Children = []*Bundle{b}
+		b.Children = []*Bundle{c}
+		c.Children = []*Bundle{a}
+		if err := a.Validate(); err == nil {
+			t.Fatal("expected deep a->b->c->a cycle to fail")
+		}
+	})
+
+	t.Run("nested umbrella validated recursively", func(t *testing.T) {
+		gc := &Bundle{Name: "grandchild"}
+		c := &Bundle{Name: "child", Children: []*Bundle{gc}}
+		p := &Bundle{Name: "parent", Children: []*Bundle{c}}
+		if err := p.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid nested child bubbles up", func(t *testing.T) {
+		badGC := &Bundle{Name: ""}
+		c := &Bundle{Name: "child", Children: []*Bundle{badGC}}
+		p := &Bundle{Name: "parent", Children: []*Bundle{c}}
+		if err := p.Validate(); err == nil {
+			t.Fatal("expected empty grandchild name to fail")
+		}
+	})
+}
+
+func TestBundleIsUmbrella(t *testing.T) {
+	var nilBundle *Bundle
+	if nilBundle.IsUmbrella() {
+		t.Error("nil bundle should not be umbrella")
+	}
+	if (&Bundle{Name: "p"}).IsUmbrella() {
+		t.Error("bundle with no Children is not an umbrella")
+	}
+	b := &Bundle{Name: "p", Children: []*Bundle{{Name: "c"}}}
+	if !b.IsUmbrella() {
+		t.Error("bundle with Children should be an umbrella")
+	}
+}
+
+func TestBundleInitializeUmbrella(t *testing.T) {
+	gc := &Bundle{Name: "grandchild"}
+	c := &Bundle{Name: "child", Children: []*Bundle{gc}}
+	p := &Bundle{Name: "parent", Children: []*Bundle{c}}
+
+	p.InitializeUmbrella()
+
+	if c.GetParent() != p {
+		t.Error("child parent should be set to parent")
+	}
+	if gc.GetParent() != c {
+		t.Error("grandchild parent should be set to child")
+	}
+	if c.ParentPath != "parent" {
+		t.Errorf("child ParentPath expected %q got %q", "parent", c.ParentPath)
+	}
+	if gc.ParentPath != "parent/child" {
+		t.Errorf("grandchild ParentPath expected %q got %q", "parent/child", gc.ParentPath)
+	}
+
+	// Idempotent
+	p.InitializeUmbrella()
+	if c.GetParent() != p || gc.GetParent() != c {
+		t.Error("InitializeUmbrella should be idempotent")
+	}
+
+	// Nil safe
+	var nilP *Bundle
+	nilP.InitializeUmbrella()
+}
+
 func TestBundleSetParent(t *testing.T) {
 	parent := &Bundle{Name: "parent", ParentPath: ""}
 	child := &Bundle{Name: "child", ParentPath: ""}

--- a/pkg/stack/fluxcd/README.md
+++ b/pkg/stack/fluxcd/README.md
@@ -114,6 +114,14 @@ Controls where Flux Kustomization resources are placed:
 - `FluxSeparate` - Flux resources in a separate directory tree
 - `FluxIntegrated` - Flux resources alongside application manifests
 
+## Validation
+
+All cluster-level entry points (`GenerateFromCluster`, `CreateLayoutWithResources`)
+call `stack.ValidateCluster` before walking the tree. Invalid umbrella
+configurations — such as a bundle referenced both by a `Node` and by another
+bundle's `Children`, shared umbrella ownership, or multi-package umbrellas —
+fail fast with a validation error rather than producing malformed output.
+
 ## Related Packages
 
 - [stack](../) - Core domain model

--- a/pkg/stack/fluxcd/README.md
+++ b/pkg/stack/fluxcd/README.md
@@ -114,6 +114,53 @@ Controls where Flux Kustomization resources are placed:
 - `FluxSeparate` - Flux resources in a separate directory tree
 - `FluxIntegrated` - Flux resources alongside application manifests
 
+## Umbrella Bundles
+
+A `Bundle` with a non-empty `Children` slice becomes an **umbrella**: a parent
+Flux Kustomization that aggregates the readiness of its children via
+`spec.wait: true` and auto-generated `spec.healthChecks`. This gives downstream
+consumers a single stable anchor regardless of how many internal tiers the
+umbrella contains.
+
+### Resource generation
+
+`ResourceGenerator.createKustomization` detects umbrella bundles and:
+- forces `spec.wait = true`
+- prepends one `HealthChecks` entry per direct child (referencing the child's
+  own Kustomization by name/namespace)
+- leaves user-supplied `HealthChecks` appended after the auto entries
+
+`GenerateFromBundle(b)` is strictly self-only — it never recurses into
+`b.Children`. Callers that want the entire umbrella closure as a flat list use
+`GenerateFromNode` or `GenerateFromCluster`, which walk umbrella children via
+`generateUmbrellaClosure` internally.
+
+### Placement in layouts
+
+`LayoutIntegrator` places umbrella child Flux CRs at the **parent** layout
+node:
+
+- **FluxIntegrated, non-nodeOnly**: the walker creates a bundle sub-layout
+  under the node layout. Umbrella child Kustomization CRs (and their Source
+  CRs, if the child has a `SourceRef.URL`) are appended to the bundle
+  sub-layout's `Resources`. Nested umbrella children are placed at their
+  enclosing umbrella child's layout node.
+- **FluxIntegrated, nodeOnly (GroupFlat)**: there is no intermediate bundle
+  layer, so umbrella children become direct sub-layouts of the node layout,
+  and their Flux CRs sit at the node layout alongside the umbrella self CR.
+- **FluxSeparate**: `GenerateFromCluster` walks the full umbrella closure, so
+  the `flux-system` layout directory receives every descendant's Kustomization
+  CR as a flat list.
+
+### On-disk shape
+
+When a parent layout has an umbrella child, the parent's `kustomization.yaml`
+references the child via `flux-system-kustomization-{child}.yaml` (the
+Kustomization CR file sitting in the parent directory) instead of the child
+subdirectory. The child subdirectory still exists and still contains its own
+`kustomization.yaml` plus workload YAML files — but **no** Flux CR files, so
+Flux does not double-apply the child's resources.
+
 ## Validation
 
 All cluster-level entry points (`GenerateFromCluster`, `CreateLayoutWithResources`)

--- a/pkg/stack/fluxcd/fluxcd_test.go
+++ b/pkg/stack/fluxcd/fluxcd_test.go
@@ -336,3 +336,275 @@ func TestCreateSource_InvalidKind(t *testing.T) {
 		t.Fatal("expected error for invalid source kind")
 	}
 }
+
+func TestGenerateFromBundle_UmbrellaAutoHealthChecks(t *testing.T) {
+	wf := fluxstack.Engine()
+	umbrella := &stack.Bundle{
+		Name: "platform",
+		Children: []*stack.Bundle{
+			{Name: "infra"},
+			{Name: "services"},
+			{Name: "apps"},
+		},
+	}
+
+	objs, err := wf.GenerateFromBundle(umbrella)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Self-only: umbrella bundle emits ONE Kustomization, not four.
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object (self-only), got %d", len(objs))
+	}
+
+	k, ok := objs[0].(*kustv1.Kustomization)
+	if !ok {
+		t.Fatalf("expected *kustv1.Kustomization, got %T", objs[0])
+	}
+
+	if !k.Spec.Wait {
+		t.Error("expected Wait=true for umbrella bundle")
+	}
+
+	if len(k.Spec.HealthChecks) != 3 {
+		t.Fatalf("expected 3 auto HealthChecks, got %d", len(k.Spec.HealthChecks))
+	}
+	wantNames := []string{"infra", "services", "apps"}
+	for i, want := range wantNames {
+		hc := k.Spec.HealthChecks[i]
+		if hc.Name != want {
+			t.Errorf("HealthChecks[%d].Name = %q, want %q", i, hc.Name, want)
+		}
+		if hc.Kind != "Kustomization" {
+			t.Errorf("HealthChecks[%d].Kind = %q, want Kustomization", i, hc.Kind)
+		}
+		if hc.APIVersion != kustv1.GroupVersion.String() {
+			t.Errorf("HealthChecks[%d].APIVersion = %q, want %q", i, hc.APIVersion, kustv1.GroupVersion.String())
+		}
+		if hc.Namespace != "flux-system" {
+			t.Errorf("HealthChecks[%d].Namespace = %q, want flux-system", i, hc.Namespace)
+		}
+	}
+}
+
+func TestGenerateFromBundle_UmbrellaUserHealthChecksAppended(t *testing.T) {
+	wf := fluxstack.Engine()
+	umbrella := &stack.Bundle{
+		Name: "platform",
+		Children: []*stack.Bundle{
+			{Name: "infra"},
+		},
+		HealthChecks: []stack.HealthCheck{
+			{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "manual-check",
+				Namespace:  "default",
+			},
+		},
+	}
+
+	objs, err := wf.GenerateFromBundle(umbrella)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	k := objs[0].(*kustv1.Kustomization)
+
+	if len(k.Spec.HealthChecks) != 2 {
+		t.Fatalf("expected 2 HealthChecks (1 auto + 1 user), got %d", len(k.Spec.HealthChecks))
+	}
+	// Auto entries come first.
+	if k.Spec.HealthChecks[0].Name != "infra" {
+		t.Errorf("HealthChecks[0] = %q, want auto entry 'infra'", k.Spec.HealthChecks[0].Name)
+	}
+	if k.Spec.HealthChecks[1].Name != "manual-check" {
+		t.Errorf("HealthChecks[1] = %q, want user entry 'manual-check'", k.Spec.HealthChecks[1].Name)
+	}
+}
+
+func TestGenerateFromBundle_UmbrellaPreservesTimeout(t *testing.T) {
+	wf := fluxstack.Engine()
+	umbrella := &stack.Bundle{
+		Name:          "platform",
+		Timeout:       "10m",
+		RetryInterval: "2m",
+		Children: []*stack.Bundle{
+			{Name: "infra"},
+		},
+	}
+
+	objs, err := wf.GenerateFromBundle(umbrella)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	k := objs[0].(*kustv1.Kustomization)
+
+	if k.Spec.Timeout == nil || k.Spec.Timeout.Duration.String() != "10m0s" {
+		t.Errorf("Timeout = %v, want 10m", k.Spec.Timeout)
+	}
+	if k.Spec.RetryInterval == nil || k.Spec.RetryInterval.Duration.String() != "2m0s" {
+		t.Errorf("RetryInterval = %v, want 2m", k.Spec.RetryInterval)
+	}
+}
+
+func TestGenerateFromBundle_UmbrellaDoesNotRecurse(t *testing.T) {
+	// Assert the GenerateFromBundle self-only invariant: a two-level umbrella
+	// still yields exactly 1 object (just the top bundle's Kustomization).
+	wf := fluxstack.Engine()
+	umbrella := &stack.Bundle{
+		Name: "platform",
+		Children: []*stack.Bundle{
+			{
+				Name: "infra",
+				Children: []*stack.Bundle{
+					{Name: "networking"},
+				},
+			},
+		},
+	}
+
+	objs, err := wf.GenerateFromBundle(umbrella)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object (self-only), got %d", len(objs))
+	}
+}
+
+func TestGenerateFromNode_UmbrellaClosure(t *testing.T) {
+	// GenerateFromNode must walk the umbrella subtree so flat-list consumers
+	// (separate Flux placement) see every descendant Kustomization.
+	wf := fluxstack.Engine()
+	n := &stack.Node{
+		Name: "root",
+		Bundle: &stack.Bundle{
+			Name: "platform",
+			Children: []*stack.Bundle{
+				{Name: "infra"},
+				{Name: "services"},
+				{Name: "apps"},
+			},
+		},
+	}
+
+	objs, err := wf.GenerateFromNode(n)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 1 umbrella + 3 children = 4 Kustomizations.
+	if len(objs) != 4 {
+		t.Fatalf("expected 4 objects (umbrella + 3 children), got %d", len(objs))
+	}
+
+	names := map[string]bool{}
+	for _, o := range objs {
+		k, ok := o.(*kustv1.Kustomization)
+		if !ok {
+			t.Fatalf("unexpected object type %T", o)
+		}
+		names[k.Name] = true
+	}
+	for _, want := range []string{"platform", "infra", "services", "apps"} {
+		if !names[want] {
+			t.Errorf("missing Kustomization %q in closure output", want)
+		}
+	}
+}
+
+func TestGenerateFromNode_NestedUmbrellaClosure(t *testing.T) {
+	wf := fluxstack.Engine()
+	n := &stack.Node{
+		Name: "root",
+		Bundle: &stack.Bundle{
+			Name: "platform",
+			Children: []*stack.Bundle{
+				{
+					Name: "infra",
+					Children: []*stack.Bundle{
+						{Name: "networking"},
+						{Name: "storage"},
+					},
+				},
+				{Name: "apps"},
+			},
+		},
+	}
+
+	objs, err := wf.GenerateFromNode(n)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// platform + infra + networking + storage + apps = 5
+	if len(objs) != 5 {
+		t.Fatalf("expected 5 objects, got %d", len(objs))
+	}
+}
+
+func TestGenerateFromNode_UmbrellaChildWithSource(t *testing.T) {
+	wf := fluxstack.Engine()
+	n := &stack.Node{
+		Name: "root",
+		Bundle: &stack.Bundle{
+			Name: "platform",
+			Children: []*stack.Bundle{
+				{
+					Name: "ext",
+					SourceRef: &stack.SourceRef{
+						Kind:   "GitRepository",
+						Name:   "ext-repo",
+						URL:    "https://github.com/example/ext",
+						Branch: "main",
+					},
+				},
+			},
+		},
+	}
+
+	objs, err := wf.GenerateFromNode(n)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// umbrella Kustomization + ext Kustomization + ext GitRepository source = 3
+	if len(objs) != 3 {
+		t.Fatalf("expected 3 objects, got %d", len(objs))
+	}
+
+	var sawSource bool
+	for _, o := range objs {
+		if _, ok := o.(*sourcev1.GitRepository); ok {
+			sawSource = true
+		}
+	}
+	if !sawSource {
+		t.Error("expected umbrella child's GitRepository source in output")
+	}
+}
+
+func TestGenerateFromBundle_UmbrellaInitializesParent(t *testing.T) {
+	// Umbrella path should call InitializeUmbrella which sets child parent
+	// pointers, allowing path derivation to work without manual SetParent.
+	wf := fluxstack.EngineWithMode(layout.KustomizationExplicit)
+	umbrella := &stack.Bundle{
+		Name: "platform",
+		Children: []*stack.Bundle{
+			{Name: "infra"},
+		},
+	}
+
+	// Generate the umbrella first — this should initialize children.
+	if _, err := wf.GenerateFromBundle(umbrella); err != nil {
+		t.Fatalf("umbrella generate: %v", err)
+	}
+
+	// Now generate the child — its path must include the parent.
+	childObjs, err := wf.GenerateFromBundle(umbrella.Children[0])
+	if err != nil {
+		t.Fatalf("child generate: %v", err)
+	}
+	k := childObjs[0].(*kustv1.Kustomization)
+	if k.Spec.Path != "platform/infra" {
+		t.Errorf("child Path = %q, want platform/infra (parent not wired)", k.Spec.Path)
+	}
+}

--- a/pkg/stack/fluxcd/fluxcd_test.go
+++ b/pkg/stack/fluxcd/fluxcd_test.go
@@ -1,15 +1,41 @@
 package fluxcd_test
 
 import (
+	"archive/tar"
+	"bytes"
+	"errors"
+	"io"
+	"strings"
 	"testing"
 
 	kustv1 "github.com/fluxcd/kustomize-controller/api/v1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-kure/kure/pkg/stack"
 	fluxstack "github.com/go-kure/kure/pkg/stack/fluxcd"
 	"github.com/go-kure/kure/pkg/stack/layout"
 )
+
+// fakeAppConfig is a minimal ApplicationConfig for end-to-end umbrella tests.
+type fakeAppConfig struct {
+	objs []*client.Object
+}
+
+func (f *fakeAppConfig) Generate(*stack.Application) ([]*client.Object, error) {
+	return f.objs, nil
+}
+
+func fakeUmbrellaApp(appName, cmName string) *stack.Application {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("v1")
+	u.SetKind("ConfigMap")
+	u.SetName(cmName)
+	u.SetNamespace("default")
+	var o client.Object = u
+	return stack.NewApplication(appName, "default", &fakeAppConfig{objs: []*client.Object{&o}})
+}
 
 func TestWorkflowBundlePathMode(t *testing.T) {
 	parent := &stack.Bundle{Name: "parent"}
@@ -607,4 +633,251 @@ func TestGenerateFromBundle_UmbrellaInitializesParent(t *testing.T) {
 	if k.Spec.Path != "platform/infra" {
 		t.Errorf("child Path = %q, want platform/infra (parent not wired)", k.Spec.Path)
 	}
+}
+
+// extractTarFilesFluxcd reads all regular file entries from a tar into a map.
+func extractTarFilesFluxcd(t *testing.T, buf *bytes.Buffer) map[string][]byte {
+	t.Helper()
+	files := make(map[string][]byte)
+	tr := tar.NewReader(buf)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar read: %v", err)
+		}
+		if hdr.Typeflag == tar.TypeReg {
+			data, err := io.ReadAll(tr)
+			if err != nil {
+				t.Fatalf("tar file read: %v", err)
+			}
+			files[hdr.Name] = data
+		}
+	}
+	return files
+}
+
+func TestEndToEndUmbrellaFromCluster_Integrated(t *testing.T) {
+	// Build a cluster with a Node whose Bundle is an umbrella with 3 children,
+	// each holding one Application. Use PresetParentDeployedControl equivalent
+	// (GroupFlat + FluxIntegrated) via LayoutRules and assert that the tar
+	// output has the right directory shape, kustomization.yaml references, and
+	// the umbrella parent Kustomization CR with HealthChecks.
+	umbrella := &stack.Bundle{
+		Name: "platform",
+		Children: []*stack.Bundle{
+			{
+				Name:         "Y-infra",
+				Applications: []*stack.Application{fakeUmbrellaApp("infra-app", "cm-infra")},
+			},
+			{
+				Name:         "Y-services",
+				Applications: []*stack.Application{fakeUmbrellaApp("services-app", "cm-services")},
+			},
+			{
+				Name:         "Y-apps",
+				Applications: []*stack.Application{fakeUmbrellaApp("apps-app", "cm-apps")},
+			},
+		},
+	}
+	node := &stack.Node{Name: "apps", Bundle: umbrella}
+	root := &stack.Node{Name: "demo", Children: []*stack.Node{node}}
+	node.SetParent(root)
+	cluster := &stack.Cluster{Name: "demo", Node: root}
+
+	integrator := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	integrator.SetFluxPlacement(layout.FluxIntegrated)
+
+	ml, err := integrator.CreateLayoutWithResources(cluster, layout.LayoutRules{
+		BundleGrouping:      layout.GroupFlat,
+		ApplicationGrouping: layout.GroupFlat,
+	})
+	if err != nil {
+		t.Fatalf("CreateLayoutWithResources: %v", err)
+	}
+
+	// Find the node layout to assert umbrella self + 3 children CRs (2 per
+	// child: none — only 3 Kustomizations) are all at the node layout in
+	// nodeOnly mode.
+	if len(ml.Children) == 0 {
+		t.Fatalf("expected children on top-level layout")
+	}
+
+	// Walk to the "apps" node layout. The exact shape depends on root
+	// flattening — find by name.
+	var nodeLayout *layout.ManifestLayout
+	var visit func(*layout.ManifestLayout)
+	visit = func(l *layout.ManifestLayout) {
+		if l.Name == "apps" {
+			nodeLayout = l
+			return
+		}
+		for _, c := range l.Children {
+			visit(c)
+			if nodeLayout != nil {
+				return
+			}
+		}
+	}
+	visit(ml)
+	if nodeLayout == nil {
+		t.Fatalf("could not locate apps node layout")
+	}
+
+	// In GroupFlat/nodeOnly mode, all 4 Flux Kustomization CRs live at the
+	// node layout (umbrella self + 3 children).
+	kustsByName := map[string]*kustv1.Kustomization{}
+	for _, r := range nodeLayout.Resources {
+		if k, ok := r.(*kustv1.Kustomization); ok {
+			kustsByName[k.Name] = k
+		}
+	}
+	for _, want := range []string{"platform", "Y-infra", "Y-services", "Y-apps"} {
+		if kustsByName[want] == nil {
+			t.Errorf("missing Flux Kustomization %q at node layout", want)
+		}
+	}
+
+	// Umbrella parent should have Wait=true and HealthChecks entries for children.
+	platform := kustsByName["platform"]
+	if platform == nil {
+		t.Fatal("no platform Kustomization")
+	}
+	if !platform.Spec.Wait {
+		t.Error("expected platform.Spec.Wait == true (umbrella)")
+	}
+	hcNames := map[string]bool{}
+	for _, hc := range platform.Spec.HealthChecks {
+		hcNames[hc.Name] = true
+	}
+	for _, want := range []string{"Y-infra", "Y-services", "Y-apps"} {
+		if !hcNames[want] {
+			t.Errorf("platform HealthChecks missing %q, got %v", want, hcNames)
+		}
+	}
+
+	// Write to tar and verify disk shape.
+	var buf bytes.Buffer
+	if err := ml.WriteToTar(&buf); err != nil {
+		t.Fatalf("WriteToTar: %v", err)
+	}
+	files := extractTarFilesFluxcd(t, &buf)
+
+	// Parent kustomization.yaml should reference each child's Flux
+	// Kustomization CR file. The node layout's namespace is demo/apps.
+	parentKust, ok := files["demo/apps/kustomization.yaml"]
+	if !ok {
+		t.Fatalf("no demo/apps/kustomization.yaml found, files: %v", fileNamesFromFluxcd(files))
+	}
+	for _, child := range []string{"Y-infra", "Y-services", "Y-apps"} {
+		want := "flux-system-kustomization-" + child + ".yaml"
+		if !bytes.Contains(parentKust, []byte(want)) {
+			t.Errorf("parent kustomization.yaml missing reference to %s:\n%s", want, parentKust)
+		}
+	}
+
+	// Each umbrella child subdir should contain its own workload + its own
+	// kustomization.yaml, and must NOT contain any flux-system-kustomization-*.
+	for _, child := range []string{"Y-infra", "Y-services", "Y-apps"} {
+		childPrefix := ""
+		for name := range files {
+			if strings.HasSuffix(name, "/"+child+"/kustomization.yaml") {
+				childPrefix = strings.TrimSuffix(name, "/kustomization.yaml")
+				break
+			}
+		}
+		if childPrefix == "" {
+			t.Errorf("no subdir kustomization.yaml for umbrella child %q", child)
+			continue
+		}
+		// Check for workload file
+		foundWorkload := false
+		for name := range files {
+			if strings.HasPrefix(name, childPrefix+"/") && strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, "kustomization.yaml") {
+				foundWorkload = true
+			}
+			if strings.HasPrefix(name, childPrefix+"/flux-system-kustomization-") {
+				t.Errorf("umbrella child subdir %q contains flux CR file: %s", child, name)
+			}
+		}
+		if !foundWorkload {
+			t.Errorf("umbrella child subdir %q has no workload file", child)
+		}
+	}
+}
+
+func TestEndToEndUmbrellaFromCluster_Separate(t *testing.T) {
+	// In separate Flux placement, the flux-system dir should contain all
+	// Kustomizations (umbrella + children) via GenerateFromCluster's flat
+	// closure output.
+	umbrella := &stack.Bundle{
+		Name: "platform",
+		Children: []*stack.Bundle{
+			{
+				Name:         "Y-infra",
+				Applications: []*stack.Application{fakeUmbrellaApp("infra-app", "cm-infra")},
+			},
+			{
+				Name:         "Y-services",
+				Applications: []*stack.Application{fakeUmbrellaApp("services-app", "cm-services")},
+			},
+		},
+	}
+	node := &stack.Node{Name: "apps", Bundle: umbrella}
+	root := &stack.Node{Name: "demo", Children: []*stack.Node{node}}
+	node.SetParent(root)
+	cluster := &stack.Cluster{Name: "demo", Node: root}
+
+	integrator := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	integrator.SetFluxPlacement(layout.FluxSeparate)
+
+	ml, err := integrator.CreateLayoutWithResources(cluster, layout.LayoutRules{
+		BundleGrouping:      layout.GroupFlat,
+		ApplicationGrouping: layout.GroupFlat,
+	})
+	if err != nil {
+		t.Fatalf("CreateLayoutWithResources: %v", err)
+	}
+
+	// Find flux-system layout
+	var flux *layout.ManifestLayout
+	var visit func(*layout.ManifestLayout)
+	visit = func(l *layout.ManifestLayout) {
+		if l.Name == "flux-system" {
+			flux = l
+			return
+		}
+		for _, c := range l.Children {
+			visit(c)
+			if flux != nil {
+				return
+			}
+		}
+	}
+	visit(ml)
+	if flux == nil {
+		t.Fatalf("no flux-system layout found")
+	}
+
+	kustNames := map[string]bool{}
+	for _, r := range flux.Resources {
+		if k, ok := r.(*kustv1.Kustomization); ok {
+			kustNames[k.Name] = true
+		}
+	}
+	for _, want := range []string{"platform", "Y-infra", "Y-services"} {
+		if !kustNames[want] {
+			t.Errorf("flux-system missing Kustomization %q, got %v", want, kustNames)
+		}
+	}
+}
+
+func fileNamesFromFluxcd(files map[string][]byte) []string {
+	names := make([]string, 0, len(files))
+	for k := range files {
+		names = append(names, k)
+	}
+	return names
 }

--- a/pkg/stack/fluxcd/layout_integrator.go
+++ b/pkg/stack/fluxcd/layout_integrator.go
@@ -97,6 +97,23 @@ func (li *LayoutIntegrator) processNodeForIntegratedFlux(root *layout.ManifestLa
 
 		// Add Flux resources to the layout node
 		layoutNode.Resources = append(layoutNode.Resources, fluxResources...)
+
+		// For umbrella bundles, place child Flux Kustomization CRs at the
+		// immediate enclosing parent layout directory (not in child subdirs).
+		if len(node.Bundle.Children) > 0 {
+			// In non-nodeOnly layouts, the walker creates an intermediate
+			// bundle layout under the node layout. Umbrella children live
+			// there. In nodeOnly layouts the umbrella children sit directly
+			// under the node layout, so the node layout IS the parent.
+			parentForChildren := layoutNode
+			if bl := findBundleLayout(layoutNode, node.Bundle.Name); bl != nil {
+				parentForChildren = bl
+			}
+			if err := li.placeUmbrellaChildrenFlux(parentForChildren, node.Bundle); err != nil {
+				return errors.ResourceValidationError("Node", node.Name, "umbrella",
+					fmt.Sprintf("failed to place umbrella child Flux resources: %v", err), err)
+			}
+		}
 	}
 
 	// Process child nodes — always search from root for path-based matching
@@ -106,6 +123,70 @@ func (li *LayoutIntegrator) processNodeForIntegratedFlux(root *layout.ManifestLa
 		}
 	}
 
+	return nil
+}
+
+// placeUmbrellaChildrenFlux walks a bundle's umbrella Children subtree and
+// places each child's Flux Kustomization CR (and Source CR if the child's
+// SourceRef has a URL) at the PARENT layout node. Nested umbrella
+// grandchildren are placed at their immediate enclosing umbrella child's
+// layout node, which the walker has already marked with UmbrellaChild=true.
+func (li *LayoutIntegrator) placeUmbrellaChildrenFlux(parentLayout *layout.ManifestLayout, umbrella *stack.Bundle) error {
+	umbrella.InitializeUmbrella()
+	for _, child := range umbrella.Children {
+		if child == nil {
+			continue
+		}
+		childKust := li.Generator.createKustomization(child)
+		parentLayout.Resources = append(parentLayout.Resources, childKust)
+
+		if child.SourceRef != nil && child.SourceRef.URL != "" {
+			src, err := li.Generator.createSource(child.SourceRef, child.Name)
+			if err != nil {
+				return errors.ResourceValidationError("Bundle", child.Name, "source",
+					fmt.Sprintf("failed to create source: %v", err), err)
+			}
+			if src != nil {
+				parentLayout.Resources = append(parentLayout.Resources, src)
+			}
+		}
+
+		if len(child.Children) > 0 {
+			childLayoutNode := findUmbrellaChildLayout(parentLayout, child.Name)
+			if childLayoutNode == nil {
+				return errors.ResourceValidationError("Bundle", child.Name, "umbrella",
+					"nested umbrella child layout not found", nil)
+			}
+			if err := li.placeUmbrellaChildrenFlux(childLayoutNode, child); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// findBundleLayout returns the direct child layout named after the given
+// bundle, if any. In non-nodeOnly layouts, the walker inserts an intermediate
+// bundle layout between the node layout and its application/umbrella-child
+// layouts — this helper locates it so umbrella children can be placed there.
+func findBundleLayout(parent *layout.ManifestLayout, bundleName string) *layout.ManifestLayout {
+	for _, c := range parent.Children {
+		if c.Name == bundleName && !c.UmbrellaChild {
+			return c
+		}
+	}
+	return nil
+}
+
+// findUmbrellaChildLayout returns the direct umbrella-child sub-layout with
+// the given name. Per-level lookup is sufficient because
+// placeUmbrellaChildrenFlux recurses into nested umbrellas explicitly.
+func findUmbrellaChildLayout(parent *layout.ManifestLayout, name string) *layout.ManifestLayout {
+	for _, c := range parent.Children {
+		if c.UmbrellaChild && c.Name == name {
+			return c
+		}
+	}
 	return nil
 }
 

--- a/pkg/stack/fluxcd/layout_integrator.go
+++ b/pkg/stack/fluxcd/layout_integrator.go
@@ -49,6 +49,12 @@ func (li *LayoutIntegrator) CreateLayoutWithResources(c *stack.Cluster, rules la
 		return nil, nil
 	}
 
+	// Fail fast on umbrella / disjointness / multi-package violations before
+	// we walk the tree.
+	if err := stack.ValidateCluster(c); err != nil {
+		return nil, err
+	}
+
 	// Generate the base manifest layout first
 	ml, err := layout.WalkCluster(c, rules)
 	if err != nil {

--- a/pkg/stack/fluxcd/layout_integrator_test.go
+++ b/pkg/stack/fluxcd/layout_integrator_test.go
@@ -352,6 +352,66 @@ func TestLayoutIntegrator_SeparateMode_EmptyCluster(t *testing.T) {
 	}
 }
 
+// TestCreateLayoutWithResources_ClusterNameWithChildNodes verifies that
+// setting rules.ClusterName on a cluster whose root node has child nodes
+// produces a layout tree whose paths match stack.Node.GetPath(), so the
+// Flux integrator's path-based lookup can find each child node's layout.
+// Previously walkClusterWithClusterName flattened child nodes to cluster
+// siblings, causing CreateLayoutWithResources to fail with "corresponding
+// layout node not found". This matches the shape of examples/demo/clusters/
+// basic/cluster.yaml.
+func TestCreateLayoutWithResources_ClusterNameWithChildNodes(t *testing.T) {
+	rootBundle := &stack.Bundle{Name: "root-bundle"}
+	appsBundle := &stack.Bundle{Name: "apps-bundle"}
+	infraBundle := &stack.Bundle{Name: "infra-bundle"}
+
+	appsNode := &stack.Node{Name: "apps", Bundle: appsBundle}
+	infraNode := &stack.Node{Name: "infra", Bundle: infraBundle}
+	rootNode := &stack.Node{
+		Name:     "flux-system",
+		Bundle:   rootBundle,
+		Children: []*stack.Node{appsNode, infraNode},
+	}
+	appsNode.SetParent(rootNode)
+	infraNode.SetParent(rootNode)
+	cluster := &stack.Cluster{Name: "demo", Node: rootNode}
+
+	integrator := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	integrator.SetFluxPlacement(layout.FluxIntegrated)
+
+	rules := layout.DefaultLayoutRules()
+	rules.ClusterName = "demo"
+	rules.FluxPlacement = layout.FluxIntegrated
+
+	ml, err := integrator.CreateLayoutWithResources(cluster, rules)
+	if err != nil {
+		t.Fatalf("CreateLayoutWithResources failed: %v", err)
+	}
+	if ml == nil {
+		t.Fatal("expected non-nil layout")
+	}
+
+	// Cluster layout contains exactly the root node layout.
+	if len(ml.Children) != 1 {
+		t.Fatalf("cluster layout should have 1 child (root node), got %d", len(ml.Children))
+	}
+	rootLayout := ml.Children[0]
+	if rootLayout.Name != "flux-system" {
+		t.Fatalf("expected root layout name %q, got %q", "flux-system", rootLayout.Name)
+	}
+
+	// Child nodes must be nested under the root layout.
+	childNames := map[string]bool{}
+	for _, c := range rootLayout.Children {
+		childNames[c.Name] = true
+	}
+	for _, want := range []string{"apps", "infra"} {
+		if !childNames[want] {
+			t.Errorf("expected child node layout %q under root layout, not found", want)
+		}
+	}
+}
+
 func TestCreateLayoutWithResources_InvalidUmbrellaRejected(t *testing.T) {
 	// Shared pointer is both a child node Bundle and an umbrella child —
 	// ValidateCluster must reject.

--- a/pkg/stack/fluxcd/layout_integrator_test.go
+++ b/pkg/stack/fluxcd/layout_integrator_test.go
@@ -3,6 +3,9 @@ package fluxcd_test
 import (
 	"testing"
 
+	kustv1 "github.com/fluxcd/kustomize-controller/api/v1"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+
 	"github.com/go-kure/kure/pkg/stack"
 	fluxstack "github.com/go-kure/kure/pkg/stack/fluxcd"
 	"github.com/go-kure/kure/pkg/stack/layout"
@@ -365,5 +368,275 @@ func TestCreateLayoutWithResources_InvalidUmbrellaRejected(t *testing.T) {
 	integrator := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
 	if _, err := integrator.CreateLayoutWithResources(c, layout.LayoutRules{}); err == nil {
 		t.Fatal("expected invalid umbrella cluster to be rejected by CreateLayoutWithResources")
+	}
+}
+
+func TestCreateLayoutWithResources_UmbrellaIntegratedPlacement(t *testing.T) {
+	// Integrated placement: the umbrella bundle's own Flux CR goes to the
+	// node layout (existing behavior, referenced via the bundle-named
+	// FluxIntegrated child reference), while each umbrella child's Flux CR
+	// lands at the bundle layout (where the bundle-dir kustomization.yaml
+	// references them via UmbrellaChild). Child sub-layouts carry no Flux CRs.
+	umbrella := &stack.Bundle{
+		Name: "platform",
+		Children: []*stack.Bundle{
+			{Name: "infra"},
+			{Name: "services"},
+		},
+	}
+	node := &stack.Node{Name: "apps", Bundle: umbrella}
+	root := &stack.Node{Name: "root", Children: []*stack.Node{node}}
+	node.SetParent(root)
+	cluster := &stack.Cluster{Name: "demo", Node: root}
+
+	integrator := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	integrator.SetFluxPlacement(layout.FluxIntegrated)
+
+	ml, err := integrator.CreateLayoutWithResources(cluster, layout.LayoutRules{
+		BundleGrouping:      layout.GroupByName,
+		ApplicationGrouping: layout.GroupByName,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Walk ml to find layouts: root -> apps -> platform
+	if len(ml.Children) != 1 {
+		t.Fatalf("expected 1 node child, got %d", len(ml.Children))
+	}
+	nodeLayout := ml.Children[0]
+
+	// Node layout carries the umbrella's own Flux CR.
+	nodeKustNames := map[string]bool{}
+	for _, r := range nodeLayout.Resources {
+		if k, ok := r.(*kustv1.Kustomization); ok {
+			nodeKustNames[k.Name] = true
+		}
+	}
+	if !nodeKustNames["platform"] {
+		t.Error("expected platform Kustomization at node layout")
+	}
+	if nodeKustNames["infra"] || nodeKustNames["services"] {
+		t.Error("umbrella child CRs should not be at node layout")
+	}
+
+	if len(nodeLayout.Children) != 1 {
+		t.Fatalf("expected 1 bundle child, got %d", len(nodeLayout.Children))
+	}
+	bundleLayout := nodeLayout.Children[0]
+	if bundleLayout.Name != "platform" {
+		t.Fatalf("expected platform bundle, got %q", bundleLayout.Name)
+	}
+
+	// Bundle layout carries the umbrella children's Flux CRs.
+	bundleKustNames := map[string]bool{}
+	for _, r := range bundleLayout.Resources {
+		if k, ok := r.(*kustv1.Kustomization); ok {
+			bundleKustNames[k.Name] = true
+		}
+	}
+	for _, want := range []string{"infra", "services"} {
+		if !bundleKustNames[want] {
+			t.Errorf("missing umbrella child Kustomization %q at bundle layout", want)
+		}
+	}
+	if bundleKustNames["platform"] {
+		t.Error("umbrella self CR should NOT be at bundle layout (it lives at node layout)")
+	}
+
+	// Umbrella child sub-layouts should carry NO Flux CRs.
+	for _, c := range bundleLayout.Children {
+		if !c.UmbrellaChild {
+			continue
+		}
+		for _, r := range c.Resources {
+			if _, ok := r.(*kustv1.Kustomization); ok {
+				t.Errorf("umbrella child %q contains Flux Kustomization CR — expected none", c.Name)
+			}
+		}
+	}
+}
+
+func TestCreateLayoutWithResources_UmbrellaNodeOnlyPlacement(t *testing.T) {
+	// In nodeOnly (GroupFlat) mode, the umbrella child Flux CRs should land
+	// at the node layout directly (no intermediate bundle layer).
+	umbrella := &stack.Bundle{
+		Name: "platform",
+		Children: []*stack.Bundle{
+			{Name: "infra"},
+		},
+	}
+	node := &stack.Node{Name: "apps", Bundle: umbrella}
+	root := &stack.Node{Name: "root", Children: []*stack.Node{node}}
+	node.SetParent(root)
+	cluster := &stack.Cluster{Name: "demo", Node: root}
+
+	integrator := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	integrator.SetFluxPlacement(layout.FluxIntegrated)
+
+	ml, err := integrator.CreateLayoutWithResources(cluster, layout.LayoutRules{
+		BundleGrouping:      layout.GroupFlat,
+		ApplicationGrouping: layout.GroupFlat,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(ml.Children) != 1 {
+		t.Fatalf("expected 1 node child, got %d", len(ml.Children))
+	}
+	nodeLayout := ml.Children[0]
+
+	// Node layout should carry umbrella self + umbrella child CRs = 2 Kustomizations
+	kustCount := 0
+	childNames := map[string]bool{}
+	for _, r := range nodeLayout.Resources {
+		if k, ok := r.(*kustv1.Kustomization); ok {
+			kustCount++
+			childNames[k.Name] = true
+		}
+	}
+	if kustCount != 2 {
+		t.Errorf("expected 2 Kustomizations at node layout, got %d", kustCount)
+	}
+	if !childNames["platform"] {
+		t.Error("missing umbrella platform Kustomization")
+	}
+	if !childNames["infra"] {
+		t.Error("missing umbrella child infra Kustomization")
+	}
+}
+
+func TestCreateLayoutWithResources_UmbrellaNestedIntegratedPlacement(t *testing.T) {
+	// Nested umbrellas: infra child has its own grandchild. The grandchild's
+	// Flux CR should land at the infra umbrella child layout, not the
+	// platform bundle layout or the grandchild sub-layout.
+	umbrella := &stack.Bundle{
+		Name: "platform",
+		Children: []*stack.Bundle{
+			{
+				Name: "infra",
+				Children: []*stack.Bundle{
+					{Name: "networking"},
+				},
+			},
+		},
+	}
+	node := &stack.Node{Name: "apps", Bundle: umbrella}
+	root := &stack.Node{Name: "root", Children: []*stack.Node{node}}
+	node.SetParent(root)
+	cluster := &stack.Cluster{Name: "demo", Node: root}
+
+	integrator := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	integrator.SetFluxPlacement(layout.FluxIntegrated)
+
+	ml, err := integrator.CreateLayoutWithResources(cluster, layout.LayoutRules{
+		BundleGrouping:      layout.GroupByName,
+		ApplicationGrouping: layout.GroupByName,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// ml -> apps(nodeLayout) -> platform(bundleLayout) -> infra(UmbrellaChild) -> networking(UmbrellaChild)
+	// Platform's own CR lives at the node layout (via GenerateFromBundle).
+	// The platform bundle layout carries only the direct umbrella children (infra).
+	nodeLayout := ml.Children[0]
+	nodeKustNames := map[string]bool{}
+	for _, r := range nodeLayout.Resources {
+		if k, ok := r.(*kustv1.Kustomization); ok {
+			nodeKustNames[k.Name] = true
+		}
+	}
+	if !nodeKustNames["platform"] {
+		t.Error("expected platform Kustomization at node layout")
+	}
+
+	bundleLayout := nodeLayout.Children[0]
+	if bundleLayout.Name != "platform" {
+		t.Fatalf("expected platform bundle layout, got %q", bundleLayout.Name)
+	}
+	bundleKustNames := map[string]bool{}
+	for _, r := range bundleLayout.Resources {
+		if k, ok := r.(*kustv1.Kustomization); ok {
+			bundleKustNames[k.Name] = true
+		}
+	}
+	if !bundleKustNames["infra"] {
+		t.Error("expected infra Kustomization at platform bundle layout")
+	}
+	if bundleKustNames["platform"] {
+		t.Error("umbrella self CR should NOT be at bundle layout")
+	}
+	if bundleKustNames["networking"] {
+		t.Error("nested grandchild CR should NOT be at platform bundle layout; it belongs at infra")
+	}
+
+	// infra umbrella child layout should have the networking Kustomization = 1
+	var infra *layout.ManifestLayout
+	for _, c := range bundleLayout.Children {
+		if c.UmbrellaChild && c.Name == "infra" {
+			infra = c
+		}
+	}
+	if infra == nil {
+		t.Fatal("missing infra umbrella child layout")
+	}
+	infraCount := 0
+	for _, r := range infra.Resources {
+		if k, ok := r.(*kustv1.Kustomization); ok {
+			infraCount++
+			if k.Name != "networking" {
+				t.Errorf("unexpected Kustomization at infra layout: %q", k.Name)
+			}
+		}
+	}
+	if infraCount != 1 {
+		t.Errorf("expected 1 Kustomization at infra layout, got %d", infraCount)
+	}
+}
+
+func TestCreateLayoutWithResources_UmbrellaChildWithSource(t *testing.T) {
+	// When an umbrella child has a SourceRef with URL, the Source CR should
+	// be placed at the parent layout alongside the child Kustomization.
+	umbrella := &stack.Bundle{
+		Name: "platform",
+		Children: []*stack.Bundle{
+			{
+				Name: "ext",
+				SourceRef: &stack.SourceRef{
+					Kind:   "GitRepository",
+					Name:   "ext-repo",
+					URL:    "https://github.com/example/ext",
+					Branch: "main",
+				},
+			},
+		},
+	}
+	node := &stack.Node{Name: "apps", Bundle: umbrella}
+	root := &stack.Node{Name: "root", Children: []*stack.Node{node}}
+	node.SetParent(root)
+	cluster := &stack.Cluster{Name: "demo", Node: root}
+
+	integrator := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	integrator.SetFluxPlacement(layout.FluxIntegrated)
+
+	ml, err := integrator.CreateLayoutWithResources(cluster, layout.LayoutRules{
+		BundleGrouping:      layout.GroupByName,
+		ApplicationGrouping: layout.GroupByName,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	bundleLayout := ml.Children[0].Children[0]
+	sawSource := false
+	for _, r := range bundleLayout.Resources {
+		if _, ok := r.(*sourcev1.GitRepository); ok {
+			sawSource = true
+		}
+	}
+	if !sawSource {
+		t.Error("expected umbrella child's GitRepository at parent bundle layout")
 	}
 }

--- a/pkg/stack/fluxcd/layout_integrator_test.go
+++ b/pkg/stack/fluxcd/layout_integrator_test.go
@@ -348,3 +348,22 @@ func TestLayoutIntegrator_SeparateMode_EmptyCluster(t *testing.T) {
 		}
 	}
 }
+
+func TestCreateLayoutWithResources_InvalidUmbrellaRejected(t *testing.T) {
+	// Shared pointer is both a child node Bundle and an umbrella child —
+	// ValidateCluster must reject.
+	shared := &stack.Bundle{Name: "shared"}
+	root := &stack.Node{
+		Name:   "root",
+		Bundle: &stack.Bundle{Name: "root", Children: []*stack.Bundle{shared}},
+		Children: []*stack.Node{
+			{Name: "child", Bundle: shared},
+		},
+	}
+	c := &stack.Cluster{Name: "c", Node: root}
+
+	integrator := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	if _, err := integrator.CreateLayoutWithResources(c, layout.LayoutRules{}); err == nil {
+		t.Fatal("expected invalid umbrella cluster to be rejected by CreateLayoutWithResources")
+	}
+}

--- a/pkg/stack/fluxcd/resource_generator.go
+++ b/pkg/stack/fluxcd/resource_generator.go
@@ -51,6 +51,9 @@ func (g *ResourceGenerator) GenerateFromCluster(c *stack.Cluster) ([]client.Obje
 }
 
 // GenerateFromNode creates Flux resources from a node and its children.
+// When a node's bundle is an umbrella (len(Bundle.Children) > 0), the umbrella
+// closure is walked and flattened into the returned slice so flat-list
+// consumers (e.g. separate Flux placement) see every child Kustomization CR.
 func (g *ResourceGenerator) GenerateFromNode(n *stack.Node) ([]client.Object, error) {
 	if n == nil {
 		return nil, nil
@@ -66,6 +69,17 @@ func (g *ResourceGenerator) GenerateFromNode(n *stack.Node) ([]client.Object, er
 				fmt.Sprintf("failed to generate bundle resources: %v", err), err)
 		}
 		resources = append(resources, bundleResources...)
+
+		// Walk umbrella closure so flat-list consumers see descendant CRs.
+		if len(n.Bundle.Children) > 0 {
+			n.Bundle.InitializeUmbrella()
+			closure, err := g.generateUmbrellaClosure(n.Bundle)
+			if err != nil {
+				return nil, errors.ResourceValidationError("Node", n.Name, "umbrella",
+					fmt.Sprintf("failed to generate umbrella closure: %v", err), err)
+			}
+			resources = append(resources, closure...)
+		}
 	}
 
 	// Generate resources for child nodes
@@ -81,7 +95,43 @@ func (g *ResourceGenerator) GenerateFromNode(n *stack.Node) ([]client.Object, er
 	return resources, nil
 }
 
-// GenerateFromBundle creates a Flux Kustomization from a bundle definition.
+// generateUmbrellaClosure walks a bundle's umbrella Children subtree and emits
+// a Kustomization (and, when URL is set, a Source) for every descendant. The
+// parent umbrella itself is NOT emitted here — callers handle it separately
+// via createKustomization / GenerateFromBundle. The walk is depth-first and
+// emits nested umbrella descendants in declaration order.
+func (g *ResourceGenerator) generateUmbrellaClosure(umbrella *stack.Bundle) ([]client.Object, error) {
+	var out []client.Object
+	for _, c := range umbrella.Children {
+		if c == nil {
+			continue
+		}
+		out = append(out, g.createKustomization(c))
+		if c.SourceRef != nil && c.SourceRef.URL != "" {
+			src, err := g.createSource(c.SourceRef, c.Name)
+			if err != nil {
+				return nil, errors.ResourceValidationError("Bundle", c.Name, "source",
+					fmt.Sprintf("failed to create source: %v", err), err)
+			}
+			if src != nil {
+				out = append(out, src)
+			}
+		}
+		if len(c.Children) > 0 {
+			nested, err := g.generateUmbrellaClosure(c)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, nested...)
+		}
+	}
+	return out, nil
+}
+
+// GenerateFromBundle creates Flux resources (Kustomization, and optionally a
+// Source) for b itself only. Umbrella Children are NOT recursed — callers that
+// need the closure should use GenerateFromNode, which walks the subtree, or
+// iterate b.Children directly.
 func (g *ResourceGenerator) GenerateFromBundle(b *stack.Bundle) ([]client.Object, error) {
 	if b == nil {
 		return nil, nil
@@ -169,17 +219,35 @@ func (g *ResourceGenerator) createKustomization(b *stack.Bundle) client.Object {
 		}
 	}
 
-	// Set health checks if specified
-	if len(b.HealthChecks) > 0 {
-		kust.Spec.HealthChecks = make([]metaapi.NamespacedObjectKindReference, 0, len(b.HealthChecks))
-		for _, hc := range b.HealthChecks {
+	// Umbrella bundles: force Wait=true and prepend auto HealthChecks for each
+	// child Kustomization. Validation has already rejected any explicit
+	// Wait=false when Children is non-empty, so this override is safe.
+	// User-supplied HealthChecks are appended AFTER the auto entries.
+	if len(b.Children) > 0 {
+		b.InitializeUmbrella()
+		kust.Spec.Wait = true
+		for _, child := range b.Children {
+			if child == nil {
+				continue
+			}
 			kust.Spec.HealthChecks = append(kust.Spec.HealthChecks, metaapi.NamespacedObjectKindReference{
-				APIVersion: hc.APIVersion,
-				Kind:       hc.Kind,
-				Name:       hc.Name,
-				Namespace:  hc.Namespace,
+				APIVersion: kustv1.GroupVersion.String(),
+				Kind:       "Kustomization",
+				Name:       child.Name,
+				Namespace:  g.DefaultNamespace,
 			})
 		}
+	}
+
+	// Append user-specified health checks. For umbrella bundles, these come
+	// AFTER the auto entries emitted above.
+	for _, hc := range b.HealthChecks {
+		kust.Spec.HealthChecks = append(kust.Spec.HealthChecks, metaapi.NamespacedObjectKindReference{
+			APIVersion: hc.APIVersion,
+			Kind:       hc.Kind,
+			Name:       hc.Name,
+			Namespace:  hc.Namespace,
+		})
 	}
 
 	// Add dependencies

--- a/pkg/stack/fluxcd/resource_generator.go
+++ b/pkg/stack/fluxcd/resource_generator.go
@@ -38,9 +38,14 @@ func NewResourceGenerator() *ResourceGenerator {
 }
 
 // GenerateFromCluster creates Flux Kustomizations and Sources from a cluster definition.
+// It runs stack.ValidateCluster first to fail fast on structural errors
+// (umbrella cycles, disjointness violations, etc.).
 func (g *ResourceGenerator) GenerateFromCluster(c *stack.Cluster) ([]client.Object, error) {
 	if c == nil || c.Node == nil {
 		return nil, nil
+	}
+	if err := stack.ValidateCluster(c); err != nil {
+		return nil, err
 	}
 	return g.GenerateFromNode(c.Node)
 }

--- a/pkg/stack/fluxcd/resource_generator_test.go
+++ b/pkg/stack/fluxcd/resource_generator_test.go
@@ -444,3 +444,30 @@ func TestGenerateFromCluster_InvalidUmbrellaRejected(t *testing.T) {
 		t.Fatal("expected invalid umbrella cluster to be rejected by GenerateFromCluster")
 	}
 }
+
+func TestGeneratePath_UmbrellaChild(t *testing.T) {
+	// Umbrella initialization wires child parent pointers, so the child's
+	// Kustomization path should reflect the umbrella hierarchy.
+	wf := fluxstack.EngineWithMode(layout.KustomizationExplicit)
+
+	umbrella := &stack.Bundle{
+		Name: "platform",
+		Children: []*stack.Bundle{
+			{Name: "infra"},
+		},
+	}
+
+	// Trigger InitializeUmbrella via GenerateFromBundle on the umbrella.
+	if _, err := wf.GenerateFromBundle(umbrella); err != nil {
+		t.Fatalf("umbrella generate: %v", err)
+	}
+
+	objs, err := wf.GenerateFromBundle(umbrella.Children[0])
+	if err != nil {
+		t.Fatalf("child generate: %v", err)
+	}
+	k := objs[0].(*kustv1.Kustomization)
+	if k.Spec.Path != "platform/infra" {
+		t.Errorf("Path = %q, want platform/infra", k.Spec.Path)
+	}
+}

--- a/pkg/stack/fluxcd/resource_generator_test.go
+++ b/pkg/stack/fluxcd/resource_generator_test.go
@@ -424,3 +424,23 @@ func TestBundlePath_MultiLevel(t *testing.T) {
 		t.Errorf("recursive Path = %q, want %q", k.Spec.Path, "cluster/infrastructure")
 	}
 }
+
+func TestGenerateFromCluster_InvalidUmbrellaRejected(t *testing.T) {
+	// Shared pointer is both a child node Bundle and an umbrella child —
+	// ValidateCluster must reject.
+	shared := &stack.Bundle{Name: "shared"}
+	root := &stack.Node{
+		Name:   "root",
+		Bundle: &stack.Bundle{Name: "root", Children: []*stack.Bundle{shared}},
+		Children: []*stack.Node{
+			{Name: "child", Bundle: shared},
+		},
+	}
+	c := &stack.Cluster{Name: "c", Node: root}
+
+	gen := fluxstack.NewResourceGenerator()
+	_, err := gen.GenerateFromCluster(c)
+	if err == nil {
+		t.Fatal("expected invalid umbrella cluster to be rejected by GenerateFromCluster")
+	}
+}

--- a/pkg/stack/layout/manifest.go
+++ b/pkg/stack/layout/manifest.go
@@ -269,10 +269,18 @@ func (ml *ManifestLayout) WriteToDisk(basePath string) error {
 		// Add child references
 		for _, child := range ml.Children {
 			if child.UmbrellaChild {
-				// Umbrella child: reference the child's Flux Kustomization CR
-				// YAML (placed in this parent directory), not the subdirectory.
-				fluxKustName := fmt.Sprintf("flux-system-kustomization-%s.yaml", child.Name)
-				writeStr(fmt.Sprintf("  - %s\n", fluxKustName))
+				// Umbrella children are not referenced from the parent
+				// kustomization.yaml's Children loop:
+				//   - FluxIntegrated: the child's Kustomization CR is
+				//     already in ml.Resources (placed there by the
+				//     LayoutIntegrator), so the Resources loop above
+				//     emits the filename exactly once.
+				//   - FluxSeparate: the child is applied by its own CR
+				//     under flux-system/ with spec.path pointing directly
+				//     at the child subdir, so the parent must not
+				//     reference it at all.
+				// The sub-layout is still walked below to write its
+				// workloads + own kustomization.yaml.
 				continue
 			}
 			if child.ApplicationFileMode == AppFileSingle {

--- a/pkg/stack/layout/manifest.go
+++ b/pkg/stack/layout/manifest.go
@@ -24,6 +24,13 @@ type ManifestLayout struct {
 	FluxPlacement       FluxPlacement // Track flux placement mode for kustomization generation
 	Resources           []client.Object
 	Children            []*ManifestLayout
+	// UmbrellaChild marks this layout as rendered from a Bundle.Children
+	// entry. When true, kustomization.yaml writers emit a
+	// flux-system-kustomization-{Name}.yaml reference in the parent directory
+	// (regardless of FluxPlacement), and the layout integrator places the
+	// child's Flux Kustomization CR at the parent layout node rather than in
+	// the child's own directory.
+	UmbrellaChild bool
 }
 
 func (ml *ManifestLayout) FullRepoPath() string {
@@ -261,6 +268,13 @@ func (ml *ManifestLayout) WriteToDisk(basePath string) error {
 
 		// Add child references
 		for _, child := range ml.Children {
+			if child.UmbrellaChild {
+				// Umbrella child: reference the child's Flux Kustomization CR
+				// YAML (placed in this parent directory), not the subdirectory.
+				fluxKustName := fmt.Sprintf("flux-system-kustomization-%s.yaml", child.Name)
+				writeStr(fmt.Sprintf("  - %s\n", fluxKustName))
+				continue
+			}
 			if child.ApplicationFileMode == AppFileSingle {
 				writeStr(fmt.Sprintf("  - %s.yaml\n", child.Name))
 			} else if ml.FluxPlacement == FluxIntegrated {

--- a/pkg/stack/layout/tar.go
+++ b/pkg/stack/layout/tar.go
@@ -117,10 +117,18 @@ func (ml *ManifestLayout) writeToTarRecursive(tw *tar.Writer, basePath string) e
 
 		for _, child := range ml.Children {
 			if child.UmbrellaChild {
-				// Umbrella child: reference the child's Flux Kustomization CR
-				// YAML (placed in this parent directory), not the subdirectory.
-				fluxKustName := fmt.Sprintf("flux-system-kustomization-%s.yaml", child.Name)
-				kustomBuf.WriteString(fmt.Sprintf("  - %s\n", fluxKustName))
+				// Umbrella children are not referenced from the parent
+				// kustomization.yaml's Children loop:
+				//   - FluxIntegrated: the child's Kustomization CR is
+				//     already in ml.Resources (placed there by the
+				//     LayoutIntegrator), so the Resources loop above
+				//     emits the filename exactly once.
+				//   - FluxSeparate: the child is applied by its own CR
+				//     under flux-system/ with spec.path pointing directly
+				//     at the child subdir, so the parent must not
+				//     reference it at all.
+				// The sub-layout is still walked below to write its
+				// workloads + own kustomization.yaml.
 				continue
 			}
 			if child.ApplicationFileMode == AppFileSingle {

--- a/pkg/stack/layout/tar.go
+++ b/pkg/stack/layout/tar.go
@@ -116,6 +116,13 @@ func (ml *ManifestLayout) writeToTarRecursive(tw *tar.Writer, basePath string) e
 		}
 
 		for _, child := range ml.Children {
+			if child.UmbrellaChild {
+				// Umbrella child: reference the child's Flux Kustomization CR
+				// YAML (placed in this parent directory), not the subdirectory.
+				fluxKustName := fmt.Sprintf("flux-system-kustomization-%s.yaml", child.Name)
+				kustomBuf.WriteString(fmt.Sprintf("  - %s\n", fluxKustName))
+				continue
+			}
 			if child.ApplicationFileMode == AppFileSingle {
 				kustomBuf.WriteString(fmt.Sprintf("  - %s.yaml\n", child.Name))
 			} else if ml.FluxPlacement == FluxIntegrated {

--- a/pkg/stack/layout/tar_test.go
+++ b/pkg/stack/layout/tar_test.go
@@ -11,6 +11,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -179,10 +180,23 @@ func TestWriteToTar_FluxIntegrated(t *testing.T) {
 }
 
 func TestWriteToTar_UmbrellaChild(t *testing.T) {
-	// Umbrella child layouts should cause the parent kustomization.yaml
-	// to reference flux-system-kustomization-{name}.yaml (regardless of
-	// FluxPlacement), and the child subdirectory should contain its own
-	// workloads + kustomization.yaml (no flux CR file).
+	// Mirrors the layout produced by the Flux LayoutIntegrator in
+	// FluxIntegrated mode: the umbrella parent carries the child's
+	// Kustomization CR in Resources (placed there by placeUmbrellaChildrenFlux),
+	// and an UmbrellaChild sub-layout in Children (carrying the child's
+	// workloads). Verifies:
+	//   1) The parent kustomization.yaml references the child CR filename
+	//      exactly once (duplication regression test — the Children-loop
+	//      UmbrellaChild branch used to emit the same entry a second time).
+	//   2) The umbrella child is NOT referenced as a plain subdirectory.
+	//   3) The child subdirectory contains its own workload + kustomization.yaml.
+	//   4) The child subdirectory does NOT contain any flux-system-kustomization-* file.
+	childKust := &unstructured.Unstructured{}
+	childKust.SetAPIVersion("kustomize.toolkit.fluxcd.io/v1")
+	childKust.SetKind("Kustomization")
+	childKust.SetName("infra")
+	childKust.SetNamespace("flux-system")
+
 	child := &ManifestLayout{
 		Name:          "infra",
 		Namespace:     "cl/apps/platform/infra",
@@ -202,6 +216,7 @@ func TestWriteToTar_UmbrellaChild(t *testing.T) {
 		Namespace: "cl/apps/platform",
 		FilePer:   FilePerResource,
 		Mode:      KustomizationExplicit,
+		Resources: []client.Object{childKust},
 		Children:  []*ManifestLayout{child},
 	}
 
@@ -219,8 +234,16 @@ func TestWriteToTar_UmbrellaChild(t *testing.T) {
 	if !bytes.Contains(parentKustom, []byte("flux-system-kustomization-infra.yaml")) {
 		t.Errorf("expected parent to reference flux-system-kustomization-infra.yaml, got:\n%s", parentKustom)
 	}
+	if got := bytes.Count(parentKustom, []byte("flux-system-kustomization-infra.yaml")); got != 1 {
+		t.Errorf("flux-system-kustomization-infra.yaml should appear exactly once in parent kustomization.yaml, got %d occurrences:\n%s", got, parentKustom)
+	}
 	if bytes.Contains(parentKustom, []byte("  - infra\n")) {
 		t.Errorf("umbrella child should NOT be referenced as plain subdirectory, got:\n%s", parentKustom)
+	}
+
+	// The parent directory also contains the child's Kustomization CR file.
+	if _, ok := files["cl/apps/platform/flux-system-kustomization-infra.yaml"]; !ok {
+		t.Errorf("missing child Kustomization CR file at parent layer, got: %v", fileNames(files))
 	}
 
 	// Child subdir contains workload + its own kustomization.yaml

--- a/pkg/stack/layout/tar_test.go
+++ b/pkg/stack/layout/tar_test.go
@@ -178,6 +178,71 @@ func TestWriteToTar_FluxIntegrated(t *testing.T) {
 	}
 }
 
+func TestWriteToTar_UmbrellaChild(t *testing.T) {
+	// Umbrella child layouts should cause the parent kustomization.yaml
+	// to reference flux-system-kustomization-{name}.yaml (regardless of
+	// FluxPlacement), and the child subdirectory should contain its own
+	// workloads + kustomization.yaml (no flux CR file).
+	child := &ManifestLayout{
+		Name:          "infra",
+		Namespace:     "cl/apps/platform/infra",
+		FilePer:       FilePerResource,
+		Mode:          KustomizationExplicit,
+		UmbrellaChild: true,
+		Resources: []client.Object{
+			&corev1.ConfigMap{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+				ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"},
+			},
+		},
+	}
+
+	parent := &ManifestLayout{
+		Name:      "platform",
+		Namespace: "cl/apps/platform",
+		FilePer:   FilePerResource,
+		Mode:      KustomizationExplicit,
+		Children:  []*ManifestLayout{child},
+	}
+
+	var buf bytes.Buffer
+	if err := parent.WriteToTar(&buf); err != nil {
+		t.Fatalf("WriteToTar failed: %v", err)
+	}
+
+	files := extractTarFiles(t, &buf)
+
+	parentKustom, ok := files["cl/apps/platform/kustomization.yaml"]
+	if !ok {
+		t.Fatalf("missing parent kustomization.yaml, got files: %v", fileNames(files))
+	}
+	if !bytes.Contains(parentKustom, []byte("flux-system-kustomization-infra.yaml")) {
+		t.Errorf("expected parent to reference flux-system-kustomization-infra.yaml, got:\n%s", parentKustom)
+	}
+	if bytes.Contains(parentKustom, []byte("  - infra\n")) {
+		t.Errorf("umbrella child should NOT be referenced as plain subdirectory, got:\n%s", parentKustom)
+	}
+
+	// Child subdir contains workload + its own kustomization.yaml
+	if _, ok := files["cl/apps/platform/infra/default-configmap-cfg.yaml"]; !ok {
+		t.Errorf("missing umbrella child workload file, got: %v", fileNames(files))
+	}
+	childKustom, ok := files["cl/apps/platform/infra/kustomization.yaml"]
+	if !ok {
+		t.Errorf("missing umbrella child kustomization.yaml, got: %v", fileNames(files))
+	}
+	if !bytes.Contains(childKustom, []byte("default-configmap-cfg.yaml")) {
+		t.Errorf("umbrella child kustomization should list workload file, got:\n%s", childKustom)
+	}
+
+	// The umbrella child subdir must NOT contain any flux-system-kustomization-* file
+	for name := range files {
+		if bytes.HasPrefix([]byte(name), []byte("cl/apps/platform/infra/flux-system-kustomization-")) {
+			t.Errorf("umbrella child subdir contains flux CR file it should not: %s", name)
+		}
+	}
+}
+
 // extractTarFiles reads all entries from a tar archive into a map.
 func extractTarFiles(t *testing.T, buf *bytes.Buffer) map[string][]byte {
 	t.Helper()

--- a/pkg/stack/layout/walker.go
+++ b/pkg/stack/layout/walker.go
@@ -100,6 +100,22 @@ func walkClusterWithClusterName(c *stack.Cluster, rules LayoutRules, nodeOnly bo
 			}
 		}
 
+		// Umbrella children of the root node's bundle become sub-layouts of
+		// the root node layout (cluster-name root dir → rootNode → children).
+		if len(c.Node.Bundle.Children) > 0 {
+			c.Node.Bundle.InitializeUmbrella()
+			umbrellaChildren, err := walkUmbrellaChildLayouts(
+				c.Node.Bundle.Children,
+				[]string{rules.ClusterName, c.Node.Name},
+				filePer,
+				rules.FluxPlacement,
+			)
+			if err != nil {
+				return nil, err
+			}
+			rootLayout.Children = append(rootLayout.Children, umbrellaChildren...)
+		}
+
 		clusterLayout.Children = append(clusterLayout.Children, rootLayout)
 	}
 
@@ -209,6 +225,16 @@ func walkNode(n *stack.Node, ancestors []string, nodeOnly bool, nodeFlat bool, f
 					ml.Resources = append(ml.Resources, *o)
 				}
 			}
+			// Umbrella: umbrella child sub-layouts live directly under the
+			// node layout in nodeOnly mode (no intermediate bundle layer).
+			if len(b.Children) > 0 {
+				b.InitializeUmbrella()
+				umbrellaChildren, err := walkUmbrellaChildLayouts(b.Children, currentPath, filePer, fluxPlacement)
+				if err != nil {
+					return nil, err
+				}
+				ml.Children = append(ml.Children, umbrellaChildren...)
+			}
 		}
 	} else {
 		var children []*ManifestLayout
@@ -237,6 +263,16 @@ func walkNode(n *stack.Node, ancestors []string, nodeOnly bool, nodeFlat bool, f
 					FluxPlacement: fluxPlacement,         // Pass flux placement mode
 				}
 				bundleChildren = append(bundleChildren, appLayout)
+			}
+			// Umbrella: umbrella child sub-layouts are siblings of application
+			// sub-layouts within the bundle's layout directory.
+			if len(b.Children) > 0 {
+				b.InitializeUmbrella()
+				umbrellaChildren, err := walkUmbrellaChildLayouts(b.Children, append(currentPath, b.Name), filePer, fluxPlacement)
+				if err != nil {
+					return nil, err
+				}
+				bundleChildren = append(bundleChildren, umbrellaChildren...)
 			}
 			bundleLayout := &ManifestLayout{
 				Name:          b.Name,
@@ -289,6 +325,55 @@ func walkNode(n *stack.Node, ancestors []string, nodeOnly bool, nodeFlat bool, f
 	}
 
 	return ml, nil
+}
+
+// walkUmbrellaChildLayouts renders a slice of umbrella Bundle.Children into a
+// flat ManifestLayout list. Each returned layout carries UmbrellaChild=true so
+// downstream writers emit a flux-system-kustomization-{Name}.yaml reference
+// in the parent directory instead of descending into a subdirectory for the
+// Flux CR. Child application resources are flattened into the child layout's
+// Resources (single-directory-per-child on disk). Nested umbrellas recurse so
+// grandchildren become sub-layouts of their immediate parent umbrella child.
+func walkUmbrellaChildLayouts(children []*stack.Bundle, currentPath []string, filePer FileExportMode, fluxPlacement FluxPlacement) ([]*ManifestLayout, error) {
+	var out []*ManifestLayout
+	for _, cb := range children {
+		if cb == nil {
+			continue
+		}
+		ml := &ManifestLayout{
+			Name:          cb.Name,
+			Namespace:     filepath.Join(currentPath...),
+			FilePer:       filePer,
+			FluxPlacement: fluxPlacement,
+			Mode:          KustomizationExplicit,
+			UmbrellaChild: true,
+		}
+		for _, app := range cb.Applications {
+			if app == nil {
+				continue
+			}
+			objsPtr, err := app.Generate()
+			if err != nil {
+				return nil, err
+			}
+			for _, o := range objsPtr {
+				if o == nil {
+					continue
+				}
+				ml.Resources = append(ml.Resources, *o)
+			}
+		}
+		if len(cb.Children) > 0 {
+			cb.InitializeUmbrella()
+			nested, err := walkUmbrellaChildLayouts(cb.Children, append(currentPath, cb.Name), filePer, fluxPlacement)
+			if err != nil {
+				return nil, err
+			}
+			ml.Children = append(ml.Children, nested...)
+		}
+		out = append(out, ml)
+	}
+	return out, nil
 }
 
 // resolvePackageRef returns the effective PackageRef for a node, using inheritance from parent

--- a/pkg/stack/layout/walker.go
+++ b/pkg/stack/layout/walker.go
@@ -19,6 +19,11 @@ func WalkCluster(c *stack.Cluster, rules LayoutRules) (*ManifestLayout, error) {
 		return nil, nil
 	}
 
+	// Fail fast on umbrella / disjointness / multi-package violations.
+	if err := stack.ValidateCluster(c); err != nil {
+		return nil, err
+	}
+
 	// Apply documented defaults for unset options.
 	def := DefaultLayoutRules()
 	if rules.NodeGrouping == GroupUnset {
@@ -120,6 +125,11 @@ func walkClusterWithClusterName(c *stack.Cluster, rules LayoutRules, nodeOnly bo
 func WalkClusterByPackage(c *stack.Cluster, rules LayoutRules) (map[string]*ManifestLayout, error) {
 	if c == nil || c.Node == nil {
 		return nil, nil
+	}
+
+	// Fail fast on umbrella / disjointness / multi-package violations.
+	if err := stack.ValidateCluster(c); err != nil {
+		return nil, err
 	}
 
 	// Apply documented defaults for unset options.

--- a/pkg/stack/layout/walker.go
+++ b/pkg/stack/layout/walker.go
@@ -63,8 +63,12 @@ func WalkCluster(c *stack.Cluster, rules LayoutRules) (*ManifestLayout, error) {
 	return ml, nil
 }
 
-// walkClusterWithClusterName creates a cluster-aware layout where the cluster name is the root
-// and all nodes (including the root node) become siblings underneath it.
+// walkClusterWithClusterName creates a cluster-aware layout where the cluster
+// name is the root directory and the root node (plus any child-node subtrees)
+// are nested underneath it. Child-node sub-layouts are placed under the root
+// node layout (not as cluster-level siblings) so their accumulated layout
+// path matches stack.Node.GetPath() — the Flux integrator's path-based lookup
+// relies on this correspondence.
 func walkClusterWithClusterName(c *stack.Cluster, rules LayoutRules, nodeOnly bool, filePer FileExportMode) (*ManifestLayout, error) {
 	// Create a cluster-level layout with the cluster name as the root
 	clusterLayout := &ManifestLayout{
@@ -74,15 +78,16 @@ func walkClusterWithClusterName(c *stack.Cluster, rules LayoutRules, nodeOnly bo
 		Children:  []*ManifestLayout{},
 	}
 
-	// Process the root node as a sibling (only its bundle, not children)
-	if c.Node.Bundle != nil {
-		rootLayout := &ManifestLayout{
-			Name:      c.Node.Name,
-			Namespace: filepath.Join(rules.ClusterName, c.Node.Name),
-			FilePer:   filePer,
-			Children:  []*ManifestLayout{},
-		}
+	// Build the root node layout. Done unconditionally (even when the root
+	// node has no Bundle) so child-node subtrees can be nested underneath it.
+	rootLayout := &ManifestLayout{
+		Name:      c.Node.Name,
+		Namespace: filepath.Join(rules.ClusterName, c.Node.Name),
+		FilePer:   filePer,
+		Children:  []*ManifestLayout{},
+	}
 
+	if c.Node.Bundle != nil {
 		// Add only the root node's bundle resources (not child resources)
 		for _, app := range c.Node.Bundle.Applications {
 			if app == nil {
@@ -115,21 +120,24 @@ func walkClusterWithClusterName(c *stack.Cluster, rules LayoutRules, nodeOnly bo
 			}
 			rootLayout.Children = append(rootLayout.Children, umbrellaChildren...)
 		}
-
-		clusterLayout.Children = append(clusterLayout.Children, rootLayout)
 	}
 
-	// Process all child nodes as siblings at the cluster level (with their own resources)
+	// Nest child-node sub-layouts under the root node layout so their
+	// accumulated path (clusterName/rootName/childName/...) matches
+	// stack.Node.GetPath() (rootName/childName/...) when the Flux integrator
+	// searches for the corresponding layout node.
 	nodeFlat := rules.NodeGrouping == GroupFlat
 	for _, child := range c.Node.Children {
-		childLayout, err := walkNode(child, []string{rules.ClusterName}, nodeOnly, nodeFlat, filePer, nil, rules.FluxPlacement)
+		childLayout, err := walkNode(child, []string{rules.ClusterName, c.Node.Name}, nodeOnly, nodeFlat, filePer, nil, rules.FluxPlacement)
 		if err != nil {
 			return nil, err
 		}
 		if childLayout != nil {
-			clusterLayout.Children = append(clusterLayout.Children, childLayout)
+			rootLayout.Children = append(rootLayout.Children, childLayout)
 		}
 	}
+
+	clusterLayout.Children = append(clusterLayout.Children, rootLayout)
 
 	return clusterLayout, nil
 }

--- a/pkg/stack/layout/walker_test.go
+++ b/pkg/stack/layout/walker_test.go
@@ -430,3 +430,37 @@ func TestWalkClusterByPackageDefaultPackage(t *testing.T) {
 		t.Fatalf("Default package child should be 'apps', got %s", defaultLayout.Children[0].Name)
 	}
 }
+
+func TestWalkCluster_InvalidUmbrellaRejected(t *testing.T) {
+	// Shared pointer is both a child node Bundle and an umbrella child —
+	// ValidateCluster must reject.
+	shared := &stack.Bundle{Name: "shared"}
+	root := &stack.Node{
+		Name:   "root",
+		Bundle: &stack.Bundle{Name: "root", Children: []*stack.Bundle{shared}},
+		Children: []*stack.Node{
+			{Name: "child", Bundle: shared},
+		},
+	}
+	c := &stack.Cluster{Name: "c", Node: root}
+
+	if _, err := layout.WalkCluster(c, layout.LayoutRules{}); err == nil {
+		t.Fatal("expected invalid umbrella cluster to be rejected by WalkCluster")
+	}
+}
+
+func TestWalkClusterByPackage_InvalidUmbrellaRejected(t *testing.T) {
+	shared := &stack.Bundle{Name: "shared"}
+	root := &stack.Node{
+		Name:   "root",
+		Bundle: &stack.Bundle{Name: "root", Children: []*stack.Bundle{shared}},
+		Children: []*stack.Node{
+			{Name: "child", Bundle: shared},
+		},
+	}
+	c := &stack.Cluster{Name: "c", Node: root}
+
+	if _, err := layout.WalkClusterByPackage(c, layout.LayoutRules{}); err == nil {
+		t.Fatal("expected invalid umbrella cluster to be rejected by WalkClusterByPackage")
+	}
+}

--- a/pkg/stack/layout/walker_test.go
+++ b/pkg/stack/layout/walker_test.go
@@ -464,3 +464,200 @@ func TestWalkClusterByPackage_InvalidUmbrellaRejected(t *testing.T) {
 		t.Fatal("expected invalid umbrella cluster to be rejected by WalkClusterByPackage")
 	}
 }
+
+// umbrellaObj returns a single-object ConfigMap the fakeConfig can emit.
+func umbrellaObj(name string) client.Object {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("v1")
+	u.SetKind("ConfigMap")
+	u.SetName(name)
+	u.SetNamespace("default")
+	return u
+}
+
+// makeUmbrellaApp builds a stack.Application whose Generate() returns the
+// given ConfigMap wrapped in the single-object slice the layout walker expects.
+func makeUmbrellaApp(appName, cmName string) *stack.Application {
+	o := umbrellaObj(cmName)
+	return stack.NewApplication(appName, "ns", &fakeConfig{objs: []*client.Object{&o}})
+}
+
+func TestWalkCluster_Umbrella_NonNodeOnly(t *testing.T) {
+	// In non-nodeOnly mode, umbrella children are siblings of application
+	// sub-layouts within the bundle layout.
+	parentApp := makeUmbrellaApp("parent-app", "cm-parent")
+	childApp := makeUmbrellaApp("child-app", "cm-child")
+
+	childBundle := &stack.Bundle{
+		Name:         "leaf",
+		Applications: []*stack.Application{childApp},
+	}
+	umbrella := &stack.Bundle{
+		Name:         "platform",
+		Applications: []*stack.Application{parentApp},
+		Children:     []*stack.Bundle{childBundle},
+	}
+	node := &stack.Node{Name: "apps", Bundle: umbrella}
+	root := &stack.Node{Name: "root", Children: []*stack.Node{node}}
+	node.SetParent(root)
+	cluster := &stack.Cluster{Name: "demo", Node: root}
+
+	ml, err := layout.WalkCluster(cluster, layout.LayoutRules{
+		BundleGrouping:      layout.GroupByName,
+		ApplicationGrouping: layout.GroupByName,
+	})
+	if err != nil {
+		t.Fatalf("walk cluster: %v", err)
+	}
+
+	// root -> apps -> platform bundle
+	if len(ml.Children) != 1 {
+		t.Fatalf("expected 1 node child, got %d", len(ml.Children))
+	}
+	nodeLayout := ml.Children[0]
+	if len(nodeLayout.Children) != 1 {
+		t.Fatalf("expected 1 bundle child, got %d", len(nodeLayout.Children))
+	}
+	bundleLayout := nodeLayout.Children[0]
+	if bundleLayout.Name != "platform" {
+		t.Fatalf("expected bundle name platform, got %q", bundleLayout.Name)
+	}
+
+	// bundle layout should contain parent-app (application) AND leaf (umbrella child)
+	if len(bundleLayout.Children) != 2 {
+		t.Fatalf("expected 2 children (parent-app + leaf), got %d", len(bundleLayout.Children))
+	}
+
+	var umbrellaChildLayout *layout.ManifestLayout
+	var appLayout *layout.ManifestLayout
+	for _, c := range bundleLayout.Children {
+		if c.UmbrellaChild {
+			umbrellaChildLayout = c
+		} else {
+			appLayout = c
+		}
+	}
+	if umbrellaChildLayout == nil {
+		t.Fatal("expected an UmbrellaChild sub-layout under the bundle")
+	}
+	if appLayout == nil {
+		t.Fatal("expected a non-UmbrellaChild application sub-layout under the bundle")
+	}
+	if umbrellaChildLayout.Name != "leaf" {
+		t.Errorf("umbrella child Name = %q, want %q", umbrellaChildLayout.Name, "leaf")
+	}
+	if umbrellaChildLayout.Namespace != "root/apps/platform" {
+		t.Errorf("umbrella child Namespace = %q, want root/apps/platform", umbrellaChildLayout.Namespace)
+	}
+	// Child workload should live in the umbrella child's Resources.
+	if len(umbrellaChildLayout.Resources) != 1 {
+		t.Errorf("expected 1 resource in umbrella child layout, got %d", len(umbrellaChildLayout.Resources))
+	}
+}
+
+func TestWalkCluster_Umbrella_NodeOnly(t *testing.T) {
+	// In nodeOnly mode (GroupFlat everywhere), umbrella child sub-layouts
+	// hang directly off the node layout with no intermediate bundle layer.
+	parentApp := makeUmbrellaApp("parent-app", "cm-parent")
+	childApp := makeUmbrellaApp("child-app", "cm-child")
+
+	childBundle := &stack.Bundle{
+		Name:         "leaf",
+		Applications: []*stack.Application{childApp},
+	}
+	umbrella := &stack.Bundle{
+		Name:         "platform",
+		Applications: []*stack.Application{parentApp},
+		Children:     []*stack.Bundle{childBundle},
+	}
+	node := &stack.Node{Name: "apps", Bundle: umbrella}
+	root := &stack.Node{Name: "root", Children: []*stack.Node{node}}
+	node.SetParent(root)
+	cluster := &stack.Cluster{Name: "demo", Node: root}
+
+	rules := layout.LayoutRules{
+		BundleGrouping:      layout.GroupFlat,
+		ApplicationGrouping: layout.GroupFlat,
+	}
+	ml, err := layout.WalkCluster(cluster, rules)
+	if err != nil {
+		t.Fatalf("walk cluster: %v", err)
+	}
+
+	if len(ml.Children) != 1 {
+		t.Fatalf("expected 1 node child, got %d", len(ml.Children))
+	}
+	nodeLayout := ml.Children[0]
+
+	// Node layout carries the parent app's resources directly (nodeOnly).
+	if len(nodeLayout.Resources) != 1 {
+		t.Errorf("expected 1 resource on node layout, got %d", len(nodeLayout.Resources))
+	}
+
+	// Umbrella child hangs directly off the node layout.
+	if len(nodeLayout.Children) != 1 {
+		t.Fatalf("expected 1 umbrella child, got %d", len(nodeLayout.Children))
+	}
+	uc := nodeLayout.Children[0]
+	if !uc.UmbrellaChild {
+		t.Error("expected UmbrellaChild=true on nodeOnly umbrella sub-layout")
+	}
+	if uc.Name != "leaf" {
+		t.Errorf("umbrella child Name = %q, want leaf", uc.Name)
+	}
+	// In nodeOnly mode, the umbrella child sits under the node path (no bundle layer).
+	if uc.Namespace != "root/apps" {
+		t.Errorf("umbrella child Namespace = %q, want root/apps", uc.Namespace)
+	}
+}
+
+func TestWalkCluster_Umbrella_Nested(t *testing.T) {
+	grandchildApp := makeUmbrellaApp("gc-app", "cm-gc")
+	grandchild := &stack.Bundle{
+		Name:         "networking",
+		Applications: []*stack.Application{grandchildApp},
+	}
+	child := &stack.Bundle{
+		Name:     "infra",
+		Children: []*stack.Bundle{grandchild},
+	}
+	umbrella := &stack.Bundle{
+		Name:     "platform",
+		Children: []*stack.Bundle{child},
+	}
+	node := &stack.Node{Name: "apps", Bundle: umbrella}
+	root := &stack.Node{Name: "root", Children: []*stack.Node{node}}
+	node.SetParent(root)
+	cluster := &stack.Cluster{Name: "demo", Node: root}
+
+	ml, err := layout.WalkCluster(cluster, layout.LayoutRules{
+		BundleGrouping:      layout.GroupByName,
+		ApplicationGrouping: layout.GroupByName,
+	})
+	if err != nil {
+		t.Fatalf("walk cluster: %v", err)
+	}
+
+	// root -> apps -> platform -> infra (UmbrellaChild) -> networking (UmbrellaChild)
+	bundleLayout := ml.Children[0].Children[0]
+	if bundleLayout.Name != "platform" {
+		t.Fatalf("expected platform bundle, got %q", bundleLayout.Name)
+	}
+	if len(bundleLayout.Children) != 1 {
+		t.Fatalf("expected 1 umbrella child, got %d", len(bundleLayout.Children))
+	}
+	infra := bundleLayout.Children[0]
+	if !infra.UmbrellaChild || infra.Name != "infra" {
+		t.Fatalf("expected infra as UmbrellaChild, got name=%q UmbrellaChild=%v", infra.Name, infra.UmbrellaChild)
+	}
+	if len(infra.Children) != 1 {
+		t.Fatalf("expected 1 nested umbrella child, got %d", len(infra.Children))
+	}
+	nw := infra.Children[0]
+	if !nw.UmbrellaChild || nw.Name != "networking" {
+		t.Fatalf("expected networking as nested UmbrellaChild, got name=%q UmbrellaChild=%v", nw.Name, nw.UmbrellaChild)
+	}
+	if nw.Namespace != "root/apps/platform/infra" {
+		t.Errorf("nested umbrella Namespace = %q, want root/apps/platform/infra", nw.Namespace)
+	}
+}

--- a/pkg/stack/layout/walker_test.go
+++ b/pkg/stack/layout/walker_test.go
@@ -209,6 +209,65 @@ func TestWalkClusterFlatRoot_DeepHierarchy(t *testing.T) {
 	}
 }
 
+// TestWalkCluster_ClusterNameWithChildNodes verifies that when rules.ClusterName
+// is set, child-node sub-layouts are nested under the root node layout (not as
+// siblings of it under the cluster-level layout). The Flux integrator's
+// path-based layout lookup uses stack.Node.GetPath() — e.g. "root/apps" for a
+// child named "apps" of a root named "root" — so the layout tree must mirror
+// that hierarchy.
+func TestWalkCluster_ClusterNameWithChildNodes(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("v1")
+	obj.SetKind("ConfigMap")
+	obj.SetName("cm")
+	obj.SetNamespace("default")
+	var o client.Object = obj
+
+	app := stack.NewApplication("app", "ns", &fakeConfig{objs: []*client.Object{&o}})
+	appsBundle := &stack.Bundle{Name: "apps-bundle", Applications: []*stack.Application{app}}
+	appsNode := &stack.Node{Name: "apps", Bundle: appsBundle}
+	rootBundle := &stack.Bundle{Name: "root-bundle"}
+	rootNode := &stack.Node{Name: "flux-system", Bundle: rootBundle, Children: []*stack.Node{appsNode}}
+	appsNode.SetParent(rootNode)
+	cluster := &stack.Cluster{Name: "demo", Node: rootNode}
+
+	rules := layout.DefaultLayoutRules()
+	rules.ClusterName = "demo"
+	ml, err := layout.WalkCluster(cluster, rules)
+	if err != nil {
+		t.Fatalf("walk cluster: %v", err)
+	}
+	if ml == nil {
+		t.Fatalf("nil layout returned")
+	}
+
+	// The cluster layout should contain exactly the root node layout —
+	// child nodes must NOT appear as siblings here.
+	if len(ml.Children) != 1 {
+		t.Fatalf("cluster layout should have exactly 1 child (root node), got %d", len(ml.Children))
+	}
+	rootLayout := ml.Children[0]
+	if rootLayout.Name != "flux-system" {
+		t.Fatalf("expected root layout name %q, got %q", "flux-system", rootLayout.Name)
+	}
+	if rootLayout.Namespace != "demo/flux-system" {
+		t.Fatalf("expected root layout namespace %q, got %q", "demo/flux-system", rootLayout.Namespace)
+	}
+
+	// The child node layout must be nested under rootLayout, not under
+	// clusterLayout — this is what the fix enforces.
+	if len(rootLayout.Children) != 1 {
+		t.Fatalf("root layout should have 1 child (apps node), got %d", len(rootLayout.Children))
+	}
+	appsLayout := rootLayout.Children[0]
+	if appsLayout.Name != "apps" {
+		t.Fatalf("expected apps layout name %q, got %q", "apps", appsLayout.Name)
+	}
+	if appsLayout.Namespace != "demo/flux-system" {
+		t.Fatalf("expected apps layout namespace %q, got %q", "demo/flux-system", appsLayout.Namespace)
+	}
+}
+
 func TestWalkClusterByPackage(t *testing.T) {
 	obj1 := &unstructured.Unstructured{}
 	obj1.SetAPIVersion("v1")

--- a/pkg/stack/layout/write.go
+++ b/pkg/stack/layout/write.go
@@ -135,10 +135,18 @@ func WriteManifest(basePath string, cfg Config, ml *ManifestLayout) error {
 		// Add child references
 		for _, child := range ml.Children {
 			if child.UmbrellaChild {
-				// Umbrella child: reference the child's Flux Kustomization CR
-				// YAML (placed in this parent directory), not the subdirectory.
-				fluxKustName := fmt.Sprintf("flux-system-kustomization-%s.yaml", child.Name)
-				writeStr(fmt.Sprintf("  - %s\n", fluxKustName))
+				// Umbrella children are not referenced from the parent
+				// kustomization.yaml's Children loop:
+				//   - FluxIntegrated: the child's Kustomization CR is
+				//     already in ml.Resources (placed there by the
+				//     LayoutIntegrator), so the Resources loop above
+				//     emits the filename exactly once.
+				//   - FluxSeparate: the child is applied by its own CR
+				//     under flux-system/ with spec.path pointing directly
+				//     at the child subdir, so the parent must not
+				//     reference it at all.
+				// The sub-layout is still walked below to write its
+				// workloads + own kustomization.yaml.
 				continue
 			}
 			if child.ApplicationFileMode == AppFileSingle {

--- a/pkg/stack/layout/write.go
+++ b/pkg/stack/layout/write.go
@@ -134,6 +134,13 @@ func WriteManifest(basePath string, cfg Config, ml *ManifestLayout) error {
 
 		// Add child references
 		for _, child := range ml.Children {
+			if child.UmbrellaChild {
+				// Umbrella child: reference the child's Flux Kustomization CR
+				// YAML (placed in this parent directory), not the subdirectory.
+				fluxKustName := fmt.Sprintf("flux-system-kustomization-%s.yaml", child.Name)
+				writeStr(fmt.Sprintf("  - %s\n", fluxKustName))
+				continue
+			}
 			if child.ApplicationFileMode == AppFileSingle {
 				writeStr(fmt.Sprintf("  - %s.yaml\n", child.Name))
 			} else {

--- a/pkg/stack/layout/write_test.go
+++ b/pkg/stack/layout/write_test.go
@@ -913,3 +913,64 @@ func TestWriteToDisk_KustomizationGenerated(t *testing.T) {
 		t.Errorf("kustomization missing service reference, got:\n%s", content)
 	}
 }
+
+func TestWriteManifest_UmbrellaChild(t *testing.T) {
+	// UmbrellaChild sub-layouts should cause the parent kustomization.yaml to
+	// emit flux-system-kustomization-{name}.yaml entries instead of a plain
+	// subdirectory reference, and each child subdir should still carry its
+	// own workloads and its own kustomization.yaml.
+	child := &ManifestLayout{
+		Name:          "infra",
+		Namespace:     "mycluster/apps/platform/infra",
+		UmbrellaChild: true,
+		Resources: []client.Object{
+			testObject("v1", "ConfigMap", "cfg", "default"),
+		},
+	}
+
+	parent := &ManifestLayout{
+		Name:      "platform",
+		Namespace: "mycluster/apps/platform",
+		Children:  []*ManifestLayout{child},
+	}
+
+	cfg := DefaultLayoutConfig()
+	dir := t.TempDir()
+	if err := WriteManifest(dir, cfg, parent); err != nil {
+		t.Fatalf("WriteManifest failed: %v", err)
+	}
+
+	parentKustom := filepath.Join(dir, "clusters", "mycluster", "apps", "platform", "kustomization.yaml")
+	data, err := os.ReadFile(parentKustom)
+	if err != nil {
+		t.Fatalf("failed to read parent kustomization.yaml: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "flux-system-kustomization-infra.yaml") {
+		t.Errorf("parent kustomization should reference flux-system-kustomization-infra.yaml, got:\n%s", content)
+	}
+	if strings.Contains(content, "\n  - infra\n") {
+		t.Errorf("umbrella child must NOT be referenced as plain subdirectory, got:\n%s", content)
+	}
+
+	// Child directory exists with its own workload + kustomization.yaml
+	childDir := filepath.Join(dir, "clusters", "mycluster", "apps", "platform", "infra")
+	if _, err := os.Stat(filepath.Join(childDir, "default-configmap-cfg.yaml")); err != nil {
+		t.Errorf("expected umbrella child workload file: %v", err)
+	}
+	childKustomPath := filepath.Join(childDir, "kustomization.yaml")
+	if _, err := os.Stat(childKustomPath); err != nil {
+		t.Errorf("expected umbrella child kustomization.yaml: %v", err)
+	}
+
+	// Child dir must NOT contain any flux-system-kustomization-* file.
+	entries, err := os.ReadDir(childDir)
+	if err != nil {
+		t.Fatalf("read child dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "flux-system-kustomization-") {
+			t.Errorf("umbrella child subdir contains flux CR file it should not: %s", e.Name())
+		}
+	}
+}

--- a/pkg/stack/layout/write_test.go
+++ b/pkg/stack/layout/write_test.go
@@ -915,10 +915,15 @@ func TestWriteToDisk_KustomizationGenerated(t *testing.T) {
 }
 
 func TestWriteManifest_UmbrellaChild(t *testing.T) {
-	// UmbrellaChild sub-layouts should cause the parent kustomization.yaml to
-	// emit flux-system-kustomization-{name}.yaml entries instead of a plain
-	// subdirectory reference, and each child subdir should still carry its
-	// own workloads and its own kustomization.yaml.
+	// Mirrors the layout produced by the Flux LayoutIntegrator in
+	// FluxIntegrated mode: the parent carries the child's Kustomization CR
+	// in Resources (via placeUmbrellaChildrenFlux) and an UmbrellaChild
+	// sub-layout in Children. Asserts the parent kustomization.yaml
+	// references the child CR filename exactly once (no duplication), and
+	// each child subdir carries its own workloads + own kustomization.yaml
+	// with no flux CR file.
+	childKustCR := testObject("kustomize.toolkit.fluxcd.io/v1", "Kustomization", "infra", "flux-system")
+
 	child := &ManifestLayout{
 		Name:          "infra",
 		Namespace:     "mycluster/apps/platform/infra",
@@ -931,6 +936,7 @@ func TestWriteManifest_UmbrellaChild(t *testing.T) {
 	parent := &ManifestLayout{
 		Name:      "platform",
 		Namespace: "mycluster/apps/platform",
+		Resources: []client.Object{childKustCR},
 		Children:  []*ManifestLayout{child},
 	}
 
@@ -949,8 +955,17 @@ func TestWriteManifest_UmbrellaChild(t *testing.T) {
 	if !strings.Contains(content, "flux-system-kustomization-infra.yaml") {
 		t.Errorf("parent kustomization should reference flux-system-kustomization-infra.yaml, got:\n%s", content)
 	}
+	if got := strings.Count(content, "flux-system-kustomization-infra.yaml"); got != 1 {
+		t.Errorf("flux-system-kustomization-infra.yaml should appear exactly once in parent kustomization.yaml, got %d occurrences:\n%s", got, content)
+	}
 	if strings.Contains(content, "\n  - infra\n") {
 		t.Errorf("umbrella child must NOT be referenced as plain subdirectory, got:\n%s", content)
+	}
+
+	// Parent directory also contains the child's Kustomization CR file.
+	parentCRFile := filepath.Join(dir, "clusters", "mycluster", "apps", "platform", "flux-system-kustomization-infra.yaml")
+	if _, err := os.Stat(parentCRFile); err != nil {
+		t.Errorf("expected child Kustomization CR file at parent layer: %v", err)
 	}
 
 	// Child directory exists with its own workload + kustomization.yaml

--- a/pkg/stack/v1alpha1/bundle.go
+++ b/pkg/stack/v1alpha1/bundle.go
@@ -29,6 +29,14 @@ type BundleSpec struct {
 	// DependsOn lists other bundles this bundle depends on
 	DependsOn []BundleReference `yaml:"dependsOn,omitempty" json:"dependsOn,omitempty"`
 
+	// Children lists bundles whose Flux Kustomization CRs are rendered into
+	// this bundle's directory and whose readiness is aggregated into this
+	// bundle's HealthChecks. When non-empty, this bundle acts as an umbrella.
+	// Children bundles must be standalone — they cannot simultaneously be
+	// attached as the Bundle of any Node. Setting Wait=false on a bundle
+	// with Children is a validation error.
+	Children []BundleReference `yaml:"children,omitempty" json:"children,omitempty"`
+
 	// Interval controls how often Flux reconciles the bundle
 	// Supports Go duration format (e.g., "5m", "1h", "30s", "1h30m")
 	// Valid range: 1s to 24h. Empty value uses system defaults.
@@ -271,6 +279,31 @@ func (b *BundleConfig) Validate() error {
 				fmt.Sprintf("duplicate dependency: %s", dep.Name), nil)
 		}
 		depNames[dep.Name] = true
+	}
+
+	// Local umbrella children checks. Deep cycle detection happens after the
+	// tree is reconstructed in ConvertV1Alpha1ToClusterTree via ValidateCluster.
+	// Wait=false + non-empty Children contradiction also lives in the
+	// unversioned Bundle.Validate — this block only checks local name rules.
+	childNames := make(map[string]bool)
+	for _, child := range b.Spec.Children {
+		if child.Name == "" {
+			return errors.ResourceValidationError("Bundle", b.Metadata.Name, "spec.children",
+				"child name cannot be empty", nil)
+		}
+		if child.Name == b.Metadata.Name {
+			return errors.ResourceValidationError("Bundle", b.Metadata.Name, "spec.children",
+				"bundle cannot be its own child", nil)
+		}
+		if childNames[child.Name] {
+			return errors.ResourceValidationError("Bundle", b.Metadata.Name, "spec.children",
+				fmt.Sprintf("duplicate child: %s", child.Name), nil)
+		}
+		if depNames[child.Name] {
+			return errors.ResourceValidationError("Bundle", b.Metadata.Name, "spec.children",
+				fmt.Sprintf("child %q also appears in dependsOn", child.Name), nil)
+		}
+		childNames[child.Name] = true
 	}
 
 	return nil

--- a/pkg/stack/v1alpha1/bundle_test.go
+++ b/pkg/stack/v1alpha1/bundle_test.go
@@ -177,6 +177,79 @@ func TestBundleConfig(t *testing.T) {
 			wantErr: true,
 			errMsg:  "nil",
 		},
+		{
+			name: "umbrella with children",
+			bundle: &BundleConfig{
+				APIVersion: "stack.gokure.dev/v1alpha1",
+				Kind:       "Bundle",
+				Metadata: gvk.BaseMetadata{
+					Name: "umbrella",
+				},
+				Spec: BundleSpec{
+					Children: []BundleReference{
+						{Name: "child1"},
+						{Name: "child2"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty child name",
+			bundle: &BundleConfig{
+				APIVersion: "stack.gokure.dev/v1alpha1",
+				Kind:       "Bundle",
+				Metadata:   gvk.BaseMetadata{Name: "umbrella"},
+				Spec: BundleSpec{
+					Children: []BundleReference{{Name: ""}},
+				},
+			},
+			wantErr: true,
+			errMsg:  "child name cannot be empty",
+		},
+		{
+			name: "self as child",
+			bundle: &BundleConfig{
+				APIVersion: "stack.gokure.dev/v1alpha1",
+				Kind:       "Bundle",
+				Metadata:   gvk.BaseMetadata{Name: "umbrella"},
+				Spec: BundleSpec{
+					Children: []BundleReference{{Name: "umbrella"}},
+				},
+			},
+			wantErr: true,
+			errMsg:  "cannot be its own child",
+		},
+		{
+			name: "duplicate child",
+			bundle: &BundleConfig{
+				APIVersion: "stack.gokure.dev/v1alpha1",
+				Kind:       "Bundle",
+				Metadata:   gvk.BaseMetadata{Name: "umbrella"},
+				Spec: BundleSpec{
+					Children: []BundleReference{
+						{Name: "child1"},
+						{Name: "child1"},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "duplicate child",
+		},
+		{
+			name: "child overlaps with dependsOn",
+			bundle: &BundleConfig{
+				APIVersion: "stack.gokure.dev/v1alpha1",
+				Kind:       "Bundle",
+				Metadata:   gvk.BaseMetadata{Name: "umbrella"},
+				Spec: BundleSpec{
+					DependsOn: []BundleReference{{Name: "shared"}},
+					Children:  []BundleReference{{Name: "shared"}},
+				},
+			},
+			wantErr: true,
+			errMsg:  "also appears in dependsOn",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/stack/v1alpha1/converters.go
+++ b/pkg/stack/v1alpha1/converters.go
@@ -346,15 +346,17 @@ func (c *StackConverter) convertNodeTreeToV1Alpha1(node *stack.Node, nodes *[]*N
 	}
 }
 
-// ConvertV1Alpha1ToClusterTree converts versioned configs back to a cluster tree
+// ConvertV1Alpha1ToClusterTree converts versioned configs back to a cluster tree.
+// It calls stack.ValidateCluster at the end so round-tripped umbrella errors
+// surface at decode time rather than leaking into downstream code.
 func (c *StackConverter) ConvertV1Alpha1ToClusterTree(
 	clusterConfig *ClusterConfig,
 	nodeConfigs []*NodeConfig,
 	bundleConfigs []*BundleConfig,
 	applications []*stack.Application,
-) *stack.Cluster {
+) (*stack.Cluster, error) {
 	if clusterConfig == nil {
-		return nil
+		return nil, nil
 	}
 
 	// Build maps for lookup
@@ -425,5 +427,9 @@ func (c *StackConverter) ConvertV1Alpha1ToClusterTree(
 		}
 	}
 
-	return cluster
+	if err := stack.ValidateCluster(cluster); err != nil {
+		return nil, err
+	}
+
+	return cluster, nil
 }

--- a/pkg/stack/v1alpha1/converters.go
+++ b/pkg/stack/v1alpha1/converters.go
@@ -212,6 +212,16 @@ func ConvertBundleToV1Alpha1(b *stack.Bundle) *BundleConfig {
 		}
 	}
 
+	// Convert umbrella children
+	for _, ch := range b.Children {
+		if ch != nil {
+			config.Spec.Children = append(config.Spec.Children, BundleReference{
+				Name:       ch.Name,
+				APIVersion: "stack.gokure.dev/v1alpha1",
+			})
+		}
+	}
+
 	// Convert applications
 	for _, app := range b.Applications {
 		if app != nil {
@@ -250,6 +260,15 @@ func ConvertV1Alpha1ToBundle(config *BundleConfig) *stack.Bundle {
 		Wait:          &wait,
 		Timeout:       config.Spec.Timeout,
 		RetryInterval: config.Spec.RetryInterval,
+	}
+
+	// Umbrella bundles always run with Wait=true (createKustomization forces
+	// it at CR generation time). Since BundleSpec.Wait is a plain bool, an
+	// unset field decodes as false — which would trigger the umbrella
+	// "Wait=false" validation error on the reverse path. Leave Wait nil for
+	// umbrellas so validation sees it as "not set" and CR generation fills it.
+	if len(config.Spec.Children) > 0 {
+		b.Wait = nil
 	}
 
 	// Convert source ref
@@ -291,6 +310,11 @@ type StackConverter struct {
 
 	// appMap maps application references to their actual applications
 	appMap map[string]*stack.Application
+
+	// visited tracks bundle pointers already emitted during a tree walk so
+	// umbrella descendants shared between node bundles are emitted exactly
+	// once.
+	visited map[*stack.Bundle]bool
 }
 
 // NewStackConverter creates a new stack converter
@@ -299,6 +323,7 @@ func NewStackConverter() *StackConverter {
 		nodeMap:   make(map[string]*NodeConfig),
 		bundleMap: make(map[string]*BundleConfig),
 		appMap:    make(map[string]*stack.Application),
+		visited:   make(map[*stack.Bundle]bool),
 	}
 }
 
@@ -333,16 +358,36 @@ func (c *StackConverter) convertNodeTreeToV1Alpha1(node *stack.Node, nodes *[]*N
 	*nodes = append(*nodes, nodeConfig)
 	c.nodeMap[node.Name] = nodeConfig
 
-	// Convert bundle if present
-	if node.Bundle != nil {
+	// Convert bundle if present, plus any umbrella descendants reachable
+	// from it. Visited-pointer dedup prevents emitting the same umbrella
+	// child twice if the tree references it from multiple node bundles.
+	if node.Bundle != nil && !c.visited[node.Bundle] {
+		c.visited[node.Bundle] = true
 		bundleConfig := ConvertBundleToV1Alpha1(node.Bundle)
 		*bundles = append(*bundles, bundleConfig)
 		c.bundleMap[node.Bundle.Name] = bundleConfig
+		c.emitUmbrellaDescendants(node.Bundle, bundles)
 	}
 
 	// Recursively convert children
 	for _, child := range node.Children {
 		c.convertNodeTreeToV1Alpha1(child, nodes, bundles)
+	}
+}
+
+// emitUmbrellaDescendants walks a bundle's umbrella Children subtree and
+// appends a BundleConfig for each descendant, skipping any bundle pointer
+// already emitted.
+func (c *StackConverter) emitUmbrellaDescendants(b *stack.Bundle, bundles *[]*BundleConfig) {
+	for _, ch := range b.Children {
+		if ch == nil || c.visited[ch] {
+			continue
+		}
+		c.visited[ch] = true
+		childConfig := ConvertBundleToV1Alpha1(ch)
+		*bundles = append(*bundles, childConfig)
+		c.bundleMap[ch.Name] = childConfig
+		c.emitUmbrellaDescendants(ch, bundles)
 	}
 }
 
@@ -387,6 +432,16 @@ func (c *StackConverter) ConvertV1Alpha1ToClusterTree(
 		for _, depRef := range bundleConfig.Spec.DependsOn {
 			if dep, exists := bundleMap[depRef.Name]; exists {
 				bundle.DependsOn = append(bundle.DependsOn, dep)
+			}
+		}
+	}
+
+	// Resolve umbrella children
+	for _, bundleConfig := range bundleConfigs {
+		bundle := bundleMap[bundleConfig.Metadata.Name]
+		for _, childRef := range bundleConfig.Spec.Children {
+			if ch, exists := bundleMap[childRef.Name]; exists {
+				bundle.Children = append(bundle.Children, ch)
 			}
 		}
 	}

--- a/pkg/stack/v1alpha1/converters_test.go
+++ b/pkg/stack/v1alpha1/converters_test.go
@@ -1083,6 +1083,182 @@ func TestSourceRefRoundTrip(t *testing.T) {
 	}
 }
 
+func TestConvertBundleToV1Alpha1_EmitsChildren(t *testing.T) {
+	// Forward conversion should populate Spec.Children from Bundle.Children.
+	b := &stack.Bundle{
+		Name: "platform",
+		Children: []*stack.Bundle{
+			{Name: "infra"},
+			{Name: "services"},
+			nil,
+		},
+	}
+
+	config := ConvertBundleToV1Alpha1(b)
+	if config == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if got, want := len(config.Spec.Children), 2; got != want {
+		t.Fatalf("expected %d children (nil filtered), got %d", want, got)
+	}
+	names := map[string]bool{}
+	for _, c := range config.Spec.Children {
+		names[c.Name] = true
+		if c.APIVersion != "stack.gokure.dev/v1alpha1" {
+			t.Errorf("child %q has wrong APIVersion: %q", c.Name, c.APIVersion)
+		}
+	}
+	if !names["infra"] || !names["services"] {
+		t.Errorf("missing child names, got: %v", names)
+	}
+}
+
+func TestConvertClusterTreeToV1Alpha1_EmitsUmbrellaDescendants(t *testing.T) {
+	// The node tree walk should emit BundleConfigs for umbrella descendants,
+	// deduplicated via a visited pointer set.
+	grandchild := &stack.Bundle{Name: "networking"}
+	infra := &stack.Bundle{
+		Name:     "infra",
+		Children: []*stack.Bundle{grandchild},
+	}
+	services := &stack.Bundle{Name: "services"}
+	umbrella := &stack.Bundle{
+		Name:     "platform",
+		Children: []*stack.Bundle{infra, services},
+	}
+
+	cluster := &stack.Cluster{
+		Name: "demo",
+		Node: &stack.Node{
+			Name:   "root",
+			Bundle: umbrella,
+		},
+	}
+
+	converter := NewStackConverter()
+	_, _, bundleConfigs := converter.ConvertClusterTreeToV1Alpha1(cluster)
+
+	// Expect platform + infra + services + networking = 4 bundles, each emitted once.
+	names := map[string]int{}
+	for _, bc := range bundleConfigs {
+		names[bc.Metadata.Name]++
+	}
+	for _, want := range []string{"platform", "infra", "services", "networking"} {
+		if names[want] != 1 {
+			t.Errorf("expected exactly 1 BundleConfig for %q, got %d", want, names[want])
+		}
+	}
+
+	// Verify Children are populated on the umbrella configs
+	var platformConfig, infraConfig *BundleConfig
+	for _, bc := range bundleConfigs {
+		switch bc.Metadata.Name {
+		case "platform":
+			platformConfig = bc
+		case "infra":
+			infraConfig = bc
+		}
+	}
+	if platformConfig == nil {
+		t.Fatal("missing platform BundleConfig")
+	}
+	if len(platformConfig.Spec.Children) != 2 {
+		t.Errorf("expected platform to have 2 Children refs, got %d", len(platformConfig.Spec.Children))
+	}
+	if infraConfig == nil {
+		t.Fatal("missing infra BundleConfig")
+	}
+	if len(infraConfig.Spec.Children) != 1 || infraConfig.Spec.Children[0].Name != "networking" {
+		t.Errorf("expected infra to have child networking, got %+v", infraConfig.Spec.Children)
+	}
+}
+
+func TestConvertV1Alpha1ToClusterTree_ReconstructsChildren(t *testing.T) {
+	// Reverse conversion should resolve Spec.Children into *Bundle pointers
+	// and ValidateCluster should accept the well-formed tree.
+	clusterConfig := &ClusterConfig{
+		Metadata: gvk.BaseMetadata{Name: "demo"},
+		Spec: ClusterSpec{
+			Node: &NodeReference{Name: "root"},
+		},
+	}
+	nodeConfigs := []*NodeConfig{
+		{
+			Metadata: gvk.BaseMetadata{Name: "root"},
+			Spec:     NodeSpec{Bundle: &BundleReference{Name: "platform"}},
+		},
+	}
+	bundleConfigs := []*BundleConfig{
+		{
+			Metadata: gvk.BaseMetadata{Name: "platform"},
+			Spec: BundleSpec{
+				Children: []BundleReference{
+					{Name: "infra"},
+					{Name: "services"},
+				},
+			},
+		},
+		{Metadata: gvk.BaseMetadata{Name: "infra"}},
+		{Metadata: gvk.BaseMetadata{Name: "services"}},
+	}
+
+	converter := NewStackConverter()
+	cluster, err := converter.ConvertV1Alpha1ToClusterTree(clusterConfig, nodeConfigs, bundleConfigs, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cluster == nil || cluster.Node == nil || cluster.Node.Bundle == nil {
+		t.Fatal("expected reconstructed cluster with root bundle")
+	}
+	platform := cluster.Node.Bundle
+	if len(platform.Children) != 2 {
+		t.Fatalf("expected 2 umbrella children, got %d", len(platform.Children))
+	}
+	if platform.Children[0].Name != "infra" || platform.Children[1].Name != "services" {
+		t.Errorf("unexpected child names: %q, %q",
+			platform.Children[0].Name, platform.Children[1].Name)
+	}
+}
+
+func TestConvertV1Alpha1ToClusterTree_InvalidUmbrellaRejected(t *testing.T) {
+	// Round-tripping an invalid umbrella (same bundle name as both a Node
+	// bundle and an umbrella child) must fail at ValidateCluster.
+	clusterConfig := &ClusterConfig{
+		Metadata: gvk.BaseMetadata{Name: "demo"},
+		Spec: ClusterSpec{
+			Node: &NodeReference{Name: "root"},
+		},
+	}
+	nodeConfigs := []*NodeConfig{
+		{
+			Metadata: gvk.BaseMetadata{Name: "root"},
+			Spec: NodeSpec{
+				Bundle:   &BundleReference{Name: "platform"},
+				Children: []NodeReference{{Name: "child"}},
+			},
+		},
+		{
+			Metadata: gvk.BaseMetadata{Name: "child"},
+			// The "shared" bundle is referenced as a Node's Bundle AND as
+			// an umbrella child of platform — ValidateCluster must reject.
+			Spec: NodeSpec{Bundle: &BundleReference{Name: "shared"}},
+		},
+	}
+	bundleConfigs := []*BundleConfig{
+		{
+			Metadata: gvk.BaseMetadata{Name: "platform"},
+			Spec:     BundleSpec{Children: []BundleReference{{Name: "shared"}}},
+		},
+		{Metadata: gvk.BaseMetadata{Name: "shared"}},
+	}
+
+	converter := NewStackConverter()
+	_, err := converter.ConvertV1Alpha1ToClusterTree(clusterConfig, nodeConfigs, bundleConfigs, nil)
+	if err == nil {
+		t.Fatal("expected ValidateCluster to reject shared umbrella/node bundle")
+	}
+}
+
 func TestHealthChecksRoundTrip(t *testing.T) {
 	original := &stack.Bundle{
 		Name: "hc-bundle",

--- a/pkg/stack/v1alpha1/converters_test.go
+++ b/pkg/stack/v1alpha1/converters_test.go
@@ -706,7 +706,10 @@ func TestStackConverter_ConvertV1Alpha1ToClusterTree(t *testing.T) {
 	}
 
 	converter := NewStackConverter()
-	cluster := converter.ConvertV1Alpha1ToClusterTree(clusterConfig, nodeConfigs, bundleConfigs, applications)
+	cluster, err := converter.ConvertV1Alpha1ToClusterTree(clusterConfig, nodeConfigs, bundleConfigs, applications)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// Verify cluster
 	if cluster == nil {
@@ -776,7 +779,10 @@ func TestStackConverter_HandleNilValues(t *testing.T) {
 	})
 
 	t.Run("nil cluster config", func(t *testing.T) {
-		cluster := converter.ConvertV1Alpha1ToClusterTree(nil, nil, nil, nil)
+		cluster, err := converter.ConvertV1Alpha1ToClusterTree(nil, nil, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if cluster != nil {
 			t.Error("expected nil cluster for nil config")
 		}
@@ -786,7 +792,10 @@ func TestStackConverter_HandleNilValues(t *testing.T) {
 		clusterConfig := &ClusterConfig{
 			Metadata: gvk.BaseMetadata{Name: "empty"},
 		}
-		cluster := converter.ConvertV1Alpha1ToClusterTree(clusterConfig, []*NodeConfig{}, []*BundleConfig{}, []*stack.Application{})
+		cluster, err := converter.ConvertV1Alpha1ToClusterTree(clusterConfig, []*NodeConfig{}, []*BundleConfig{}, []*stack.Application{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
 		if cluster == nil {
 			t.Fatal("expected non-nil cluster")
@@ -1009,7 +1018,7 @@ func BenchmarkConvertV1Alpha1ToClusterTree(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		converter.ConvertV1Alpha1ToClusterTree(clusterConfig, nodeConfigs, bundleConfigs, applications)
+		_, _ = converter.ConvertV1Alpha1ToClusterTree(clusterConfig, nodeConfigs, bundleConfigs, applications)
 	}
 }
 

--- a/pkg/stack/validate.go
+++ b/pkg/stack/validate.go
@@ -1,0 +1,113 @@
+package stack
+
+import (
+	"fmt"
+
+	"github.com/go-kure/kure/pkg/errors"
+)
+
+// ValidateCluster performs cluster-level structural validation that cannot be
+// expressed on a single Bundle alone. It is the single validation entry point
+// shared by the resource generator, layout walker, layout integrator, and the
+// v1alpha1 converter round-trip.
+//
+// It enforces:
+//  1. Every Node bundle passes Bundle.Validate (which recursively validates
+//     umbrella Children subtrees including cycle detection).
+//  2. Disjointness: a bundle pointer appearing inside any umbrella Children
+//     subtree must NOT also be attached as the Bundle of any stack.Node.
+//  3. No umbrella child pointer is shared by two distinct umbrella parents.
+//  4. Multi-package rejection: if any Node has a PackageRef set and any
+//     bundle in the cluster has umbrella Children, the cluster is rejected.
+//     Cross-package umbrella semantics are follow-up work.
+//
+// ValidateCluster is safe to call with a nil cluster or a cluster with no
+// root node (it returns nil in both cases).
+func ValidateCluster(c *Cluster) error {
+	if c == nil || c.Node == nil {
+		return nil
+	}
+
+	// Collect every bundle pointer that is attached to a Node.
+	nodeBundles := make(map[*Bundle]*Node)
+	var walkNodes func(*Node)
+	walkNodes = func(n *Node) {
+		if n == nil {
+			return
+		}
+		if n.Bundle != nil {
+			nodeBundles[n.Bundle] = n
+		}
+		for _, ch := range n.Children {
+			walkNodes(ch)
+		}
+	}
+	walkNodes(c.Node)
+
+	// 1. Validate every Node bundle. Bundle.Validate recursively walks the
+	//    umbrella Children subtree.
+	for b := range nodeBundles {
+		if err := b.Validate(); err != nil {
+			return errors.Wrapf(err, "bundle %q failed validation", b.Name)
+		}
+	}
+
+	// 2 & 3. Walk every umbrella Children subtree to check disjointness with
+	// the Node tree and no shared umbrella ownership.
+	umbrellaOwnership := make(map[*Bundle]*Bundle)
+	var collectUmbrella func(owner, b *Bundle) error
+	collectUmbrella = func(owner, b *Bundle) error {
+		for _, child := range b.Children {
+			if child == nil {
+				continue
+			}
+			if _, isNode := nodeBundles[child]; isNode {
+				return errors.ResourceValidationError("Cluster", c.Name, "bundles",
+					fmt.Sprintf("bundle %q is referenced by umbrella %q but also attached to a Node", child.Name, owner.Name),
+					nil)
+			}
+			if prev, dup := umbrellaOwnership[child]; dup && prev != owner {
+				return errors.ResourceValidationError("Cluster", c.Name, "bundles",
+					fmt.Sprintf("bundle %q is child of two umbrellas: %q and %q", child.Name, prev.Name, owner.Name),
+					nil)
+			}
+			umbrellaOwnership[child] = owner
+			if err := collectUmbrella(owner, child); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for nb := range nodeBundles {
+		if err := collectUmbrella(nb, nb); err != nil {
+			return err
+		}
+	}
+
+	// 4. Multi-package rejection: umbrella + PackageRef is out of scope for
+	// this initial patch.
+	if len(umbrellaOwnership) > 0 {
+		hasPackageRef := false
+		var scanPkg func(*Node)
+		scanPkg = func(n *Node) {
+			if n == nil || hasPackageRef {
+				return
+			}
+			if n.PackageRef != nil {
+				hasPackageRef = true
+				return
+			}
+			for _, ch := range n.Children {
+				scanPkg(ch)
+			}
+		}
+		scanPkg(c.Node)
+		if hasPackageRef {
+			return errors.ResourceValidationError("Cluster", c.Name, "bundles",
+				"umbrella bundles (Bundle.Children) are not supported with multi-package PackageRef in this release",
+				nil)
+		}
+	}
+
+	return nil
+}

--- a/pkg/stack/validate_test.go
+++ b/pkg/stack/validate_test.go
@@ -1,0 +1,95 @@
+package stack
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestValidateCluster_Nil(t *testing.T) {
+	if err := ValidateCluster(nil); err != nil {
+		t.Errorf("nil cluster should pass: %v", err)
+	}
+	if err := ValidateCluster(&Cluster{Name: "c"}); err != nil {
+		t.Errorf("cluster with nil Node should pass: %v", err)
+	}
+}
+
+func TestValidateCluster_HappyUmbrella(t *testing.T) {
+	child := &Bundle{Name: "child"}
+	root := &Bundle{Name: "root", Children: []*Bundle{child}}
+	c := &Cluster{Name: "c", Node: &Node{Name: "n", Bundle: root}}
+	if err := ValidateCluster(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateCluster_ChildAlsoNodeRejected(t *testing.T) {
+	sharedBundle := &Bundle{Name: "shared"}
+	// Build a cluster where "shared" is both the child node's Bundle and an
+	// umbrella child of the root node's bundle.
+	rootBundle := &Bundle{Name: "root", Children: []*Bundle{sharedBundle}}
+	root := &Node{
+		Name:   "root-node",
+		Bundle: rootBundle,
+		Children: []*Node{
+			{Name: "child-node", Bundle: sharedBundle},
+		},
+	}
+	c := &Cluster{Name: "c", Node: root}
+	if err := ValidateCluster(c); err == nil {
+		t.Fatal("expected overlap between node bundle and umbrella child to fail")
+	}
+}
+
+func TestValidateCluster_SharedChildBetweenUmbrellasRejected(t *testing.T) {
+	shared := &Bundle{Name: "shared"}
+	u1 := &Bundle{Name: "u1", Children: []*Bundle{shared}}
+	u2 := &Bundle{Name: "u2", Children: []*Bundle{shared}}
+	root := &Node{
+		Name:   "root",
+		Bundle: u1,
+		Children: []*Node{
+			{Name: "child", Bundle: u2},
+		},
+	}
+	c := &Cluster{Name: "c", Node: root}
+	if err := ValidateCluster(c); err == nil {
+		t.Fatal("expected shared umbrella child between two umbrellas to fail")
+	}
+}
+
+func TestValidateCluster_MultiPackageWithUmbrellaRejected(t *testing.T) {
+	child := &Bundle{Name: "child"}
+	root := &Node{
+		Name:       "root",
+		PackageRef: &schema.GroupVersionKind{Group: "g", Version: "v", Kind: "K"},
+		Bundle:     &Bundle{Name: "root", Children: []*Bundle{child}},
+	}
+	c := &Cluster{Name: "c", Node: root}
+	if err := ValidateCluster(c); err == nil {
+		t.Fatal("expected PackageRef + umbrella to be rejected")
+	}
+}
+
+func TestValidateCluster_NoUmbrellaMultiPackageAllowed(t *testing.T) {
+	root := &Node{
+		Name:       "root",
+		PackageRef: &schema.GroupVersionKind{Group: "g", Version: "v", Kind: "K"},
+		Bundle:     &Bundle{Name: "root"},
+	}
+	c := &Cluster{Name: "c", Node: root}
+	if err := ValidateCluster(c); err != nil {
+		t.Fatalf("multi-package with no umbrella should pass: %v", err)
+	}
+}
+
+func TestValidateCluster_InvalidBundleBubblesUp(t *testing.T) {
+	// Parent has Wait=false but has Children — invalid per Bundle.Validate.
+	falseVal := false
+	root := &Bundle{Name: "root", Wait: &falseVal, Children: []*Bundle{{Name: "c"}}}
+	c := &Cluster{Name: "c", Node: &Node{Name: "n", Bundle: root}}
+	if err := ValidateCluster(c); err == nil {
+		t.Fatal("expected Wait=false umbrella to fail")
+	}
+}

--- a/site/content/concepts/domain-model.md
+++ b/site/content/concepts/domain-model.md
@@ -31,8 +31,28 @@ Nodes map to **directory structures** in the GitOps repository. Each node can al
 A deployment unit corresponding to a single GitOps reconciliation resource (e.g., a Flux Kustomization or ArgoCD Application). Bundles contain applications and support:
 
 - **Dependency ordering** via `DependsOn` (e.g., "deploy cert-manager before my app")
+- **Umbrella composition** via `Children` (see below)
 - **Reconciliation settings**: interval, pruning, timeouts
 - **Labels and annotations** for metadata
+
+#### Umbrella Bundles
+
+`DependsOn` and `Children` answer different questions. `DependsOn` is about
+**ordering** between siblings: "reconcile X only after Y is Ready".
+`Children` is about **containment**: the parent Bundle becomes an umbrella
+whose Flux Kustomization renders its child Kustomization CRs, sets
+`spec.wait: true`, and aggregates each child's Ready condition via
+`spec.healthChecks`. The parent is Ready iff all children are Ready.
+
+This gives downstream consumers a single stable anchor — for example, a
+`platform` umbrella with tier children `infra`, `services`, `apps` lets an
+external bundle `DependsOn: [platform]` without having to know or care about
+the internal tiers.
+
+A bundle referenced by `Children` must be **standalone**: it cannot
+simultaneously be the `Bundle` of any `Node`. The `stack.ValidateCluster`
+check enforces disjointness, cycle detection, and rejects multi-package
+umbrellas in the current release.
 
 ### Application
 

--- a/site/content/guides/flux-workflow.md
+++ b/site/content/guides/flux-workflow.md
@@ -170,6 +170,36 @@ Umbrella children must be **standalone** — a bundle cannot simultaneously be
 the `Bundle` of a `stack.Node` and appear in another bundle's `Children`.
 `stack.ValidateCluster` rejects any such overlap before resource generation.
 
+### Disk layout
+
+In `FluxIntegrated` placement, the umbrella children's Flux Kustomization CRs
+live alongside the parent's, and the parent's `kustomization.yaml` references
+each child via the CR file (not the child subdirectory):
+
+```
+clusters/production/apps/
+  platform/                                       # umbrella bundle directory
+    flux-system-kustomization-platform.yaml       # umbrella self CR (wait+HC)
+    flux-system-kustomization-platform-infra.yaml # child CR (placed at parent)
+    flux-system-kustomization-platform-apps.yaml  # child CR (placed at parent)
+    kustomization.yaml                            # references the CR files
+    platform-infra/                               # umbrella child subdirectory
+      workload-*.yaml
+      kustomization.yaml                          # workloads only, no Flux CRs
+    platform-apps/
+      workload-*.yaml
+      kustomization.yaml
+```
+
+The child subdirectories contain **only** their workload manifests and a
+per-directory `kustomization.yaml` listing those workloads. They do **not**
+contain any `flux-system-kustomization-*.yaml` files — those live in the
+parent directory, so Flux applies them once via the parent's Kustomization.
+
+In `FluxSeparate` placement, all Kustomization CRs (the umbrella's own plus
+every descendant) are written to the shared `flux-system/` directory as a
+flat list.
+
 ## Bootstrap
 
 Generate Flux system bootstrap manifests:

--- a/site/content/guides/flux-workflow.md
+++ b/site/content/guides/flux-workflow.md
@@ -115,6 +115,61 @@ The [Layout Engine](/api-reference/layout) supports multiple grouping and file o
 | FilePer | `FilePerResource`, `FilePerKind` | One file per resource or group by kind |
 | FluxPlacement | `FluxSeparate`, `FluxIntegrated` | Separate or inline Flux resources |
 
+## Umbrella Bundles — Readiness Aggregation
+
+A bundle with non-empty `Children` becomes an **umbrella**: Flux will only mark
+its Kustomization `Ready` once every child Kustomization is `Ready`. The Flux
+engine enforces this by:
+
+- Forcing `spec.wait: true` on the umbrella's Kustomization
+- Prepending an auto `spec.healthChecks` entry for each direct child
+
+The resulting umbrella Kustomization aggregates child readiness regardless of
+how many children there are, giving external consumers a single stable anchor:
+
+```go
+umbrella := &stack.Bundle{
+    Name: "platform",
+    Children: []*stack.Bundle{
+        {Name: "platform-infra"},
+        {Name: "platform-services"},
+        {Name: "platform-apps"},
+    },
+}
+```
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: platform
+  namespace: flux-system
+spec:
+  wait: true
+  healthChecks:
+  - apiVersion: kustomize.toolkit.fluxcd.io/v1
+    kind: Kustomization
+    name: platform-infra
+    namespace: flux-system
+  - apiVersion: kustomize.toolkit.fluxcd.io/v1
+    kind: Kustomization
+    name: platform-services
+    namespace: flux-system
+  - apiVersion: kustomize.toolkit.fluxcd.io/v1
+    kind: Kustomization
+    name: platform-apps
+    namespace: flux-system
+  # ...rest of spec
+```
+
+User-supplied `HealthChecks` on the umbrella bundle are appended AFTER the
+auto entries. Setting `Wait: false` on a bundle that has `Children` is
+rejected at validation time.
+
+Umbrella children must be **standalone** — a bundle cannot simultaneously be
+the `Bundle` of a `stack.Node` and appear in another bundle's `Children`.
+`stack.ValidateCluster` rejects any such overlap before resource generation.
+
 ## Bootstrap
 
 Generate Flux system bootstrap manifests:


### PR DESCRIPTION
## Summary

Implements `Bundle.Children` for the umbrella Kustomization pattern (fixes #423). A parent Flux Kustomization now aggregates child readiness via `spec.wait: true` + auto `spec.healthChecks`, giving downstream consumers a single stable anchor regardless of how many internal tiers the umbrella contains. Unblocks crane#13 and crane#20.

- **Containment vs ordering**: `Children` expresses containment (parent wraps children, renders their CRs, aggregates readiness); `DependsOn` still expresses sibling ordering. A bundle referenced by `Children` must be standalone — it cannot simultaneously be a Node's Bundle.
- **Validation**: new `stack.ValidateCluster` enforces disjointness, cycle detection, shared-ownership rejection, and multi-package umbrella rejection (initial patch restriction). Wired into every cluster entry point (`GenerateFromCluster`, `CreateLayoutWithResources`, `WalkCluster`, `WalkClusterByPackage`, `ConvertV1Alpha1ToClusterTree`).
- **Full YAML parity**: `v1alpha1.BundleSpec.Children` + forward/reverse converters with visited-pointer dedup. Umbrella reverse path leaves `Wait` nil so CR generation forces `spec.wait=true`.
- **Placement semantics**: in `FluxIntegrated` mode the umbrella self's CR stays at the node layout; umbrella children's CRs go to the parent bundle layout (or node layout in `nodeOnly`/`GroupFlat`); nested grandchildren go to their enclosing umbrella child's layout. No double placement — `GenerateFromBundle` is strictly self-only. `FluxSeparate` walks the full closure via `GenerateFromNode`/`GenerateFromCluster`.
- **Disk shape**: parent `kustomization.yaml` references each umbrella child via `flux-system-kustomization-{child}.yaml` (placed at parent) instead of a subdirectory reference. Child subdir still contains its own workloads + `kustomization.yaml`, but no Flux CR files.

## Commits

1. `feat(stack): add Bundle.Children + shared cluster validator` — field, `InitializeUmbrella`, `IsUmbrella`, extended `Validate` with cycle detection, new `stack.ValidateCluster`, `deepCopyBundle` preserves Children, `v1alpha1.BundleConfig.Validate()` local children rules.
2. `feat(stack): wire ValidateCluster into all entry points` — signature change: `ConvertV1Alpha1ToClusterTree` now returns `(*stack.Cluster, error)`.
3. `feat(fluxcd): umbrella Kustomization spec generation` — `createKustomization` umbrella path (force Wait, auto HealthChecks), `GenerateFromBundle` doc comment (self-only), `GenerateFromNode` closure via `generateUmbrellaClosure`.
4. `feat(layout): umbrella layout walker + integrated placement + v1alpha1 parity` — walker extension in both nodeOnly and non-nodeOnly branches, tar/write/manifest writers emit UmbrellaChild CR references, layout integrator `placeUmbrellaChildrenFlux`, v1alpha1 converter Children round-trip with visited dedup, end-to-end integration test.

## API break

`v1alpha1.StackConverter.ConvertV1Alpha1ToClusterTree` now returns `(*stack.Cluster, error)` (was `*stack.Cluster`). Deliberate — validation errors need to surface at decode time. Only known consumer is kure itself; crane build check passes (see Test plan).

## What this does NOT solve

- Multi-package umbrellas: children crossing `PackageRef` boundaries. Rejected by `ValidateCluster`; follow-up after crane needs it.
- Automatic SourceRef inheritance from umbrella to children.
- Dedup of auto vs user HealthChecks when a user explicitly lists the same child.
- No new CLI surface for rendering "just the umbrella anchor".

## Test plan

- [x] `GOWORK=off go test ./...` — full kure suite green
- [x] `GOWORK=off go build ./...` — no API breaks outside the deliberate converter signature change
- [x] `mise run lint` — 0 issues
- [x] New focused tests:
  - `pkg/stack/bundle_test.go` — umbrella validation cases, cycle detection, `InitializeUmbrella`, `IsUmbrella`
  - `pkg/stack/validate_test.go` — disjointness, shared-ownership, multi-package rejection
  - `pkg/stack/builders_test.go` — copy-on-write preserves Children
  - `pkg/stack/v1alpha1/bundle_test.go` — local children validation
  - `pkg/stack/v1alpha1/converters_test.go` — forward/reverse Children, dedup, invalid round-trip rejection
  - `pkg/stack/fluxcd/fluxcd_test.go` — umbrella spec generation, closure walk, nested, path derivation, end-to-end integrated + separate
  - `pkg/stack/fluxcd/layout_integrator_test.go` — integrated placement (non-nodeOnly + nodeOnly), nested, child Source CRs
  - `pkg/stack/fluxcd/resource_generator_test.go` — `TestGeneratePath_UmbrellaChild`
  - `pkg/stack/layout/walker_test.go` — sub-layout shape in both modes, `UmbrellaChild` marker
  - `pkg/stack/layout/tar_test.go` / `write_test.go` — parent `kustomization.yaml` contents, child subdir shape, no flux CR leakage
- [x] Cross-repo check against crane via workspace `replace`: `go build ./...` + `go test ./...` — both green
