### PR TITLE
fix(stack/layout): honor FileNaming in WriteToDisk, WriteManifest, and package walker

### DIFF
--- a/pkg/stack/argocd/argo.go
+++ b/pkg/stack/argocd/argo.go
@@ -152,10 +152,11 @@ func (w *WorkflowEngine) CreateLayoutWithResources(c *stack.Cluster, rulesInterf
 
 	if len(apps) > 0 {
 		argoCDLayout := &layout.ManifestLayout{
-			Name:      "argocd",
-			Namespace: filepath.Join(ml.Namespace, "argocd"),
-			FilePer:   layout.FilePerResource,
-			Resources: apps,
+			Name:       "argocd",
+			Namespace:  filepath.Join(ml.Namespace, "argocd"),
+			FilePer:    layout.FilePerResource,
+			FileNaming: ml.FileNaming,
+			Resources:  apps,
 		}
 		ml.Children = append(ml.Children, argoCDLayout)
 	}

--- a/pkg/stack/layout/manifest.go
+++ b/pkg/stack/layout/manifest.go
@@ -196,12 +196,8 @@ func (ml *ManifestLayout) WriteToDisk(basePath string) error {
 		if appMode == AppFileSingle {
 			fileName = fmt.Sprintf("%s.yaml", ml.Name)
 		} else {
-			switch fileMode {
-			case FilePerKind:
-				fileName = fmt.Sprintf("%s-%s.yaml", ns, kind)
-			default:
-				fileName = fmt.Sprintf("%s-%s-%s.yaml", ns, kind, name)
-			}
+			nameFn := ml.resolveManifestFileName()
+			fileName = nameFn(ns, kind, name, fileMode)
 		}
 
 		fileGroups[fileName] = append(fileGroups[fileName], obj)
@@ -299,8 +295,11 @@ func (ml *ManifestLayout) WriteToDisk(basePath string) error {
 			if child.ApplicationFileMode == AppFileSingle {
 				writeStr(fmt.Sprintf("  - %s.yaml\n", child.Name))
 			} else if ml.FluxPlacement == FluxIntegrated {
-				// FluxIntegrated: reference Flux Kustomization YAML files
-				fluxKustName := fmt.Sprintf("flux-system-kustomization-%s.yaml", child.Name)
+				// FluxIntegrated: reference Flux Kustomization YAML files.
+				// Use FilePerResource to force per-resource naming even when
+				// the parent directory uses FilePerKind.
+				nameFn := ml.resolveManifestFileName()
+				fluxKustName := nameFn("flux-system", "kustomization", child.Name, FilePerResource)
 				writeStr(fmt.Sprintf("  - %s\n", fluxKustName))
 			} else {
 				// For package-aware layouts, use relative path

--- a/pkg/stack/layout/walker.go
+++ b/pkg/stack/layout/walker.go
@@ -187,7 +187,7 @@ func WalkClusterByPackage(c *stack.Cluster, rules LayoutRules) (map[string]*Mani
 	// Second pass: build layouts for each package
 	layouts := make(map[string]*ManifestLayout)
 	for pkgKey, pkgRef := range packages {
-		layout, err := walkNodeForPackage(c.Node, nil, nodeOnly, filePer, pkgRef, pkgKey)
+		layout, err := walkNodeForPackage(c.Node, nil, nodeOnly, filePer, pkgRef, pkgKey, rules.FileNaming)
 		if err != nil {
 			return nil, err
 		}
@@ -423,12 +423,12 @@ func collectPackageRefs(n *stack.Node, inheritedPackageRef *schema.GroupVersionK
 }
 
 // walkNodeForPackage walks the tree but only includes nodes that belong to the specified package
-func walkNodeForPackage(n *stack.Node, ancestors []string, nodeOnly bool, filePer FileExportMode, targetPackageRef *schema.GroupVersionKind, targetKey string) (*ManifestLayout, error) {
-	return walkNodeForPackageInternal(n, ancestors, nodeOnly, filePer, nil, targetPackageRef, targetKey)
+func walkNodeForPackage(n *stack.Node, ancestors []string, nodeOnly bool, filePer FileExportMode, targetPackageRef *schema.GroupVersionKind, targetKey string, fileNaming FileNamingMode) (*ManifestLayout, error) {
+	return walkNodeForPackageInternal(n, ancestors, nodeOnly, filePer, nil, targetPackageRef, targetKey, fileNaming)
 }
 
 // walkNodeForPackageInternal is the internal implementation with inheritance tracking
-func walkNodeForPackageInternal(n *stack.Node, ancestors []string, nodeOnly bool, filePer FileExportMode, inheritedPackageRef *schema.GroupVersionKind, targetPackageRef *schema.GroupVersionKind, targetKey string) (*ManifestLayout, error) {
+func walkNodeForPackageInternal(n *stack.Node, ancestors []string, nodeOnly bool, filePer FileExportMode, inheritedPackageRef *schema.GroupVersionKind, targetPackageRef *schema.GroupVersionKind, targetKey string, fileNaming FileNamingMode) (*ManifestLayout, error) {
 	if n == nil {
 		return nil, nil
 	}
@@ -446,9 +446,10 @@ func walkNodeForPackageInternal(n *stack.Node, ancestors []string, nodeOnly bool
 	var ml *ManifestLayout
 	if belongsToPackage {
 		ml = &ManifestLayout{
-			Name:      n.Name,
-			Namespace: filepath.Join(ancestors...),
-			FilePer:   filePer,
+			Name:       n.Name,
+			Namespace:  filepath.Join(ancestors...),
+			FilePer:    filePer,
+			FileNaming: fileNaming,
 		}
 
 		if nodeOnly {
@@ -489,24 +490,26 @@ func walkNodeForPackageInternal(n *stack.Node, ancestors []string, nodeOnly bool
 						objs = append(objs, *o)
 					}
 					appLayout := &ManifestLayout{
-						Name:      app.Name,
-						Namespace: filepath.Join(append(currentPath, b.Name)...),
-						Resources: objs,
+						Name:       app.Name,
+						Namespace:  filepath.Join(append(currentPath, b.Name)...),
+						Resources:  objs,
+						FileNaming: fileNaming,
 					}
 					bundleChildren = append(bundleChildren, appLayout)
 				}
 				if len(bundleChildren) > 0 {
 					bundleLayout := &ManifestLayout{
-						Name:      b.Name,
-						Namespace: filepath.Join(currentPath...),
-						Children:  bundleChildren,
+						Name:       b.Name,
+						Namespace:  filepath.Join(currentPath...),
+						Children:   bundleChildren,
+						FileNaming: fileNaming,
 					}
 					children = append(children, bundleLayout)
 				}
 			}
 
 			for _, child := range n.Children {
-				cl, err := walkNodeForPackageInternal(child, currentPath, nodeOnly, filePer, currentPackageRef, targetPackageRef, targetKey)
+				cl, err := walkNodeForPackageInternal(child, currentPath, nodeOnly, filePer, currentPackageRef, targetPackageRef, targetKey, fileNaming)
 				if err != nil {
 					return nil, err
 				}
@@ -520,7 +523,7 @@ func walkNodeForPackageInternal(n *stack.Node, ancestors []string, nodeOnly bool
 
 		if nodeOnly {
 			for _, child := range n.Children {
-				cl, err := walkNodeForPackageInternal(child, currentPath, nodeOnly, filePer, currentPackageRef, targetPackageRef, targetKey)
+				cl, err := walkNodeForPackageInternal(child, currentPath, nodeOnly, filePer, currentPackageRef, targetPackageRef, targetKey, fileNaming)
 				if err != nil {
 					return nil, err
 				}
@@ -533,7 +536,7 @@ func walkNodeForPackageInternal(n *stack.Node, ancestors []string, nodeOnly bool
 		// Node doesn't belong to target package, but continue traversing children
 		// in case they have different PackageRef values
 		for _, child := range n.Children {
-			cl, err := walkNodeForPackageInternal(child, ancestors, nodeOnly, filePer, currentPackageRef, targetPackageRef, targetKey)
+			cl, err := walkNodeForPackageInternal(child, ancestors, nodeOnly, filePer, currentPackageRef, targetPackageRef, targetKey, fileNaming)
 			if err != nil {
 				return nil, err
 			}
@@ -542,10 +545,11 @@ func walkNodeForPackageInternal(n *stack.Node, ancestors []string, nodeOnly bool
 				// we need to create a minimal parent structure
 				if ml == nil {
 					ml = &ManifestLayout{
-						Name:      "",
-						Namespace: filepath.Join(ancestors...),
-						FilePer:   filePer,
-						Children:  []*ManifestLayout{cl},
+						Name:       "",
+						Namespace:  filepath.Join(ancestors...),
+						FilePer:    filePer,
+						FileNaming: fileNaming,
+						Children:   []*ManifestLayout{cl},
 					}
 				} else {
 					ml.Children = append(ml.Children, cl)

--- a/pkg/stack/layout/walker_test.go
+++ b/pkg/stack/layout/walker_test.go
@@ -720,3 +720,41 @@ func TestWalkCluster_Umbrella_Nested(t *testing.T) {
 		t.Errorf("nested umbrella Namespace = %q, want root/apps/platform/infra", nw.Namespace)
 	}
 }
+
+func TestWalkClusterByPackage_PropagatesFileNaming(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("v1")
+	obj.SetKind("ConfigMap")
+	obj.SetName("cm")
+	obj.SetNamespace("default")
+	var o client.Object = obj
+
+	app := stack.NewApplication("app1", "ns", &fakeConfig{objs: []*client.Object{&o}})
+	bundle := &stack.Bundle{Name: "bundle1", Applications: []*stack.Application{app}}
+	root := &stack.Node{Name: "root", Bundle: bundle}
+	cluster := &stack.Cluster{Name: "demo", Node: root}
+
+	packages, err := layout.WalkClusterByPackage(cluster, layout.LayoutRules{
+		FileNaming: layout.FileNamingKindName,
+	})
+	if err != nil {
+		t.Fatalf("walk cluster by package: %v", err)
+	}
+
+	for _, ml := range packages {
+		if ml.FileNaming != layout.FileNamingKindName {
+			t.Errorf("root layout FileNaming = %q, want %q", ml.FileNaming, layout.FileNamingKindName)
+		}
+		// Check children recursively
+		var check func(l *layout.ManifestLayout)
+		check = func(l *layout.ManifestLayout) {
+			if l.FileNaming != layout.FileNamingKindName {
+				t.Errorf("layout %q FileNaming = %q, want %q", l.Name, l.FileNaming, layout.FileNamingKindName)
+			}
+			for _, c := range l.Children {
+				check(c)
+			}
+		}
+		check(ml)
+	}
+}

--- a/pkg/stack/layout/write.go
+++ b/pkg/stack/layout/write.go
@@ -152,9 +152,10 @@ func WriteManifest(basePath string, cfg Config, ml *ManifestLayout) error {
 			if child.ApplicationFileMode == AppFileSingle {
 				writeStr(fmt.Sprintf("  - %s.yaml\n", child.Name))
 			} else {
-				// For FluxIntegrated mode, reference Flux Kustomization YAML files instead of directories
+				// For FluxIntegrated mode, reference Flux Kustomization YAML files instead of directories.
+				// Always use FilePerResource — each child must have a unique filename.
 				if ml.FluxPlacement == FluxIntegrated {
-					fluxKustName := fmt.Sprintf("flux-system-kustomization-%s.yaml", child.Name)
+					fluxKustName := manifestFileName("flux-system", "kustomization", child.Name, FilePerResource)
 					writeStr(fmt.Sprintf("  - %s\n", fluxKustName))
 				} else {
 					writeStr(fmt.Sprintf("  - %s\n", child.Name))

--- a/pkg/stack/layout/write_test.go
+++ b/pkg/stack/layout/write_test.go
@@ -989,3 +989,139 @@ func TestWriteManifest_UmbrellaChild(t *testing.T) {
 		}
 	}
 }
+
+func TestWriteManifest_FileNamingKindName_FluxIntegrated(t *testing.T) {
+	child := &ManifestLayout{
+		Name:       "team-a",
+		Namespace:  "cl/flux-system/team-a",
+		FileNaming: FileNamingKindName,
+		Resources:  []client.Object{testObject("v1", "ConfigMap", "ca", "flux-system")},
+	}
+
+	root := &ManifestLayout{
+		Name:          "flux-root",
+		Namespace:     "cl/flux-system",
+		FluxPlacement: FluxIntegrated,
+		FileNaming:    FileNamingKindName,
+		Children:      []*ManifestLayout{child},
+	}
+
+	cfg := DefaultLayoutConfig()
+	cfg.FileNaming = FileNamingKindName
+	cfg.ManifestFileName = nil // Let FileNaming take effect
+	dir := t.TempDir()
+
+	if err := WriteManifest(dir, cfg, root); err != nil {
+		t.Fatalf("WriteManifest failed: %v", err)
+	}
+
+	kustomFile := filepath.Join(dir, "clusters", "cl", "flux-system", "flux-root", "kustomization.yaml")
+	data, err := os.ReadFile(kustomFile)
+	if err != nil {
+		t.Fatalf("read kustomization: %v", err)
+	}
+
+	content := string(data)
+	// With FileNamingKindName, flux kustomization reference should be kustomization-team-a.yaml
+	if !strings.Contains(content, "kustomization-team-a.yaml") {
+		t.Errorf("expected kustomization-team-a.yaml reference, got:\n%s", content)
+	}
+	if strings.Contains(content, "flux-system-kustomization-team-a.yaml") {
+		t.Errorf("should not have namespace-prefixed flux kustomization reference, got:\n%s", content)
+	}
+
+	// Child resource should use kind-name format
+	childResFile := filepath.Join(dir, "clusters", "cl", "flux-system", "team-a", "configmap-ca.yaml")
+	if _, err := os.Stat(childResFile); err != nil {
+		t.Errorf("expected kind-name resource file at %s: %v", childResFile, err)
+	}
+}
+
+func TestWriteToDisk_FileNamingKindName(t *testing.T) {
+	ml := &ManifestLayout{
+		Name:       "apps",
+		Namespace:  "default",
+		FilePer:    FilePerResource,
+		FileNaming: FileNamingKindName,
+		Mode:       KustomizationExplicit,
+		Resources: []client.Object{
+			testObject("v1", "Service", "web", "default"),
+			testObject("apps/v1", "Deployment", "web", "default"),
+		},
+	}
+
+	dir := t.TempDir()
+	if err := ml.WriteToDisk(dir); err != nil {
+		t.Fatalf("WriteToDisk failed: %v", err)
+	}
+
+	// With FileNamingKindName, files should be {kind}-{name}.yaml
+	svcFile := filepath.Join(dir, "default", "apps", "service-web.yaml")
+	if _, err := os.Stat(svcFile); err != nil {
+		t.Errorf("expected service-web.yaml at %s: %v", svcFile, err)
+	}
+	deployFile := filepath.Join(dir, "default", "apps", "deployment-web.yaml")
+	if _, err := os.Stat(deployFile); err != nil {
+		t.Errorf("expected deployment-web.yaml at %s: %v", deployFile, err)
+	}
+
+	// Should NOT have namespace-prefixed files
+	oldSvcFile := filepath.Join(dir, "default", "apps", "default-service-web.yaml")
+	if _, err := os.Stat(oldSvcFile); err == nil {
+		t.Errorf("unexpected namespace-prefixed file: %s", oldSvcFile)
+	}
+
+	// Kustomization should reference kind-name files
+	kustomFile := filepath.Join(dir, "default", "apps", "kustomization.yaml")
+	data, err := os.ReadFile(kustomFile)
+	if err != nil {
+		t.Fatalf("read kustomization: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "service-web.yaml") {
+		t.Errorf("kustomization.yaml should reference service-web.yaml:\n%s", content)
+	}
+	if !strings.Contains(content, "deployment-web.yaml") {
+		t.Errorf("kustomization.yaml should reference deployment-web.yaml:\n%s", content)
+	}
+}
+
+func TestWriteToDisk_FileNamingKindName_FluxIntegrated(t *testing.T) {
+	child := &ManifestLayout{
+		Name:       "team-a",
+		Namespace:  "cl/flux-system/team-a",
+		FilePer:    FilePerResource,
+		FileNaming: FileNamingKindName,
+		Mode:       KustomizationExplicit,
+		Resources:  []client.Object{testObject("v1", "ConfigMap", "ca", "flux-system")},
+	}
+
+	root := &ManifestLayout{
+		Name:          "flux-root",
+		Namespace:     "cl/flux-system",
+		FluxPlacement: FluxIntegrated,
+		FilePer:       FilePerResource,
+		FileNaming:    FileNamingKindName,
+		Mode:          KustomizationExplicit,
+		Children:      []*ManifestLayout{child},
+	}
+
+	dir := t.TempDir()
+	if err := root.WriteToDisk(dir); err != nil {
+		t.Fatalf("WriteToDisk failed: %v", err)
+	}
+
+	kustomFile := filepath.Join(dir, "cl", "flux-system", "flux-root", "kustomization.yaml")
+	data, err := os.ReadFile(kustomFile)
+	if err != nil {
+		t.Fatalf("read kustomization: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "kustomization-team-a.yaml") {
+		t.Errorf("expected kustomization-team-a.yaml reference, got:\n%s", content)
+	}
+	if strings.Contains(content, "flux-system-kustomization-team-a.yaml") {
+		t.Errorf("should not have namespace-prefixed flux reference, got:\n%s", content)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #428 -- a comprehensive sweep found three additional code paths that ignored FileNaming:

- **WriteToDisk** (manifest.go): hardcoded ns-kind-name.yaml and flux-system-kustomization-name.yaml -- now uses ml.resolveManifestFileName()
- **WriteManifest** (write.go): hardcoded FluxIntegrated kustomization reference -- now uses manifestFileName() with FilePerResource
- **walkNodeForPackage / walkNodeForPackageInternal** (walker.go): did not accept or propagate FileNaming -- all ManifestLayout literals now receive it from WalkClusterByPackage
- **ArgoCD workflow** (argo.go): child layout did not inherit FileNaming from parent

Without this, WriteToDisk and WriteManifest produce different filenames than WriteToTar when FileNamingKindName is set, and WalkClusterByPackage ignores LayoutRules.FileNaming entirely.

## Test plan

- [x] New: TestWriteManifest_FileNamingKindName_FluxIntegrated
- [x] New: TestWriteToDisk_FileNamingKindName
- [x] New: TestWriteToDisk_FileNamingKindName_FluxIntegrated
- [x] New: TestWalkClusterByPackage_PropagatesFileNaming
- [x] All existing tests pass unchanged
- [x] mise run check (lint, vet, tests)