### PR TITLE
feat(stack/fluxcd): emit full Flux Operator install bundle in flux-operator mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- BootstrapGenerator (flux-operator mode) now emits the full Flux Operator install bundle (Namespace, CRDs, RBAC, ServiceAccount, Service, controller Deployment) in addition to the FluxInstance. The install manifest is vendored from upstream `fluxcd/flux-operator v0.40.0` and embedded via `//go:embed`, with the version surfaced as `fluxcd.FluxOperatorVersion`. Callers can now stand up flux-operator from scratch with a single apply of the bootstrap output — no separate install step required. Consumers that only want the FluxInstance can filter by type.
+
 ## [0.1.0-rc.4] - 2026-04-10
 
 ### Added

--- a/pkg/stack/fluxcd/bootstrap_generator.go
+++ b/pkg/stack/fluxcd/bootstrap_generator.go
@@ -92,11 +92,29 @@ func (bg *BootstrapGenerator) generateGotkBootstrap(config *stack.BootstrapConfi
 }
 
 // generateFluxOperatorBootstrap generates bootstrap resources using the Flux Operator.
+//
+// Output order (also a valid apply order):
+//  1. Flux Operator install bundle — Namespace, CRDs, RBAC, ServiceAccount,
+//     Service, controller Deployment (from the embedded upstream install.yaml,
+//     see FluxOperatorInstallObjects / FluxOperatorVersion).
+//  2. FluxInstance CR — configured from BootstrapConfig.
+//
+// Prior to kure v0.1.0-rc.5 only the FluxInstance was emitted, which
+// required every caller to provide the Flux Operator install bundle
+// separately (see crane's bootstrap-chain design §9). Emitting the full
+// set here makes the generator self-sufficient so callers can return a
+// single apply-ready bundle.
 func (bg *BootstrapGenerator) generateFluxOperatorBootstrap(config *stack.BootstrapConfig, rootNode *stack.Node) ([]client.Object, error) {
-	// Generate FluxInstance resource
-	fluxInstance := bg.generateFluxInstance(config, rootNode)
+	installObjs, err := FluxOperatorInstallObjects()
+	if err != nil {
+		return nil, errors.ResourceValidationError("BootstrapConfig", "flux-operator", "install",
+			fmt.Sprintf("failed to load vendored flux-operator install bundle: %v", err), err)
+	}
 
-	return []client.Object{fluxInstance}, nil
+	resources := make([]client.Object, 0, len(installObjs)+1)
+	resources = append(resources, installObjs...)
+	resources = append(resources, bg.generateFluxInstance(config, rootNode))
+	return resources, nil
 }
 
 // generateGotkComponents generates the standard Flux toolkit components.

--- a/pkg/stack/fluxcd/bootstrap_generator_test.go
+++ b/pkg/stack/fluxcd/bootstrap_generator_test.go
@@ -4,10 +4,26 @@ import (
 	"testing"
 
 	fluxv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-kure/kure/pkg/stack"
 	fluxstack "github.com/go-kure/kure/pkg/stack/fluxcd"
 )
+
+// findFluxInstance locates the FluxInstance in a flux-operator bootstrap
+// resource list. Since v0.1.0-rc.5 the list also contains the Flux
+// Operator install bundle (Namespace, CRDs, RBAC, Deployment, Service)
+// so FluxInstance is no longer at index 0.
+func findFluxInstance(t *testing.T, resources []client.Object) *fluxv1.FluxInstance {
+	t.Helper()
+	for _, obj := range resources {
+		if fi, ok := obj.(*fluxv1.FluxInstance); ok {
+			return fi
+		}
+	}
+	t.Fatalf("FluxInstance not found in %d resources", len(resources))
+	return nil
+}
 
 func TestNewBootstrapGenerator(t *testing.T) {
 	bg := fluxstack.NewBootstrapGenerator()
@@ -174,16 +190,11 @@ func TestGenerateBootstrapDefaultMode(t *testing.T) {
 		t.Fatalf("GenerateBootstrap() error = %v", err)
 	}
 
-	// Should generate FluxInstance (flux-operator mode)
+	// flux-operator mode emits the install bundle + FluxInstance.
 	if len(resources) == 0 {
 		t.Fatal("expected at least one resource")
 	}
-
-	// Verify it's a FluxInstance (not gotk output)
-	if resources[0].GetObjectKind().GroupVersionKind().Kind != "FluxInstance" {
-		t.Errorf("expected FluxInstance for default mode, got %s",
-			resources[0].GetObjectKind().GroupVersionKind().Kind)
-	}
+	_ = findFluxInstance(t, resources)
 }
 
 func TestFluxOperatorSourceKindGitRepository(t *testing.T) {
@@ -205,14 +216,7 @@ func TestFluxOperatorSourceKindGitRepository(t *testing.T) {
 		t.Fatalf("GenerateBootstrap() error = %v", err)
 	}
 
-	if len(resources) != 1 {
-		t.Fatalf("expected 1 resource, got %d", len(resources))
-	}
-
-	fi, ok := resources[0].(*fluxv1.FluxInstance)
-	if !ok {
-		t.Fatalf("expected FluxInstance, got %T", resources[0])
-	}
+	fi := findFluxInstance(t, resources)
 
 	if fi.Spec.Sync == nil {
 		t.Fatal("expected Sync to be set")
@@ -247,10 +251,7 @@ func TestFluxOperatorSourceKindOCIDefault(t *testing.T) {
 		t.Fatalf("GenerateBootstrap() error = %v", err)
 	}
 
-	fi, ok := resources[0].(*fluxv1.FluxInstance)
-	if !ok {
-		t.Fatalf("expected FluxInstance, got %T", resources[0])
-	}
+	fi := findFluxInstance(t, resources)
 
 	if fi.Spec.Sync == nil {
 		t.Fatal("expected Sync to be set")
@@ -278,10 +279,7 @@ func TestFluxOperatorSourceKindExplicitOCI(t *testing.T) {
 		t.Fatalf("GenerateBootstrap() error = %v", err)
 	}
 
-	fi, ok := resources[0].(*fluxv1.FluxInstance)
-	if !ok {
-		t.Fatalf("expected FluxInstance, got %T", resources[0])
-	}
+	fi := findFluxInstance(t, resources)
 
 	if fi.Spec.Sync.Kind != "OCIRepository" {
 		t.Errorf("Sync.Kind = %q, want %q", fi.Spec.Sync.Kind, "OCIRepository")
@@ -370,11 +368,7 @@ func TestGotkGitRepositorySourceGeneration(t *testing.T) {
 		t.Fatalf("GenerateBootstrap() error = %v", err)
 	}
 
-	if len(resources) != 1 {
-		t.Fatalf("expected 1 resource (FluxInstance), got %d", len(resources))
-	}
-
-	fi := resources[0].(*fluxv1.FluxInstance)
+	fi := findFluxInstance(t, resources)
 	if fi.Spec.Sync == nil {
 		t.Fatal("Sync should be set")
 	}
@@ -383,5 +377,85 @@ func TestGotkGitRepositorySourceGeneration(t *testing.T) {
 	}
 	if fi.Spec.Sync.Path != "./test" {
 		t.Errorf("Sync.Path = %q, want ./test", fi.Spec.Sync.Path)
+	}
+}
+
+// TestFluxOperatorInstallObjects verifies the vendored install.yaml parses
+// into the expected resource inventory. If the manifest is bumped to a
+// newer flux-operator release the counts may shift and this test should
+// be updated deliberately.
+func TestFluxOperatorInstallObjects(t *testing.T) {
+	objs, err := fluxstack.FluxOperatorInstallObjects()
+	if err != nil {
+		t.Fatalf("FluxOperatorInstallObjects() error = %v", err)
+	}
+
+	if fluxstack.FluxOperatorVersion == "" {
+		t.Error("FluxOperatorVersion must not be empty")
+	}
+
+	counts := map[string]int{}
+	for _, obj := range objs {
+		kind := obj.GetObjectKind().GroupVersionKind().Kind
+		counts[kind]++
+	}
+
+	// Inventory from upstream install.yaml at FluxOperatorVersion.
+	// Update deliberately if the vendored manifest is refreshed.
+	wantCounts := map[string]int{
+		"Namespace":                1,
+		"CustomResourceDefinition": 4, // FluxInstance, FluxReport, ResourceSet, ResourceSetInputProvider
+		"ServiceAccount":           1,
+		"ClusterRole":              2,
+		"ClusterRoleBinding":       1,
+		"Service":                  1,
+		"Deployment":               1,
+	}
+	for kind, want := range wantCounts {
+		if got := counts[kind]; got != want {
+			t.Errorf("install bundle kind %q: got %d, want %d (all kinds: %v)", kind, got, want, counts)
+		}
+	}
+}
+
+// TestFluxOperatorBootstrapIncludesInstallBundle asserts the install
+// bundle is emitted before the FluxInstance so a single apply of the
+// result is enough to stand up flux-operator from scratch.
+func TestFluxOperatorBootstrapIncludesInstallBundle(t *testing.T) {
+	bg := fluxstack.NewBootstrapGenerator()
+
+	config := &stack.BootstrapConfig{
+		Enabled:  true,
+		FluxMode: "flux-operator",
+	}
+	rootNode := &stack.Node{Name: "test"}
+
+	resources, err := bg.GenerateBootstrap(config, rootNode)
+	if err != nil {
+		t.Fatalf("GenerateBootstrap() error = %v", err)
+	}
+
+	// Expect install bundle objects (> 1) plus the FluxInstance.
+	if len(resources) < 2 {
+		t.Fatalf("expected install bundle + FluxInstance, got %d resources", len(resources))
+	}
+
+	// FluxInstance must be the last object so it's applied after the CRDs
+	// and controller are in place.
+	last := resources[len(resources)-1]
+	if _, ok := last.(*fluxv1.FluxInstance); !ok {
+		t.Errorf("last resource: got %T, want *fluxv1.FluxInstance", last)
+	}
+
+	// Find the install-bundle marker resources to be sure they were prepended.
+	kinds := map[string]bool{}
+	for _, obj := range resources {
+		kinds[obj.GetObjectKind().GroupVersionKind().Kind] = true
+	}
+	mustHave := []string{"Namespace", "CustomResourceDefinition", "ClusterRole", "ClusterRoleBinding", "ServiceAccount", "Deployment"}
+	for _, k := range mustHave {
+		if !kinds[k] {
+			t.Errorf("missing expected install-bundle kind %q (have: %v)", k, kinds)
+		}
 	}
 }

--- a/pkg/stack/fluxcd/flux_operator_install.go
+++ b/pkg/stack/fluxcd/flux_operator_install.go
@@ -1,0 +1,60 @@
+package fluxcd
+
+import (
+	_ "embed"
+	"fmt"
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kio "github.com/go-kure/kure/pkg/io"
+)
+
+// FluxOperatorVersion is the upstream flux-operator release whose install
+// manifest is vendored as fluxOperatorInstallYAML. It is pinned to match
+// the github.com/controlplaneio-fluxcd/flux-operator Go module version in
+// kure's go.mod so that the generated FluxInstance type and the install
+// bundle stay in lockstep.
+//
+// To refresh this vendoring:
+//  1. Bump github.com/controlplaneio-fluxcd/flux-operator in go.mod.
+//  2. Download the matching install.yaml from the flux-operator GitHub
+//     release page:
+//     https://github.com/controlplaneio-fluxcd/flux-operator/releases/download/{version}/install.yaml
+//  3. Replace pkg/stack/fluxcd/flux_operator_install.yaml with it.
+//  4. Update this constant.
+//  5. Run the tests in this package and confirm the resource inventory in
+//     TestFluxOperatorInstallObjects still matches.
+const FluxOperatorVersion = "v0.40.0"
+
+//go:embed flux_operator_install.yaml
+var fluxOperatorInstallYAML []byte
+
+var (
+	fluxOperatorInstallOnce    sync.Once
+	fluxOperatorInstallObjects []client.Object
+	fluxOperatorInstallErr     error
+)
+
+// FluxOperatorInstallObjects returns the parsed Flux Operator install
+// manifest: Namespace, CRDs, RBAC, ServiceAccount, Service, and
+// controller Deployment. The bytes are embedded at build time from
+// flux_operator_install.yaml (version FluxOperatorVersion).
+//
+// The returned slice is cached on first parse; callers must treat it as
+// read-only. To mutate any object, deep-copy first.
+//
+// The order of objects matches the order in the upstream install.yaml
+// (Namespace → CRDs → RBAC → ServiceAccount → Deployment → Service),
+// which is also a valid apply order.
+func FluxOperatorInstallObjects() ([]client.Object, error) {
+	fluxOperatorInstallOnce.Do(func() {
+		objs, err := kio.ParseYAML(fluxOperatorInstallYAML)
+		if err != nil {
+			fluxOperatorInstallErr = fmt.Errorf("parse vendored flux-operator install.yaml (%s): %w", FluxOperatorVersion, err)
+			return
+		}
+		fluxOperatorInstallObjects = objs
+	})
+	return fluxOperatorInstallObjects, fluxOperatorInstallErr
+}

--- a/pkg/stack/fluxcd/flux_operator_install.yaml
+++ b/pkg/stack/fluxcd/flux_operator_install.yaml
@@ -1,0 +1,1857 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/name: flux-operator
+  name: flux-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: fluxinstances.fluxcd.controlplane.io
+spec:
+  group: fluxcd.controlplane.io
+  names:
+    kind: FluxInstance
+    listKind: FluxInstanceList
+    plural: fluxinstances
+    singular: fluxinstance
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .status.lastAttemptedRevision
+      name: Revision
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: FluxInstance is the Schema for the fluxinstances API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FluxInstanceSpec defines the desired state of FluxInstance
+            properties:
+              cluster:
+                description: Cluster holds the specification of the Kubernetes cluster.
+                properties:
+                  domain:
+                    default: cluster.local
+                    description: |-
+                      Domain is the cluster domain used for generating the FQDN of services.
+                      Defaults to 'cluster.local'.
+                    type: string
+                  multitenant:
+                    default: false
+                    description: Multitenant enables the multitenancy lockdown. Defaults
+                      to false.
+                    type: boolean
+                  multitenantWorkloadIdentity:
+                    default: false
+                    description: |-
+                      MultitenantWorkloadIdentity enables the multitenancy lockdown for
+                      workload identity. Defaults to false.
+                    type: boolean
+                  networkPolicy:
+                    default: true
+                    description: |-
+                      NetworkPolicy restricts network access to the current namespace.
+                      Defaults to true.
+                    type: boolean
+                  objectLevelWorkloadIdentity:
+                    description: |-
+                      ObjectLevelWorkloadIdentity enables the feature gate
+                      required for object-level workload identity.
+                      This feature is only available in Flux v2.6.0 and later.
+                    type: boolean
+                  size:
+                    description: |-
+                      Size defines the vertical scaling profile of the Flux controllers.
+                      The size is used to determine the concurrency and CPU/Memory limits for the Flux controllers.
+                      Accepted values are: 'small', 'medium' and 'large'.
+                    enum:
+                    - small
+                    - medium
+                    - large
+                    type: string
+                  tenantDefaultDecryptionServiceAccount:
+                    description: |-
+                      TenantDefaultDecryptionServiceAccount is the name of the service account
+                      to use as default for kustomize-controller SOPS decryption when the
+                      multitenant lockdown for workload identity is enabled. Defaults to the
+                      'default' service account from the tenant namespace.
+                    type: string
+                  tenantDefaultKubeConfigServiceAccount:
+                    description: |-
+                      TenantDefaultKubeConfigServiceAccount is the name of the service account
+                      to use as default for kustomize-controller and helm-controller remote
+                      cluster access via spec.kubeConfig.configMapRef when the multitenant
+                      lockdown for workload identity is enabled. Defaults to the 'default'
+                      service account from the tenant namespace.
+                    type: string
+                  tenantDefaultServiceAccount:
+                    description: |-
+                      TenantDefaultServiceAccount is the name of the service account
+                      to use as default when the multitenant lockdown is enabled, for
+                      kustomize-controller and helm-controller.
+                      This field will also be used for multitenant workload identity
+                      lockdown for source-controller, notification-controller,
+                      image-reflector-controller and image-automation-controller.
+                      Defaults to the 'default' service account from the tenant namespace.
+                    type: string
+                  type:
+                    default: kubernetes
+                    description: |-
+                      Type specifies the distro of the Kubernetes cluster.
+                      Defaults to 'kubernetes'.
+                    enum:
+                    - kubernetes
+                    - openshift
+                    - aws
+                    - azure
+                    - gcp
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: .objectLevelWorkloadIdentity must be set to true when .multitenantWorkloadIdentity
+                    is set to true
+                  rule: (has(self.objectLevelWorkloadIdentity) && self.objectLevelWorkloadIdentity)
+                    || !has(self.multitenantWorkloadIdentity) || !self.multitenantWorkloadIdentity
+              commonMetadata:
+                description: |-
+                  CommonMetadata specifies the common labels and annotations that are
+                  applied to all resources. Any existing label or annotation will be
+                  overridden if its key matches a common one.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations to be added to the object's metadata.
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels to be added to the object's metadata.
+                    type: object
+                type: object
+              components:
+                description: |-
+                  Components is the list of controllers to install.
+                  Defaults to a commonly used subset.
+                items:
+                  description: Component is the name of a controller to install.
+                  enum:
+                  - source-controller
+                  - kustomize-controller
+                  - helm-controller
+                  - notification-controller
+                  - image-reflector-controller
+                  - image-automation-controller
+                  - source-watcher
+                  type: string
+                type: array
+              distribution:
+                description: Distribution specifies the version and container registry
+                  to pull images from.
+                properties:
+                  artifact:
+                    description: |-
+                      Artifact is the URL to the OCI artifact containing
+                      the latest Kubernetes manifests for the distribution,
+                      e.g. 'oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest'.
+                    pattern: ^oci://.*$
+                    type: string
+                  artifactPullSecret:
+                    description: |-
+                      ArtifactPullSecret is the name of the Kubernetes secret
+                      to use for pulling the Kubernetes manifests for the distribution specified in the Artifact field.
+                    type: string
+                  imagePullSecret:
+                    description: |-
+                      ImagePullSecret is the name of the Kubernetes secret
+                      to use for pulling images.
+                    type: string
+                  registry:
+                    description: |-
+                      Registry address to pull the distribution images from
+                      e.g. 'ghcr.io/fluxcd'.
+                    type: string
+                  variant:
+                    description: |-
+                      Variant specifies the Flux distribution flavor stored
+                      in the registry.
+                    enum:
+                    - upstream-alpine
+                    - enterprise-alpine
+                    - enterprise-distroless
+                    - enterprise-distroless-fips
+                    type: string
+                  version:
+                    description: Version semver expression e.g. '2.x', '2.3.x'.
+                    type: string
+                required:
+                - registry
+                - version
+                type: object
+              kustomize:
+                description: |-
+                  Kustomize holds a set of patches that can be applied to the
+                  Flux installation, to customize the way Flux operates.
+                properties:
+                  patches:
+                    description: |-
+                      Strategic merge and JSON patches, defined as inline YAML objects,
+                      capable of targeting objects based on kind, label and annotation selectors.
+                    items:
+                      description: |-
+                        Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+                        be applied to.
+                      properties:
+                        patch:
+                          description: |-
+                            Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+                            an array of operation objects.
+                          type: string
+                        target:
+                          description: Target points to the resources that the patch
+                            document should be applied to.
+                          properties:
+                            annotationSelector:
+                              description: |-
+                                AnnotationSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource annotations.
+                              type: string
+                            group:
+                              description: |-
+                                Group is the API group to select resources from.
+                                Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            kind:
+                              description: |-
+                                Kind of the API Group to select resources from.
+                                Together with Group and Version it is capable of unambiguously
+                                identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource labels.
+                              type: string
+                            name:
+                              description: Name to match resources with.
+                              type: string
+                            namespace:
+                              description: Namespace to select resources from.
+                              type: string
+                            version:
+                              description: |-
+                                Version of the API Group to select resources from.
+                                Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                          type: object
+                      required:
+                      - patch
+                      type: object
+                    type: array
+                type: object
+              migrateResources:
+                default: true
+                description: |-
+                  MigrateResources instructs the controller to migrate the Flux custom resources
+                  from the previous version to the latest API version specified in the CRD.
+                  Defaults to true.
+                type: boolean
+              sharding:
+                description: Sharding holds the specification of the sharding configuration.
+                properties:
+                  key:
+                    default: sharding.fluxcd.io/key
+                    description: Key is the label key used to shard the resources.
+                    type: string
+                  shards:
+                    description: Shards is the list of shard names.
+                    items:
+                      type: string
+                    minItems: 1
+                    type: array
+                  storage:
+                    description: |-
+                      Storage defines if the source-controller shards
+                      should use an emptyDir or a persistent volume claim for storage.
+                      Accepted values are 'ephemeral' or 'persistent', defaults to 'ephemeral'.
+                      For 'persistent' to take effect, the '.spec.storage' field must be set.
+                    enum:
+                    - ephemeral
+                    - persistent
+                    type: string
+                required:
+                - shards
+                type: object
+              storage:
+                description: |-
+                  Storage holds the specification of the source-controller
+                  persistent volume claim.
+                properties:
+                  class:
+                    description: Class is the storage class to use for the PVC.
+                    type: string
+                  size:
+                    description: Size is the size of the PVC.
+                    type: string
+                required:
+                - class
+                - size
+                type: object
+              sync:
+                description: |-
+                  Sync specifies the source for the cluster sync operation.
+                  When set, a Flux source (GitRepository, OCIRepository or Bucket)
+                  and Flux Kustomization are created to sync the cluster state
+                  with the source repository.
+                properties:
+                  interval:
+                    default: 1m
+                    description: Interval is the time between syncs.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                  kind:
+                    description: Kind is the kind of the source.
+                    enum:
+                    - OCIRepository
+                    - GitRepository
+                    - Bucket
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the Flux source and kustomization resources.
+                      When not specified, the name is set to the namespace name of the FluxInstance.
+                    maxLength: 63
+                    type: string
+                    x-kubernetes-validations:
+                    - message: Sync name is immutable
+                      rule: self == oldSelf
+                  path:
+                    description: |-
+                      Path is the path to the source directory containing
+                      the kustomize overlay or plain Kubernetes manifests.
+                    type: string
+                  provider:
+                    description: |-
+                      Provider specifies OIDC provider for source authentication.
+                      For OCIRepository and Bucket the provider can be set to 'aws', 'azure' or 'gcp'.
+                      for GitRepository the accepted value can be set to 'azure' or 'github'.
+                      To disable OIDC authentication the provider can be set to 'generic' or left empty.
+                    enum:
+                    - generic
+                    - aws
+                    - azure
+                    - gcp
+                    - github
+                    type: string
+                  pullSecret:
+                    description: |-
+                      PullSecret specifies the Kubernetes Secret containing the
+                      authentication credentials for the source.
+                      For Git over HTTP/S sources, the secret must contain username and password fields.
+                      For Git over SSH sources, the secret must contain known_hosts and identity fields.
+                      For OCI sources, the secret must be of type kubernetes.io/dockerconfigjson.
+                      For Bucket sources, the secret must contain accesskey and secretkey fields.
+                    type: string
+                  ref:
+                    description: |-
+                      Ref is the source reference, can be a Git ref name e.g. 'refs/heads/main',
+                      an OCI tag e.g. 'latest' or a bucket name e.g. 'flux'.
+                    type: string
+                  url:
+                    description: |-
+                      URL is the source URL, can be a Git repository HTTP/S or SSH address,
+                      an OCI repository address or a Bucket endpoint.
+                    type: string
+                required:
+                - kind
+                - path
+                - ref
+                - url
+                type: object
+              wait:
+                default: true
+                description: |-
+                  Wait instructs the controller to check the health of all the reconciled
+                  resources. Defaults to true.
+                type: boolean
+            required:
+            - distribution
+            type: object
+          status:
+            description: FluxInstanceStatus defines the observed state of FluxInstance
+            properties:
+              components:
+                description: Components contains the container images used by the
+                  components.
+                items:
+                  description: ComponentImage represents a container image used by
+                    a component.
+                  properties:
+                    digest:
+                      description: Digest of the container image.
+                      type: string
+                    name:
+                      description: Name of the component.
+                      type: string
+                    repository:
+                      description: Repository address of the container image.
+                      type: string
+                    tag:
+                      description: Tag of the container image.
+                      type: string
+                  required:
+                  - name
+                  - repository
+                  - tag
+                  type: object
+                type: array
+              conditions:
+                description: Conditions contains the readiness conditions of the object.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              history:
+                description: |-
+                  History contains the reconciliation history of the FluxInstance
+                  as a list of snapshots ordered by the last reconciled time.
+                items:
+                  description: |-
+                    Snapshot represents a point-in-time record of a group of resources reconciliation,
+                    including timing information, status, and a unique digest identifier.
+                  properties:
+                    digest:
+                      description: Digest is the checksum in the format `<algo>:<hex>`
+                        of the resources in this snapshot.
+                      type: string
+                    firstReconciled:
+                      description: FirstReconciled is the time when this revision
+                        was first reconciled to the cluster.
+                      format: date-time
+                      type: string
+                    lastReconciled:
+                      description: LastReconciled is the time when this revision was
+                        last reconciled to the cluster.
+                      format: date-time
+                      type: string
+                    lastReconciledDuration:
+                      description: LastReconciledDuration is time it took to reconcile
+                        the resources in this revision.
+                      type: string
+                    lastReconciledStatus:
+                      description: LastReconciledStatus is the status of the last
+                        reconciliation.
+                      type: string
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      description: Metadata contains additional information about
+                        the snapshot.
+                      type: object
+                    totalReconciliations:
+                      description: TotalReconciliations is the total number of reconciliations
+                        that have occurred for this snapshot.
+                      format: int64
+                      type: integer
+                  required:
+                  - digest
+                  - firstReconciled
+                  - lastReconciled
+                  - lastReconciledDuration
+                  - lastReconciledStatus
+                  - totalReconciliations
+                  type: object
+                type: array
+              inventory:
+                description: |-
+                  Inventory contains a list of Kubernetes resource object references
+                  last applied on the cluster.
+                properties:
+                  entries:
+                    description: Entries of Kubernetes resource object references.
+                    items:
+                      description: ResourceRef contains the information necessary
+                        to locate a resource within a cluster.
+                      properties:
+                        id:
+                          description: |-
+                            ID is the string representation of the Kubernetes resource object's metadata,
+                            in the format '<namespace>_<name>_<group>_<kind>'.
+                          type: string
+                        v:
+                          description: Version is the API version of the Kubernetes
+                            resource object's kind.
+                          type: string
+                      required:
+                      - id
+                      - v
+                      type: object
+                    type: array
+                required:
+                - entries
+                type: object
+              lastAppliedRevision:
+                description: |-
+                  LastAppliedRevision is the version and digest of the
+                  distribution config that was last reconcile.
+                type: string
+              lastArtifactRevision:
+                description: |-
+                  LastArtifactRevision is the digest of the last pulled
+                  distribution artifact.
+                type: string
+              lastAttemptedRevision:
+                description: |-
+                  LastAttemptedRevision is the version and digest of the
+                  distribution config that was last attempted to reconcile.
+                type: string
+              lastHandledForceAt:
+                description: |-
+                  LastHandledForceAt holds the value of the most recent
+                  force request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: the only accepted name for a FluxInstance is 'flux'
+          rule: self.metadata.name == 'flux'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: fluxreports.fluxcd.controlplane.io
+spec:
+  group: fluxcd.controlplane.io
+  names:
+    kind: FluxReport
+    listKind: FluxReportList
+    plural: fluxreports
+    singular: fluxreport
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.distribution.entitlement
+      name: Entitlement
+      priority: 10
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].lastTransitionTime
+      name: LastUpdated
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: FluxReport is the Schema for the fluxreports API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FluxReportSpec defines the observed state of a Flux installation.
+            properties:
+              cluster:
+                description: Cluster is the version information of the Kubernetes
+                  cluster.
+                properties:
+                  nodes:
+                    description: Nodes is the number of nodes in the Kubernetes cluster.
+                    type: integer
+                  platform:
+                    description: Platform is the os/arch of the Kubernetes control
+                      plane.
+                    type: string
+                  serverVersion:
+                    description: ServerVersion is the version of the Kubernetes API
+                      server.
+                    type: string
+                required:
+                - platform
+                - serverVersion
+                type: object
+              components:
+                description: ComponentsStatus is the status of the Flux controller
+                  deployments.
+                items:
+                  description: FluxComponentStatus defines the observed state of a
+                    Flux component.
+                  properties:
+                    image:
+                      description: Image is the container image of the Flux component.
+                      type: string
+                    name:
+                      description: Name is the name of the Flux component.
+                      type: string
+                    ready:
+                      description: Ready is the readiness status of the Flux component.
+                      type: boolean
+                    status:
+                      description: |-
+                        Status is a human-readable message indicating details
+                        about the Flux component observed state.
+                      type: string
+                  required:
+                  - image
+                  - name
+                  - ready
+                  - status
+                  type: object
+                type: array
+              distribution:
+                description: Distribution is the version information of the Flux installation.
+                properties:
+                  entitlement:
+                    description: Entitlement is the entitlement verification status.
+                    type: string
+                  managedBy:
+                    description: ManagedBy is the name of the operator managing the
+                      Flux instance.
+                    type: string
+                  status:
+                    description: |-
+                      Status is a human-readable message indicating details
+                      about the distribution observed state.
+                    type: string
+                  version:
+                    description: Version is the version of the Flux instance.
+                    type: string
+                required:
+                - entitlement
+                - status
+                type: object
+              operator:
+                description: Operator is the version information of the Flux Operator.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the API version of the Flux Operator.
+                    type: string
+                  platform:
+                    description: Platform is the os/arch of Flux Operator.
+                    type: string
+                  version:
+                    description: Version is the version number of Flux Operator.
+                    type: string
+                required:
+                - apiVersion
+                - platform
+                - version
+                type: object
+              reconcilers:
+                description: |-
+                  ReconcilersStatus is the list of Flux reconcilers and
+                  their statistics grouped by API kind.
+                items:
+                  description: FluxReconcilerStatus defines the observed state of
+                    a Flux reconciler.
+                  properties:
+                    apiVersion:
+                      description: APIVersion is the API version of the Flux resource.
+                      type: string
+                    kind:
+                      description: Kind is the kind of the Flux resource.
+                      type: string
+                    stats:
+                      description: Stats is the reconcile statics of the Flux resource
+                        kind.
+                      properties:
+                        failing:
+                          description: |-
+                            Failing is the number of reconciled
+                            resources in the Failing state and not Suspended.
+                          type: integer
+                        running:
+                          description: |-
+                            Running is the number of reconciled
+                            resources in the Running state.
+                          type: integer
+                        suspended:
+                          description: |-
+                            Suspended is the number of reconciled
+                            resources in the Suspended state.
+                          type: integer
+                        totalSize:
+                          description: TotalSize is the total size of the artifacts
+                            in storage.
+                          type: string
+                      required:
+                      - failing
+                      - running
+                      - suspended
+                      type: object
+                  required:
+                  - apiVersion
+                  - kind
+                  type: object
+                type: array
+              sync:
+                description: |-
+                  SyncStatus is the status of the cluster sync
+                  Source and Kustomization resources.
+                properties:
+                  id:
+                    description: ID is the identifier of the sync.
+                    type: string
+                  path:
+                    description: Path is the kustomize path of the sync.
+                    type: string
+                  ready:
+                    description: Ready is the readiness status of the sync.
+                    type: boolean
+                  source:
+                    description: Source is the URL of the source repository.
+                    type: string
+                  status:
+                    description: |-
+                      Status is a human-readable message indicating details
+                      about the sync observed state.
+                    type: string
+                required:
+                - id
+                - ready
+                - status
+                type: object
+            required:
+            - distribution
+            type: object
+          status:
+            description: FluxReportStatus defines the readiness of a FluxReport.
+            properties:
+              conditions:
+                description: Conditions contains the readiness conditions of the object.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: the only accepted name for a FluxReport is 'flux'
+          rule: self.metadata.name == 'flux'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: resourcesetinputproviders.fluxcd.controlplane.io
+spec:
+  group: fluxcd.controlplane.io
+  names:
+    kind: ResourceSetInputProvider
+    listKind: ResourceSetInputProviderList
+    plural: resourcesetinputproviders
+    shortNames:
+    - rsip
+    singular: resourcesetinputprovider
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ResourceSetInputProvider is the Schema for the ResourceSetInputProviders
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ResourceSetInputProviderSpec defines the desired state of
+              ResourceSetInputProvider
+            properties:
+              certSecretRef:
+                description: |-
+                  CertSecretRef specifies the Kubernetes Secret containing either or both of
+
+                  - a PEM-encoded CA certificate (`ca.crt`)
+                  - a PEM-encoded client certificate (`tls.crt`) and private key (`tls.key`)
+
+                  When connecting to a Git or OCI provider that uses self-signed certificates, the CA certificate
+                  must be set in the Secret under the 'ca.crt' key to establish the trust relationship.
+                  When connecting to an OCI provider that supports client certificates (mTLS), the client certificate
+                  and private key must be set in the Secret under the 'tls.crt' and 'tls.key' keys, respectively.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              defaultValues:
+                additionalProperties:
+                  x-kubernetes-preserve-unknown-fields: true
+                description: |-
+                  DefaultValues contains the default values for the inputs.
+                  These values are used to populate the inputs when the provider
+                  response does not contain them.
+                type: object
+              filter:
+                description: Filter defines the filter to apply to the input provider
+                  response.
+                properties:
+                  excludeBranch:
+                    description: |-
+                      ExcludeBranch specifies the regular expression to filter the branches
+                      that the input provider should exclude.
+                    type: string
+                  excludeEnvironment:
+                    description: |-
+                      ExcludeEnvironment specifies the regular expression to filter the environments
+                      that the input provider should exclude.
+                    type: string
+                  excludeTag:
+                    description: |-
+                      ExcludeTag specifies the regular expression to filter the tags
+                      that the input provider should exclude.
+                    type: string
+                  includeBranch:
+                    description: |-
+                      IncludeBranch specifies the regular expression to filter the branches
+                      that the input provider should include.
+                    type: string
+                  includeEnvironment:
+                    description: |-
+                      IncludeEnvironment specifies the regular expression to filter the environments
+                      that the input provider should include.
+                    type: string
+                  includeTag:
+                    description: |-
+                      IncludeTag specifies the regular expression to filter the tags
+                      that the input provider should include.
+                    type: string
+                  labels:
+                    description: Labels specifies the list of labels to filter the
+                      input provider response.
+                    items:
+                      type: string
+                    type: array
+                  limit:
+                    default: 100
+                    description: |-
+                      Limit specifies the maximum number of input sets to return.
+                      When not set, the default limit is 100.
+                    type: integer
+                  semver:
+                    description: |-
+                      Semver specifies a semantic version range to filter and sort the tags.
+                      If this field is not specified, the tags will be sorted in reverse
+                      alphabetical order.
+                      Supported only for tags at the moment.
+                    type: string
+                type: object
+              schedule:
+                description: Schedule defines the schedules for the input provider
+                  to run.
+                items:
+                  description: Schedule defines a schedule for something to run.
+                  properties:
+                    cron:
+                      description: Cron specifies the cron expression for the schedule.
+                      type: string
+                    timeZone:
+                      default: UTC
+                      description: TimeZone specifies the time zone for the cron schedule.
+                        Defaults to UTC.
+                      type: string
+                    window:
+                      default: 0s
+                      description: |-
+                        Window defines the time window during which the execution is allowed.
+                        Defaults to 0s, meaning no window is applied.
+                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                      type: string
+                  required:
+                  - cron
+                  type: object
+                type: array
+              secretRef:
+                description: |-
+                  SecretRef specifies the Kubernetes Secret containing the basic-auth credentials
+                  to access the input provider.
+                  When connecting to a Git provider, the secret must contain the keys
+                  'username' and 'password', and the password should be a personal access token
+                  that grants read-only access to the repository.
+                  When connecting to an OCI provider, the secret must contain a Kubernetes
+                  Image Pull Secret, as if created by `kubectl create secret docker-registry`.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              serviceAccountName:
+                description: |-
+                  ServiceAccountName specifies the name of the Kubernetes ServiceAccount
+                  used for authentication with AWS, Azure or GCP services through
+                  workload identity federation features. If not specified, the
+                  authentication for these cloud providers will use the ServiceAccount
+                  of the operator (or any other environment authentication configuration).
+                type: string
+              skip:
+                description: Skip defines whether we need to skip input provider response
+                  updates.
+                properties:
+                  labels:
+                    description: |-
+                      Labels specifies list of labels to skip input provider response when any of the label conditions matched.
+                      When prefixed with !, input provider response will be skipped if it does not have this label.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              type:
+                description: Type specifies the type of the input provider.
+                enum:
+                - Static
+                - GitHubBranch
+                - GitHubTag
+                - GitHubPullRequest
+                - GitLabBranch
+                - GitLabTag
+                - GitLabMergeRequest
+                - GitLabEnvironment
+                - AzureDevOpsBranch
+                - AzureDevOpsTag
+                - AzureDevOpsPullRequest
+                - OCIArtifactTag
+                - ACRArtifactTag
+                - ECRArtifactTag
+                - GARArtifactTag
+                type: string
+              url:
+                description: |-
+                  URL specifies the HTTP/S or OCI address of the input provider API.
+                  When connecting to a Git provider, the URL should point to the repository address.
+                  When connecting to an OCI provider, the URL should point to the OCI repository address.
+                pattern: ^((http|https|oci)://.*){0,1}$
+                type: string
+            required:
+            - type
+            type: object
+            x-kubernetes-validations:
+            - message: spec.url must be empty when spec.type is 'Static'
+              rule: self.type != 'Static' || !has(self.url)
+            - message: spec.url must not be empty when spec.type is not 'Static'
+              rule: self.type == 'Static' || has(self.url)
+            - message: spec.url must start with 'http://' or 'https://' when spec.type
+                is a Git provider
+              rule: '!self.type.startsWith(''Git'') || self.url.startsWith(''http'')'
+            - message: spec.url must start with 'http://' or 'https://' when spec.type
+                is a Git provider
+              rule: '!self.type.startsWith(''AzureDevOps'') || self.url.startsWith(''http'')'
+            - message: spec.url must start with 'oci://' when spec.type is an OCI
+                provider
+              rule: '!self.type.endsWith(''ArtifactTag'') || self.url.startsWith(''oci'')'
+            - message: cannot specify spec.serviceAccountName when spec.type is not
+                one of AzureDevOps* or *ArtifactTag
+              rule: '!has(self.serviceAccountName) || self.type.startsWith(''AzureDevOps'')
+                || self.type.endsWith(''ArtifactTag'')'
+            - message: cannot specify spec.certSecretRef when spec.type is one of
+                Static, AzureDevOps*, ACRArtifactTag, ECRArtifactTag or GARArtifactTag
+              rule: '!has(self.certSecretRef) || !(self.url == ''Static'' || self.type.startsWith(''AzureDevOps'')
+                || (self.type.endsWith(''ArtifactTag'') && self.type != ''OCIArtifactTag''))'
+            - message: cannot specify spec.secretRef when spec.type is one of Static,
+                ACRArtifactTag, ECRArtifactTag or GARArtifactTag
+              rule: '!has(self.secretRef) || !(self.url == ''Static'' || (self.type.endsWith(''ArtifactTag'')
+                && self.type != ''OCIArtifactTag''))'
+          status:
+            description: ResourceSetInputProviderStatus defines the observed state
+              of ResourceSetInputProvider.
+            properties:
+              conditions:
+                description: Conditions contains the readiness conditions of the object.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              exportedInputs:
+                description: ExportedInputs contains the list of inputs exported by
+                  the provider.
+                items:
+                  additionalProperties:
+                    x-kubernetes-preserve-unknown-fields: true
+                  description: ResourceSetInput defines the key-value pairs of the
+                    ResourceSet input.
+                  type: object
+                type: array
+              lastExportedRevision:
+                description: |-
+                  LastExportedRevision is the digest of the
+                  inputs that were last reconcile.
+                type: string
+              lastHandledForceAt:
+                description: |-
+                  LastHandledForceAt holds the value of the most recent
+                  force request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              nextSchedule:
+                description: NextSchedule is the next schedule when the input provider
+                  will run.
+                properties:
+                  cron:
+                    description: Cron specifies the cron expression for the schedule.
+                    type: string
+                  timeZone:
+                    default: UTC
+                    description: TimeZone specifies the time zone for the cron schedule.
+                      Defaults to UTC.
+                    type: string
+                  when:
+                    description: When is the next time the schedule will run.
+                    format: date-time
+                    type: string
+                  window:
+                    default: 0s
+                    description: |-
+                      Window defines the time window during which the execution is allowed.
+                      Defaults to 0s, meaning no window is applied.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                required:
+                - cron
+                - when
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: resourcesets.fluxcd.controlplane.io
+spec:
+  group: fluxcd.controlplane.io
+  names:
+    kind: ResourceSet
+    listKind: ResourceSetList
+    plural: resourcesets
+    shortNames:
+    - rset
+    singular: resourceset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ResourceSet is the Schema for the ResourceSets API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ResourceSetSpec defines the desired state of ResourceSet
+            properties:
+              commonMetadata:
+                description: |-
+                  CommonMetadata specifies the common labels and annotations that are
+                  applied to all resources. Any existing label or annotation will be
+                  overridden if its key matches a common one.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations to be added to the object's metadata.
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels to be added to the object's metadata.
+                    type: object
+                type: object
+              dependsOn:
+                description: |-
+                  DependsOn specifies the list of Kubernetes resources that must
+                  exist on the cluster before the reconciliation process starts.
+                items:
+                  description: Dependency defines a ResourceSet dependency on a Kubernetes
+                    resource.
+                  properties:
+                    apiVersion:
+                      description: APIVersion of the resource to depend on.
+                      type: string
+                    kind:
+                      description: Kind of the resource to depend on.
+                      type: string
+                    name:
+                      description: Name of the resource to depend on.
+                      type: string
+                    namespace:
+                      description: Namespace of the resource to depend on.
+                      type: string
+                    ready:
+                      description: Ready checks if the resource Ready status condition
+                        is true.
+                      type: boolean
+                    readyExpr:
+                      description: |-
+                        ReadyExpr checks if the resource satisfies the given CEL expression.
+                        The expression replaces the default readiness check and
+                        is only evaluated if Ready is set to 'true'.
+                      type: string
+                  required:
+                  - apiVersion
+                  - kind
+                  - name
+                  type: object
+                type: array
+              inputStrategy:
+                description: |-
+                  InputStrategy defines how the inputs are combined when multiple
+                  input provider objects are used. Defaults to flattening all inputs
+                  from all providers into a single list of input sets.
+                properties:
+                  name:
+                    description: |-
+                      Name defines how the inputs are combined when multiple
+                      input provider objects are used. Supported values are:
+                      - Flatten: all inputs sets from all input provider objects are
+                        flattened into a single list of input sets.
+                      - Permute: all inputs sets from all input provider objects are
+                        combined using a Cartesian product, resulting in a list of input sets
+                        that contains every possible combination of input values.
+                        For example, if provider A has inputs [{x: 1}, {x: 2}] and provider B has
+                        inputs [{y: "a"}, {y: "b"}], the resulting input sets will be:
+                        [{x: 1, y: "a"}, {x: 1, y: "b"}, {x: 2, y: "a"}, {x: 2, y: "b"}].
+                        This strategy can lead to a large number of input sets and should be
+                        used with caution. Users should use filtering features from
+                        ResourceSetInputProvider to limit the amount of exported inputs.
+                    enum:
+                    - Flatten
+                    - Permute
+                    type: string
+                required:
+                - name
+                type: object
+              inputs:
+                description: Inputs contains the list of ResourceSet inputs.
+                items:
+                  additionalProperties:
+                    x-kubernetes-preserve-unknown-fields: true
+                  description: ResourceSetInput defines the key-value pairs of the
+                    ResourceSet input.
+                  type: object
+                type: array
+              inputsFrom:
+                description: |-
+                  InputsFrom contains the list of references to input providers.
+                  When set, the inputs are fetched from the providers and concatenated
+                  with the in-line inputs defined in the ResourceSet.
+                items:
+                  description: |-
+                    InputProviderReference defines a reference to an input provider resource
+                    in the same namespace as the ResourceSet.
+                  properties:
+                    apiVersion:
+                      description: |-
+                        APIVersion of the input provider resource.
+                        When not set, the APIVersion of the ResourceSet is used.
+                      enum:
+                      - fluxcd.controlplane.io/v1
+                      type: string
+                    kind:
+                      description: Kind of the input provider resource.
+                      enum:
+                      - ResourceSetInputProvider
+                      type: string
+                    name:
+                      description: |-
+                        Name of the input provider resource. Cannot be set
+                        when the Selector field is set.
+                      type: string
+                    selector:
+                      description: |-
+                        Selector is a label selector to filter the input provider resources
+                        as an alternative to the Name field.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                  x-kubernetes-validations:
+                  - message: at least one of name or selector must be set for input
+                      provider references
+                    rule: has(self.name) || has(self.selector)
+                  - message: cannot set both name and selector for input provider
+                      references
+                    rule: '!has(self.name) || !has(self.selector)'
+                type: array
+              resources:
+                description: Resources contains the list of Kubernetes resources to
+                  reconcile.
+                items:
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
+              resourcesTemplate:
+                description: |-
+                  ResourcesTemplate is a Go template that generates the list of
+                  Kubernetes resources to reconcile. The template is rendered
+                  as multi-document YAML, the resources should be separated by '---'.
+                  When both Resources and ResourcesTemplate are set, the resulting
+                  objects are merged and deduplicated, with the ones from Resources taking precedence.
+                type: string
+              serviceAccountName:
+                description: |-
+                  The name of the Kubernetes service account to impersonate
+                  when reconciling the generated resources.
+                type: string
+              wait:
+                description: |-
+                  Wait instructs the controller to check the health
+                  of all the reconciled resources.
+                type: boolean
+            type: object
+          status:
+            description: ResourceSetStatus defines the observed state of ResourceSet.
+            properties:
+              conditions:
+                description: Conditions contains the readiness conditions of the object.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              history:
+                description: |-
+                  History contains the reconciliation history of the ResourceSet
+                  as a list of snapshots ordered by the last reconciled time.
+                items:
+                  description: |-
+                    Snapshot represents a point-in-time record of a group of resources reconciliation,
+                    including timing information, status, and a unique digest identifier.
+                  properties:
+                    digest:
+                      description: Digest is the checksum in the format `<algo>:<hex>`
+                        of the resources in this snapshot.
+                      type: string
+                    firstReconciled:
+                      description: FirstReconciled is the time when this revision
+                        was first reconciled to the cluster.
+                      format: date-time
+                      type: string
+                    lastReconciled:
+                      description: LastReconciled is the time when this revision was
+                        last reconciled to the cluster.
+                      format: date-time
+                      type: string
+                    lastReconciledDuration:
+                      description: LastReconciledDuration is time it took to reconcile
+                        the resources in this revision.
+                      type: string
+                    lastReconciledStatus:
+                      description: LastReconciledStatus is the status of the last
+                        reconciliation.
+                      type: string
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      description: Metadata contains additional information about
+                        the snapshot.
+                      type: object
+                    totalReconciliations:
+                      description: TotalReconciliations is the total number of reconciliations
+                        that have occurred for this snapshot.
+                      format: int64
+                      type: integer
+                  required:
+                  - digest
+                  - firstReconciled
+                  - lastReconciled
+                  - lastReconciledDuration
+                  - lastReconciledStatus
+                  - totalReconciliations
+                  type: object
+                type: array
+              inventory:
+                description: |-
+                  Inventory contains a list of Kubernetes resource object references
+                  last applied on the cluster.
+                properties:
+                  entries:
+                    description: Entries of Kubernetes resource object references.
+                    items:
+                      description: ResourceRef contains the information necessary
+                        to locate a resource within a cluster.
+                      properties:
+                        id:
+                          description: |-
+                            ID is the string representation of the Kubernetes resource object's metadata,
+                            in the format '<namespace>_<name>_<group>_<kind>'.
+                          type: string
+                        v:
+                          description: Version is the API version of the Kubernetes
+                            resource object's kind.
+                          type: string
+                      required:
+                      - id
+                      - v
+                      type: object
+                    type: array
+                required:
+                - entries
+                type: object
+              lastAppliedRevision:
+                description: |-
+                  LastAppliedRevision is the digest of the
+                  generated resources that were last reconcile.
+                type: string
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: flux-operator
+  name: flux-operator
+  namespace: flux-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: flux-operator-edit
+rules:
+- apiGroups:
+  - fluxcd.controlplane.io
+  resources:
+  - resourcesets
+  - resourcesetinputproviders
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: flux-operator-view
+rules:
+- apiGroups:
+  - fluxcd.controlplane.io
+  resources:
+  - resourcesets
+  - resourcesetinputproviders
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flux-operator-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: flux-operator
+  namespace: flux-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: flux-operator
+  name: flux-operator
+  namespace: flux-system
+spec:
+  ports:
+  - name: http-web
+    port: 9080
+    protocol: TCP
+    targetPort: 9080
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/name: flux-operator
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: flux-operator
+  name: flux-operator
+  namespace: flux-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: flux-operator
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: flux-operator
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      containers:
+      - env:
+        - name: RUNTIME_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: ghcr.io/controlplaneio-fluxcd/flux-operator:v0.40.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9080
+          name: http-web
+          protocol: TCP
+        - containerPort: 8080
+          name: http-metrics
+          protocol: TCP
+        - containerPort: 8081
+          name: http
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 1Gi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /tmp
+          name: temp
+      serviceAccountName: flux-operator
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - emptyDir: {}
+        name: temp


### PR DESCRIPTION
## Summary

`BootstrapGenerator` in `flux-operator` mode previously returned only the `FluxInstance` CR, forcing every caller to separately install the Flux Operator CRDs, RBAC, and controller Deployment before the output would apply cleanly. This was flagged as an implementation prerequisite in crane's bootstrap-chain design doc (§9) and is blocking autops/wharf/crane#13 (bootstrap.render NATS handler).

This PR makes the generator self-sufficient: it now prepends the full upstream Flux Operator install bundle (Namespace, 4 CRDs, 2 ClusterRoles, ClusterRoleBinding, ServiceAccount, Service, Deployment) ahead of the `FluxInstance`, so a single apply of the result stands up flux-operator from scratch.

No changes to `generateGotkBootstrap` — gotk mode still uses `fluxcd/flux2` `install.Generate()` as before.

## Implementation

### New files

- **`pkg/stack/fluxcd/flux_operator_install.yaml`** — vendored from the upstream [fluxcd/flux-operator v0.40.0 release](https://github.com/controlplaneio-fluxcd/flux-operator/releases/tag/v0.40.0) (matches the Go module version pinned in `go.mod`). 11 resources total.
- **`pkg/stack/fluxcd/flux_operator_install.go`** — exports:
  - `FluxOperatorVersion` constant (`"v0.40.0"`) so callers can surface the pinned version in metadata
  - `FluxOperatorInstallObjects() ([]client.Object, error)` loader — embeds via `//go:embed`, parses through the existing `kio.ParseYAML` helper, caches the parsed slice via `sync.Once` so repeated calls are cheap.

A refresh procedure for future version bumps is documented in `flux_operator_install.go`'s doc comment.

### Modified

- **`pkg/stack/fluxcd/bootstrap_generator.go`** — `generateFluxOperatorBootstrap` now calls `FluxOperatorInstallObjects()` and appends `generateFluxInstance(...)`. Output order is install-bundle-first so the CRDs land before the `FluxInstance` CR (also a valid apply order).
- **`pkg/stack/fluxcd/bootstrap_generator_test.go`** — existing tests that asserted `resources[0]` was the `FluxInstance` or `len(resources) == 1` are updated to use a new `findFluxInstance` helper. Two new tests added:
  - `TestFluxOperatorInstallObjects` — verifies the vendored manifest parses and asserts the per-kind resource inventory (1 Namespace, 4 CRDs, 1 ServiceAccount, 2 ClusterRoles, 1 ClusterRoleBinding, 1 Service, 1 Deployment). If the manifest is bumped, this inventory should be updated deliberately.
  - `TestFluxOperatorBootstrapIncludesInstallBundle` — asserts that `flux-operator` mode emits the install bundle + a trailing `FluxInstance` as the last object (so apply order is correct).

### CHANGELOG

New `[Unreleased]` section at the top of `CHANGELOG.md` describing the change.

## Test plan

- [x] `go build ./pkg/stack/fluxcd/...` clean
- [x] `go test ./pkg/stack/fluxcd/...` — all tests pass, including the 2 new tests and the 5 updated ones
- [x] `go test ./...` — full kure test suite passes (no regressions in other packages)
- [x] `golangci-lint run ./pkg/stack/fluxcd/...` — 0 issues
- [ ] CI pipeline green

## Consumer impact

Breaking change for any caller that assumed `flux-operator` mode returned exactly one object or that `resources[0]` was the `FluxInstance`. Known consumers:

- **crane** (autops/wharf/crane) — waits on this PR. crane#13 is the tracking ticket; it will bump kure's dep once this lands and a new pre-release is cut (rc.5 is already the `VERSION` tip).

Any consumer that wants _only_ the `FluxInstance` can type-assert while iterating the returned slice.

## Refresh procedure

Documented in `flux_operator_install.go`:

1. Bump `github.com/controlplaneio-fluxcd/flux-operator` in `go.mod`.
2. Download the matching `install.yaml` from the upstream GitHub release: `https://github.com/controlplaneio-fluxcd/flux-operator/releases/download/{version}/install.yaml`
3. Replace `pkg/stack/fluxcd/flux_operator_install.yaml`.
4. Update `FluxOperatorVersion`.
5. Re-run `TestFluxOperatorInstallObjects` and update the per-kind inventory if the upstream manifest changed shape.

## Refs

- Blocks autops/wharf/crane#13 (bootstrap.render NATS handler)
- Related: crane bootstrap-chain design doc §9 ("Implementation Prerequisites")
- Upstream release: https://github.com/controlplaneio-fluxcd/flux-operator/releases/tag/v0.40.0