### PR TITLE
docs: document undocumented features across package READMEs and guides

### DIFF
--- a/pkg/io/README.md
+++ b/pkg/io/README.md
@@ -134,6 +134,12 @@ printer := io.NewResourcePrinter(io.PrintOptions{
     ShowLabels:   true,
 })
 err := printer.Print(objects, os.Stdout)
+
+// Format-agnostic printing (selects printer by format string)
+err := io.PrintObjects(objects, "yaml", os.Stdout)
+
+// Validate a format string before use
+err := io.ValidateOutputFormat("table")
 ```
 
 ## Related Packages

--- a/pkg/kubernetes/README.md
+++ b/pkg/kubernetes/README.md
@@ -215,7 +215,59 @@ kubernetes.AddHTTPRouteRuleBackendRef(&rule, gwapiv1.HTTPBackendRef{
 err = kubernetes.AddHTTPRouteRule(route, rule)
 ```
 
+## PSA Security Context Helpers
+
+Helpers for Pod Security Admission (PSA) compliance at Restricted, Baseline, and Privileged levels.
+
+```go
+// Get a security context matching the Restricted PSA level
+sc := kubernetes.RestrictedSecurityContext()
+
+// Get a pod-level security context
+psc := kubernetes.RestrictedPodSecurityContext()
+
+// Level-based selection
+sc := kubernetes.SecurityContextForLevel(kubernetes.PSALevelBaseline)
+psc := kubernetes.PodSecurityContextForLevel(kubernetes.PSALevelRestricted)
+
+// Validate a container against a PSA level
+err := kubernetes.ValidateContainerPSA(container, kubernetes.PSALevelRestricted)
+
+// Validate an entire PodSpec
+violations := kubernetes.ValidatePodSpecPSA(podSpec, kubernetes.PSALevelRestricted)
+```
+
+## ResourceRequirements Builder
+
+Build Kubernetes resource requirements for containers.
+
+```go
+reqs := kubernetes.CreateResourceRequirements()
+kubernetes.SetResourceRequestCPU(reqs, "100m")
+kubernetes.SetResourceRequestMemory(reqs, "128Mi")
+kubernetes.SetResourceLimitCPU(reqs, "500m")
+kubernetes.SetResourceLimitMemory(reqs, "512Mi")
+kubernetes.SetResourceRequestEphemeralStorage(reqs, "1Gi")
+kubernetes.SetResourceLimitEphemeralStorage(reqs, "2Gi")
+```
+
+## Prometheus Builders
+
+Builders for Prometheus Operator CRDs are in the `pkg/kubernetes/prometheus/` sub-package:
+
+```go
+import "github.com/go-kure/kure/pkg/kubernetes/prometheus"
+
+sm := prometheus.CreateServiceMonitor("my-app", "monitoring")
+prometheus.AddServiceMonitorEndpoint(sm, "/metrics", "http", "30s")
+prometheus.SetServiceMonitorSelector(sm, map[string]string{"app": "my-app"})
+
+pm := prometheus.CreatePodMonitor("my-app", "monitoring")
+rule := prometheus.CreatePrometheusRule("alerts", "monitoring")
+```
+
 ## Related Packages
 
 - [fluxcd](/api-reference/fluxcd-builders/) - FluxCD resource constructors
+- [prometheus](prometheus/) - Prometheus Operator CRD builders
 - [errors](../errors/) - Structured error types used for nil-check sentinels

--- a/pkg/launcher/README.md
+++ b/pkg/launcher/README.md
@@ -243,7 +243,19 @@ kurel schema generate my-app.kurel/
 # - Type information from parameter values
 # - Kubernetes validation rules where traceable
 # - Custom validation patterns
+# - Regex pattern constraints from parameter definitions
 ```
+
+Parameters can define regex patterns for validation:
+
+```yaml
+# parameters.yaml
+domain:
+  pattern: "^[a-z0-9.-]+$"
+  value: "example.com"
+```
+
+The generated JSON schema includes `"pattern"` constraints that are enforced during `kurel validate`.
 
 ### Building Manifests
 ```bash

--- a/pkg/patch/README.md
+++ b/pkg/patch/README.md
@@ -41,6 +41,21 @@ patches:
     value: "nginx:latest"
 ```
 
+## CLI Usage
+
+The `kure patch` command provides a CLI for applying patches:
+
+```bash
+# Apply patches and write output
+kure patch base.yaml patches/customize.kpatch -o output.yaml
+
+# Preview changes without writing (diff mode)
+kure patch --diff base.yaml patches/customize.kpatch
+
+# Combine all patched resources into a single output
+kure patch --combined base.yaml patches/
+```
+
 ## Quick Start
 
 ```go

--- a/pkg/stack/README.md
+++ b/pkg/stack/README.md
@@ -67,6 +67,22 @@ The child bundles' Flux Kustomization CRs are rendered into the parent
 bundle's directory. Children must be standalone bundles — they cannot
 simultaneously be attached as the `Bundle` of any `stack.Node`.
 
+`Bundle.HealthChecks` can also be set explicitly to monitor specific resources
+during reconciliation:
+
+```go
+bundle.HealthChecks = []stack.HealthCheck{
+    {APIVersion: "apps/v1", Kind: "Deployment", Name: "web", Namespace: "default"},
+}
+```
+
+When Children is non-empty, health checks for each child Kustomization are
+auto-generated and merged with any user-supplied entries.
+
+**Validation:** `ValidateCluster()` runs automatically in all layout entry
+points (`WalkCluster`, `WalkClusterByPackage`) and rejects invalid umbrella
+configurations (e.g., shared ownership, children that are also node bundles).
+
 ### Application
 
 An individual Kubernetes workload. Applications use the `ApplicationConfig` interface to generate their resources.
@@ -124,7 +140,9 @@ Configs that do not implement `Validator` continue to work without changes.
 
 ## Fluent Builder API
 
-For ergonomic cluster construction, use the fluent builder:
+For ergonomic cluster construction, use the fluent builder. Builder methods
+use **copy-on-write semantics** — each `With*` call returns a new builder
+instance, leaving the original unchanged:
 
 ```go
 cluster := stack.NewClusterBuilder("production").

--- a/pkg/stack/fluxcd/README.md
+++ b/pkg/stack/fluxcd/README.md
@@ -85,13 +85,20 @@ err = layout.WriteManifest(ml, "./clusters")
 
 ## Bootstrap Generation
 
-Generate Flux system bootstrap manifests:
+Generate Flux system bootstrap manifests. Two modes are supported:
+
+| Mode | Description |
+|------|-------------|
+| `"flux-operator"` | **Default.** Emits a full Flux Operator install bundle (CRDs, Deployment, RBAC). Recommended for new clusters. |
+| `"gotk"` | Legacy mode. Emits the GitOps Toolkit component manifests directly. |
+
+When `FluxMode` is empty, it defaults to `"flux-operator"`.
 
 ```go
 bootstrapConfig := &stack.BootstrapConfig{
     Enabled:     true,
-    FluxMode:    "install",
-    FluxVersion: "v2.6.4",
+    FluxMode:    "flux-operator", // or "gotk"; empty defaults to "flux-operator"
+    FluxVersion: "v2.8.2",
     SourceRef:   sourceRef,
 }
 

--- a/pkg/stack/layout/README.md
+++ b/pkg/stack/layout/README.md
@@ -21,16 +21,19 @@ The layout module transforms Kure's in-memory stack representation (Clusters →
 - **ApplicationGrouping**: How applications within bundles are organized
 - **FilePer**: How resources are written (FilePerResource vs FilePerKind)
 - **FluxPlacement**: Where Flux Kustomizations go (FluxSeparate vs FluxIntegrated)
-- **FileNaming**: Resource file naming pattern (FileNamingDefault vs FileNamingKindName)
+- **FileNaming**: Resource file naming pattern (see [File Naming Modes](#file-naming-modes))
+- **ClusterName**: Optional cluster name prefix for cluster-aware directory paths
 
 ### 3. Two Main Walker Functions
 - **WalkCluster()**: Standard hierarchical layout (Node → Bundle → App structure)
 - **WalkClusterByPackage()**: Groups by PackageRef for multi-source scenarios
 
 ### 4. Writing System
-- **WriteManifest()**: Standard hierarchical writing
+- **WriteManifest()**: Config-driven writing — uses `Config` to resolve file naming, kustomization mode, and directory structure
+- **WriteToDisk()**: Self-contained method on ManifestLayout — uses the layout's own `FileNaming` and `FluxPlacement` fields
+- **WriteToTar()**: Same as WriteToDisk but writes to a tar archive (used by Crane for OCI artifacts)
 - **WritePackagesToDisk()**: Package-based writing with sanitized directory names
-- Auto-generates kustomization.yaml files with proper resource references
+- All writers auto-generate kustomization.yaml files with proper resource references
 
 ## Directory Structure Patterns
 
@@ -93,10 +96,40 @@ clusters/
 - **FilePerKind**: Group objects by Kind (all Services together, etc.)
 - **AppFileSingle**: All app resources in one file
 
+### File Naming Modes
+
+Controls how resource YAML files are named:
+
+| Mode | Format | Example |
+|------|--------|---------|
+| `FileNamingDefault` | `{namespace}-{kind}-{name}.yaml` | `default-service-web.yaml` |
+| `FileNamingKindName` | `{kind}-{name}.yaml` | `service-web.yaml` |
+
+`FileNamingKindName` drops the namespace prefix, which is useful when each application already has its own directory (e.g., Pattern A / CentralizedControlPlane). The naming mode is propagated through all writers: `WriteManifest`, `WriteToDisk`, and `WriteToTar`.
+
 ### Kustomization Generation
 - **KustomizationExplicit**: Lists all manifest files explicitly
 - **KustomizationRecursive**: References subdirectories only
 - Smart handling of cross-references and child relationships
+
+### ClusterName-Aware Layouts
+
+Setting `LayoutRules.ClusterName` prepends the cluster name as a root directory, producing paths like `{clusterName}/{nodeName}/...` instead of `{nodeName}/...`. This is useful when a single repository manages multiple clusters.
+
+## Layout Presets
+
+Three named presets provide pre-configured LayoutRules for common deployment patterns. Use `LayoutRulesForPreset()` to get rules, or `ConfigForPreset()` to get a matching Config.
+
+| Preset | Pattern | FluxPlacement | NodeGrouping | FileNaming |
+|--------|---------|---------------|--------------|------------|
+| `CentralizedControlPlane` | A | FluxSeparate | GroupFlat | FileNamingKindName |
+| `SiblingControlPlane` | B | FluxSeparate | GroupByName | FileNamingDefault |
+| `ParentDeployedControl` | C | FluxIntegrated | GroupByName | FileNamingDefault |
+
+```go
+rules, err := layout.LayoutRulesForPreset(layout.PresetCentralizedControlPlane)
+cfg, err := layout.ConfigForPreset(layout.PresetCentralizedControlPlane)
+```
 
 ## Real-World Use Cases
 

--- a/site/content/guides/flux-workflow.md
+++ b/site/content/guides/flux-workflow.md
@@ -202,13 +202,18 @@ flat list.
 
 ## Bootstrap
 
-Generate Flux system bootstrap manifests:
+Generate Flux system bootstrap manifests. Two modes are available:
+
+- **`"flux-operator"`** (default) — emits a full Flux Operator install bundle (CRDs, Deployment, RBAC). Recommended for new clusters.
+- **`"gotk"`** — emits the legacy GitOps Toolkit component manifests directly.
+
+When `FluxMode` is empty, it defaults to `"flux-operator"`.
 
 ```go
 bootstrapConfig := &stack.BootstrapConfig{
     Enabled:     true,
-    FluxMode:    "install",
-    FluxVersion: "v2.6.4",
+    FluxMode:    "flux-operator", // or "gotk"; empty defaults to "flux-operator"
+    FluxVersion: "v2.8.2",
     SourceRef:   sourceRef,
 }
 

--- a/site/content/guides/generators.md
+++ b/site/content/guides/generators.md
@@ -93,6 +93,11 @@ Generates a complete application deployment:
 Generates Flux HelmRelease resources:
 - HelmRelease with chart reference and values
 - HelmRepository source (when needed)
+- ChartRef support for OCI-based charts (alternative to HelmRepository)
+- Configurable remediation strategies (install/upgrade retries, rollback)
+- ValuesFrom references for external value sources
+- PostRenderer Kustomize patches for chart output customization
+- Target namespace and release name overrides
 
 ### KurelPackage
 

--- a/site/content/guides/library-usage.md
+++ b/site/content/guides/library-usage.md
@@ -47,6 +47,8 @@ ks := fluxcd.Kustomization(&fluxcd.KustomizationConfig{
 
 See the [FluxCD Builders reference](/api-reference/fluxcd-builders) for all available resource types.
 
+Beyond FluxCD, the [Kubernetes Builders](/api-reference/kubernetes-builders) package provides typed constructors for core resources (Deployment, Service, Ingress, CronJob, NetworkPolicy, HTTPRoute), PSA security context helpers, ResourceRequirements builders, and more. The [Prometheus Builders](/api-reference/prometheus-builders) sub-package covers ServiceMonitor, PodMonitor, and PrometheusRule CRDs.
+
 ## Generating YAML
 
 Use the `io` package to serialize resources:


### PR DESCRIPTION
## Summary

A comprehensive audit found that several user-facing features had landed without corresponding documentation updates. Since package READMEs are auto-mounted to gokure.dev, these gaps were visible on the live docs site.

## Package READMEs
- **layout**: FileNaming modes, layout presets, ClusterName, WriteToDisk/WriteToTar writing system
- **kubernetes**: PSA Security Context Helpers, ResourceRequirements Builder, Prometheus Builders (previously only in doc.go)
- **fluxcd**: flux-operator as default bootstrap mode, comparison with gotk
- **stack**: HealthChecks usage, ValidateCluster auto-invocation, fluent builder copy-on-write semantics
- **io**: PrintObjects() and ValidateOutputFormat() exports
- **patch**: CLI usage section (`--diff`, `--combined` flags)
- **launcher**: regex pattern validation in schema parameters

## Site guides
- **flux-workflow**: bootstrap mode comparison (flux-operator vs gotk)
- **library-usage**: references to PSA, Prometheus, ResourceRequirements builders
- **generators**: FluxHelm chartRef, remediation, valuesFrom, postRenderer

## Test plan

- [x] `mise run check` passes (lint, vet, tests)
- [x] No code changes -- docs only