### PR TITLE
feat(stack/layout): propagate FileNaming to ManifestLayout and WriteToTar

### DIFF
--- a/pkg/stack/layout/README.md
+++ b/pkg/stack/layout/README.md
@@ -21,6 +21,7 @@ The layout module transforms Kure's in-memory stack representation (Clusters →
 - **ApplicationGrouping**: How applications within bundles are organized
 - **FilePer**: How resources are written (FilePerResource vs FilePerKind)
 - **FluxPlacement**: Where Flux Kustomizations go (FluxSeparate vs FluxIntegrated)
+- **FileNaming**: Resource file naming pattern (FileNamingDefault vs FileNamingKindName)
 
 ### 3. Two Main Walker Functions
 - **WalkCluster()**: Standard hierarchical layout (Node → Bundle → App structure)

--- a/pkg/stack/layout/manifest.go
+++ b/pkg/stack/layout/manifest.go
@@ -21,7 +21,8 @@ type ManifestLayout struct {
 	FilePer             FileExportMode
 	ApplicationFileMode ApplicationFileMode
 	Mode                KustomizationMode
-	FluxPlacement       FluxPlacement // Track flux placement mode for kustomization generation
+	FluxPlacement       FluxPlacement  // Track flux placement mode for kustomization generation
+	FileNaming          FileNamingMode // Controls resource file naming pattern
 	Resources           []client.Object
 	Children            []*ManifestLayout
 	// UmbrellaChild marks this layout as rendered from a Bundle.Children
@@ -31,6 +32,18 @@ type ManifestLayout struct {
 	// child's Flux Kustomization CR at the parent layout node rather than in
 	// the child's own directory.
 	UmbrellaChild bool
+}
+
+// resolveManifestFileName returns the effective ManifestFileNameFunc for this
+// layout. It mirrors Config.ResolveManifestFileName but uses the layout's own
+// FileNaming field.
+func (ml *ManifestLayout) resolveManifestFileName() ManifestFileNameFunc {
+	switch ml.FileNaming {
+	case FileNamingKindName:
+		return KindNameManifestFileName
+	default:
+		return DefaultManifestFileName
+	}
 }
 
 func (ml *ManifestLayout) FullRepoPath() string {

--- a/pkg/stack/layout/tar.go
+++ b/pkg/stack/layout/tar.go
@@ -131,8 +131,10 @@ func (ml *ManifestLayout) writeToTarRecursive(tw *tar.Writer, basePath string) e
 			if child.ApplicationFileMode == AppFileSingle {
 				kustomBuf.WriteString(fmt.Sprintf("  - %s.yaml\n", child.Name))
 			} else if ml.FluxPlacement == FluxIntegrated {
-				// FluxIntegrated: reference Flux Kustomization YAML files
-				fluxKustName := nameFn("flux-system", "kustomization", child.Name, fileMode)
+				// FluxIntegrated: reference Flux Kustomization YAML files.
+				// Always use FilePerResource here — each child must have a
+				// unique filename; FilePerKind would drop child.Name.
+				fluxKustName := nameFn("flux-system", "kustomization", child.Name, FilePerResource)
 				kustomBuf.WriteString(fmt.Sprintf("  - %s\n", fluxKustName))
 			} else {
 				if ml.PackageRef != nil && child.PackageRef != nil && ml.PackageRef != child.PackageRef {

--- a/pkg/stack/layout/tar.go
+++ b/pkg/stack/layout/tar.go
@@ -45,6 +45,8 @@ func (ml *ManifestLayout) writeToTarRecursive(tw *tar.Writer, basePath string) e
 		return err
 	}
 
+	nameFn := ml.resolveManifestFileName()
+
 	// Group resources into files
 	fileGroups := map[string][]client.Object{}
 	for _, obj := range ml.Resources {
@@ -60,12 +62,7 @@ func (ml *ManifestLayout) writeToTarRecursive(tw *tar.Writer, basePath string) e
 		if appMode == AppFileSingle {
 			fileName = fmt.Sprintf("%s.yaml", ml.Name)
 		} else {
-			switch fileMode {
-			case FilePerKind:
-				fileName = fmt.Sprintf("%s-%s.yaml", ns, kind)
-			default:
-				fileName = fmt.Sprintf("%s-%s-%s.yaml", ns, kind, name)
-			}
+			fileName = nameFn(ns, kind, name, fileMode)
 		}
 
 		fileGroups[fileName] = append(fileGroups[fileName], obj)
@@ -135,7 +132,7 @@ func (ml *ManifestLayout) writeToTarRecursive(tw *tar.Writer, basePath string) e
 				kustomBuf.WriteString(fmt.Sprintf("  - %s.yaml\n", child.Name))
 			} else if ml.FluxPlacement == FluxIntegrated {
 				// FluxIntegrated: reference Flux Kustomization YAML files
-				fluxKustName := fmt.Sprintf("flux-system-kustomization-%s.yaml", child.Name)
+				fluxKustName := nameFn("flux-system", "kustomization", child.Name, fileMode)
 				kustomBuf.WriteString(fmt.Sprintf("  - %s\n", fluxKustName))
 			} else {
 				if ml.PackageRef != nil && child.PackageRef != nil && ml.PackageRef != child.PackageRef {

--- a/pkg/stack/layout/tar_test.go
+++ b/pkg/stack/layout/tar_test.go
@@ -266,6 +266,110 @@ func TestWriteToTar_UmbrellaChild(t *testing.T) {
 	}
 }
 
+func TestWriteToTar_FileNamingKindName(t *testing.T) {
+	ml := &ManifestLayout{
+		Name:       "apps",
+		Namespace:  "default",
+		FilePer:    FilePerResource,
+		FileNaming: FileNamingKindName,
+		Mode:       KustomizationExplicit,
+		Resources: []client.Object{
+			&corev1.Service{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+				ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+			},
+			&appsv1.Deployment{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
+				ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := ml.WriteToTar(&buf); err != nil {
+		t.Fatalf("WriteToTar failed: %v", err)
+	}
+
+	files := extractTarFiles(t, &buf)
+
+	// With FileNamingKindName, files should be {kind}-{name}.yaml (no namespace prefix)
+	expectedFiles := []string{
+		"default/apps/",
+		"default/apps/service-web.yaml",
+		"default/apps/deployment-web.yaml",
+		"default/apps/kustomization.yaml",
+	}
+	for _, expected := range expectedFiles {
+		if _, ok := files[expected]; !ok {
+			t.Errorf("missing expected file: %s (got: %v)", expected, fileNames(files))
+		}
+	}
+
+	// Should NOT have namespace-prefixed files
+	for name := range files {
+		if name == "default/apps/default-service-web.yaml" || name == "default/apps/default-deployment-web.yaml" {
+			t.Errorf("unexpected namespace-prefixed file: %s", name)
+		}
+	}
+
+	// Kustomization should reference the kind-name files
+	kustomContent := string(files["default/apps/kustomization.yaml"])
+	if !bytes.Contains([]byte(kustomContent), []byte("service-web.yaml")) {
+		t.Errorf("kustomization.yaml should reference service-web.yaml:\n%s", kustomContent)
+	}
+	if !bytes.Contains([]byte(kustomContent), []byte("deployment-web.yaml")) {
+		t.Errorf("kustomization.yaml should reference deployment-web.yaml:\n%s", kustomContent)
+	}
+}
+
+func TestWriteToTar_FileNamingKindName_FluxIntegrated(t *testing.T) {
+	child := &ManifestLayout{
+		Name:       "team-a",
+		Namespace:  "cl/flux-system/team-a",
+		FilePer:    FilePerResource,
+		FileNaming: FileNamingKindName,
+		Mode:       KustomizationExplicit,
+		Resources: []client.Object{
+			&corev1.ConfigMap{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+				ObjectMeta: metav1.ObjectMeta{Name: "ca", Namespace: "flux-system"},
+			},
+		},
+	}
+
+	root := &ManifestLayout{
+		Name:          "flux-root",
+		Namespace:     "cl/flux-system",
+		FluxPlacement: FluxIntegrated,
+		FilePer:       FilePerResource,
+		FileNaming:    FileNamingKindName,
+		Mode:          KustomizationExplicit,
+		Children:      []*ManifestLayout{child},
+	}
+
+	var buf bytes.Buffer
+	if err := root.WriteToTar(&buf); err != nil {
+		t.Fatalf("WriteToTar failed: %v", err)
+	}
+
+	files := extractTarFiles(t, &buf)
+
+	// With FileNamingKindName, the flux kustomization reference should be
+	// kustomization-team-a.yaml (not flux-system-kustomization-team-a.yaml)
+	rootKustom := string(files["cl/flux-system/flux-root/kustomization.yaml"])
+	if !bytes.Contains([]byte(rootKustom), []byte("kustomization-team-a.yaml")) {
+		t.Errorf("expected kustomization-team-a.yaml reference, got:\n%s", rootKustom)
+	}
+	if bytes.Contains([]byte(rootKustom), []byte("flux-system-kustomization-team-a.yaml")) {
+		t.Errorf("should not have namespace-prefixed flux kustomization reference, got:\n%s", rootKustom)
+	}
+
+	// Child resource should use kind-name format
+	if _, ok := files["cl/flux-system/team-a/configmap-ca.yaml"]; !ok {
+		t.Errorf("missing kind-name child resource file (got: %v)", fileNames(files))
+	}
+}
+
 // extractTarFiles reads all entries from a tar archive into a map.
 func extractTarFiles(t *testing.T, buf *bytes.Buffer) map[string][]byte {
 	t.Helper()

--- a/pkg/stack/layout/tar_test.go
+++ b/pkg/stack/layout/tar_test.go
@@ -370,6 +370,60 @@ func TestWriteToTar_FileNamingKindName_FluxIntegrated(t *testing.T) {
 	}
 }
 
+func TestWriteToTar_FilePerKind_FluxIntegrated(t *testing.T) {
+	// Regression: FilePerKind must not collapse FluxIntegrated kustomization
+	// references — each child needs a unique filename including child.Name.
+	childA := &ManifestLayout{
+		Name:      "team-a",
+		Namespace: "cl/flux-system/team-a",
+		FilePer:   FilePerKind,
+		Mode:      KustomizationExplicit,
+		Resources: []client.Object{
+			&corev1.ConfigMap{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+				ObjectMeta: metav1.ObjectMeta{Name: "cfg-a", Namespace: "flux-system"},
+			},
+		},
+	}
+	childB := &ManifestLayout{
+		Name:      "team-b",
+		Namespace: "cl/flux-system/team-b",
+		FilePer:   FilePerKind,
+		Mode:      KustomizationExplicit,
+		Resources: []client.Object{
+			&corev1.ConfigMap{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+				ObjectMeta: metav1.ObjectMeta{Name: "cfg-b", Namespace: "flux-system"},
+			},
+		},
+	}
+
+	root := &ManifestLayout{
+		Name:          "flux-root",
+		Namespace:     "cl/flux-system",
+		FluxPlacement: FluxIntegrated,
+		FilePer:       FilePerKind,
+		Mode:          KustomizationExplicit,
+		Children:      []*ManifestLayout{childA, childB},
+	}
+
+	var buf bytes.Buffer
+	if err := root.WriteToTar(&buf); err != nil {
+		t.Fatalf("WriteToTar failed: %v", err)
+	}
+
+	files := extractTarFiles(t, &buf)
+	rootKustom := string(files["cl/flux-system/flux-root/kustomization.yaml"])
+
+	// Each child must have a distinct reference
+	if !bytes.Contains([]byte(rootKustom), []byte("flux-system-kustomization-team-a.yaml")) {
+		t.Errorf("expected flux-system-kustomization-team-a.yaml reference, got:\n%s", rootKustom)
+	}
+	if !bytes.Contains([]byte(rootKustom), []byte("flux-system-kustomization-team-b.yaml")) {
+		t.Errorf("expected flux-system-kustomization-team-b.yaml reference, got:\n%s", rootKustom)
+	}
+}
+
 // extractTarFiles reads all entries from a tar archive into a map.
 func extractTarFiles(t *testing.T, buf *bytes.Buffer) map[string][]byte {
 	t.Helper()

--- a/pkg/stack/layout/walker.go
+++ b/pkg/stack/layout/walker.go
@@ -55,7 +55,7 @@ func WalkCluster(c *stack.Cluster, rules LayoutRules) (*ManifestLayout, error) {
 	}
 
 	// Traditional layout without cluster name
-	ml, err := walkNode(c.Node, nil, nodeOnly, nodeFlat, filePer, nil, rules.FluxPlacement)
+	ml, err := walkNode(c.Node, nil, nodeOnly, nodeFlat, filePer, nil, rules.FluxPlacement, rules.FileNaming)
 	if err != nil {
 		return nil, err
 	}
@@ -72,19 +72,21 @@ func WalkCluster(c *stack.Cluster, rules LayoutRules) (*ManifestLayout, error) {
 func walkClusterWithClusterName(c *stack.Cluster, rules LayoutRules, nodeOnly bool, filePer FileExportMode) (*ManifestLayout, error) {
 	// Create a cluster-level layout with the cluster name as the root
 	clusterLayout := &ManifestLayout{
-		Name:      "",
-		Namespace: rules.ClusterName,
-		FilePer:   filePer,
-		Children:  []*ManifestLayout{},
+		Name:       "",
+		Namespace:  rules.ClusterName,
+		FilePer:    filePer,
+		FileNaming: rules.FileNaming,
+		Children:   []*ManifestLayout{},
 	}
 
 	// Build the root node layout. Done unconditionally (even when the root
 	// node has no Bundle) so child-node subtrees can be nested underneath it.
 	rootLayout := &ManifestLayout{
-		Name:      c.Node.Name,
-		Namespace: filepath.Join(rules.ClusterName, c.Node.Name),
-		FilePer:   filePer,
-		Children:  []*ManifestLayout{},
+		Name:       c.Node.Name,
+		Namespace:  filepath.Join(rules.ClusterName, c.Node.Name),
+		FilePer:    filePer,
+		FileNaming: rules.FileNaming,
+		Children:   []*ManifestLayout{},
 	}
 
 	if c.Node.Bundle != nil {
@@ -114,6 +116,7 @@ func walkClusterWithClusterName(c *stack.Cluster, rules LayoutRules, nodeOnly bo
 				[]string{rules.ClusterName, c.Node.Name},
 				filePer,
 				rules.FluxPlacement,
+				rules.FileNaming,
 			)
 			if err != nil {
 				return nil, err
@@ -128,7 +131,7 @@ func walkClusterWithClusterName(c *stack.Cluster, rules LayoutRules, nodeOnly bo
 	// searches for the corresponding layout node.
 	nodeFlat := rules.NodeGrouping == GroupFlat
 	for _, child := range c.Node.Children {
-		childLayout, err := walkNode(child, []string{rules.ClusterName, c.Node.Name}, nodeOnly, nodeFlat, filePer, nil, rules.FluxPlacement)
+		childLayout, err := walkNode(child, []string{rules.ClusterName, c.Node.Name}, nodeOnly, nodeFlat, filePer, nil, rules.FluxPlacement, rules.FileNaming)
 		if err != nil {
 			return nil, err
 		}
@@ -199,7 +202,7 @@ func WalkClusterByPackage(c *stack.Cluster, rules LayoutRules) (map[string]*Mani
 // walkNode recursively processes a stack.Node and its children.
 // When nodeFlat is true, child nodes do not create subdirectories; their
 // resources are merged into the parent ManifestLayout.
-func walkNode(n *stack.Node, ancestors []string, nodeOnly bool, nodeFlat bool, filePer FileExportMode, inheritedPackageRef *schema.GroupVersionKind, fluxPlacement FluxPlacement) (*ManifestLayout, error) {
+func walkNode(n *stack.Node, ancestors []string, nodeOnly bool, nodeFlat bool, filePer FileExportMode, inheritedPackageRef *schema.GroupVersionKind, fluxPlacement FluxPlacement, fileNaming FileNamingMode) (*ManifestLayout, error) {
 	if n == nil {
 		return nil, nil
 	}
@@ -213,7 +216,8 @@ func walkNode(n *stack.Node, ancestors []string, nodeOnly bool, nodeFlat bool, f
 		Name:          n.Name,
 		Namespace:     filepath.Join(ancestors...),
 		FilePer:       filePer,
-		FluxPlacement: fluxPlacement, // Pass flux placement mode
+		FluxPlacement: fluxPlacement,
+		FileNaming:    fileNaming,
 	}
 
 	if nodeOnly {
@@ -237,7 +241,7 @@ func walkNode(n *stack.Node, ancestors []string, nodeOnly bool, nodeFlat bool, f
 			// node layout in nodeOnly mode (no intermediate bundle layer).
 			if len(b.Children) > 0 {
 				b.InitializeUmbrella()
-				umbrellaChildren, err := walkUmbrellaChildLayouts(b.Children, currentPath, filePer, fluxPlacement)
+				umbrellaChildren, err := walkUmbrellaChildLayouts(b.Children, currentPath, filePer, fluxPlacement, fileNaming)
 				if err != nil {
 					return nil, err
 				}
@@ -267,8 +271,9 @@ func walkNode(n *stack.Node, ancestors []string, nodeOnly bool, nodeFlat bool, f
 					Name:          app.Name,
 					Namespace:     filepath.Join(append(currentPath, b.Name)...),
 					Resources:     objs,
-					Mode:          KustomizationExplicit, // Ensure applications get their own kustomization.yaml
-					FluxPlacement: fluxPlacement,         // Pass flux placement mode
+					Mode:          KustomizationExplicit,
+					FluxPlacement: fluxPlacement,
+					FileNaming:    fileNaming,
 				}
 				bundleChildren = append(bundleChildren, appLayout)
 			}
@@ -276,7 +281,7 @@ func walkNode(n *stack.Node, ancestors []string, nodeOnly bool, nodeFlat bool, f
 			// sub-layouts within the bundle's layout directory.
 			if len(b.Children) > 0 {
 				b.InitializeUmbrella()
-				umbrellaChildren, err := walkUmbrellaChildLayouts(b.Children, append(currentPath, b.Name), filePer, fluxPlacement)
+				umbrellaChildren, err := walkUmbrellaChildLayouts(b.Children, append(currentPath, b.Name), filePer, fluxPlacement, fileNaming)
 				if err != nil {
 					return nil, err
 				}
@@ -286,14 +291,15 @@ func walkNode(n *stack.Node, ancestors []string, nodeOnly bool, nodeFlat bool, f
 				Name:          b.Name,
 				Namespace:     filepath.Join(currentPath...),
 				Children:      bundleChildren,
-				Mode:          KustomizationRecursive, // Bundle directories reference subdirectories
-				FluxPlacement: fluxPlacement,          // Pass flux placement mode
+				Mode:          KustomizationRecursive,
+				FluxPlacement: fluxPlacement,
+				FileNaming:    fileNaming,
 			}
 			children = append(children, bundleLayout)
 		}
 
 		for _, child := range n.Children {
-			cl, err := walkNode(child, currentPath, nodeOnly, nodeFlat, filePer, resolvePackageRef(n, inheritedPackageRef), fluxPlacement)
+			cl, err := walkNode(child, currentPath, nodeOnly, nodeFlat, filePer, resolvePackageRef(n, inheritedPackageRef), fluxPlacement, fileNaming)
 			if err != nil {
 				return nil, err
 			}
@@ -309,7 +315,7 @@ func walkNode(n *stack.Node, ancestors []string, nodeOnly bool, nodeFlat bool, f
 		for _, child := range n.Children {
 			if nodeFlat {
 				// Merge child node resources directly into this node
-				cl, err := walkNode(child, ancestors, nodeOnly, nodeFlat, filePer, resolvePackageRef(n, inheritedPackageRef), fluxPlacement)
+				cl, err := walkNode(child, ancestors, nodeOnly, nodeFlat, filePer, resolvePackageRef(n, inheritedPackageRef), fluxPlacement, fileNaming)
 				if err != nil {
 					return nil, err
 				}
@@ -321,7 +327,7 @@ func walkNode(n *stack.Node, ancestors []string, nodeOnly bool, nodeFlat bool, f
 					}
 				}
 			} else {
-				cl, err := walkNode(child, currentPath, nodeOnly, nodeFlat, filePer, resolvePackageRef(n, inheritedPackageRef), fluxPlacement)
+				cl, err := walkNode(child, currentPath, nodeOnly, nodeFlat, filePer, resolvePackageRef(n, inheritedPackageRef), fluxPlacement, fileNaming)
 				if err != nil {
 					return nil, err
 				}
@@ -342,7 +348,7 @@ func walkNode(n *stack.Node, ancestors []string, nodeOnly bool, nodeFlat bool, f
 // Flux CR. Child application resources are flattened into the child layout's
 // Resources (single-directory-per-child on disk). Nested umbrellas recurse so
 // grandchildren become sub-layouts of their immediate parent umbrella child.
-func walkUmbrellaChildLayouts(children []*stack.Bundle, currentPath []string, filePer FileExportMode, fluxPlacement FluxPlacement) ([]*ManifestLayout, error) {
+func walkUmbrellaChildLayouts(children []*stack.Bundle, currentPath []string, filePer FileExportMode, fluxPlacement FluxPlacement, fileNaming FileNamingMode) ([]*ManifestLayout, error) {
 	var out []*ManifestLayout
 	for _, cb := range children {
 		if cb == nil {
@@ -353,6 +359,7 @@ func walkUmbrellaChildLayouts(children []*stack.Bundle, currentPath []string, fi
 			Namespace:     filepath.Join(currentPath...),
 			FilePer:       filePer,
 			FluxPlacement: fluxPlacement,
+			FileNaming:    fileNaming,
 			Mode:          KustomizationExplicit,
 			UmbrellaChild: true,
 		}
@@ -373,7 +380,7 @@ func walkUmbrellaChildLayouts(children []*stack.Bundle, currentPath []string, fi
 		}
 		if len(cb.Children) > 0 {
 			cb.InitializeUmbrella()
-			nested, err := walkUmbrellaChildLayouts(cb.Children, append(currentPath, cb.Name), filePer, fluxPlacement)
+			nested, err := walkUmbrellaChildLayouts(cb.Children, append(currentPath, cb.Name), filePer, fluxPlacement, fileNaming)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Summary

- Add `FileNaming FileNamingMode` field to `ManifestLayout` struct
- Thread `FileNaming` from `LayoutRules` through the layout walker (`WalkCluster`, `walkNode`, `walkUmbrellaChildLayouts`, `walkClusterWithClusterName`)
- Replace hardcoded file naming in `writeToTarRecursive` with a resolved naming function that respects `FileNaming`
- Fix FluxIntegrated kustomization reference in tar output to also honor `FileNaming`

Unset `FileNaming` defaults to existing behavior, so this is fully backward compatible.

Closes #427

## Test plan

- [x] All existing `WriteToTar` tests pass unchanged (default naming)
- [x] New `TestWriteToTar_FileNamingKindName` — verifies `{kind}-{name}.yaml` filenames and kustomization references
- [x] New `TestWriteToTar_FileNamingKindName_FluxIntegrated` — verifies FluxIntegrated kustomization reference uses `kustomization-{name}.yaml`
- [x] Full suite: `mise run check` (lint, vet, tests)