### PR TITLE
docs: add prometheus-builders API reference page and fix broken links

### DIFF
--- a/pkg/kubernetes/README.md
+++ b/pkg/kubernetes/README.md
@@ -269,5 +269,5 @@ rule := prometheus.CreatePrometheusRule("alerts", "monitoring")
 ## Related Packages
 
 - [fluxcd](/api-reference/fluxcd-builders/) - FluxCD resource constructors
-- [prometheus](prometheus/) - Prometheus Operator CRD builders
+- [prometheus](/api-reference/prometheus-builders/) - Prometheus Operator CRD builders
 - [errors](../errors/) - Structured error types used for nil-check sentinels

--- a/pkg/kubernetes/prometheus/README.md
+++ b/pkg/kubernetes/prometheus/README.md
@@ -1,0 +1,125 @@
+# Prometheus Builders - Prometheus Operator CRD Constructors
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/go-kure/kure/pkg/kubernetes/prometheus.svg)](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/prometheus)
+
+The `prometheus` package provides strongly-typed constructor functions for creating Prometheus Operator Kubernetes resources. These are the low-level building blocks used by Kure's higher-level stack and workflow packages.
+
+## Overview
+
+Each function takes a configuration struct and returns a fully initialized Prometheus Operator custom resource. The builders handle API version and kind metadata, letting you focus on the resource specification.
+
+## Supported Resources
+
+### ServiceMonitor
+
+```go
+import "github.com/go-kure/kure/pkg/kubernetes/prometheus"
+
+sm := prometheus.ServiceMonitor(&prometheus.ServiceMonitorConfig{
+    Name:      "my-app",
+    Namespace: "monitoring",
+    Selector:  metav1.LabelSelector{
+        MatchLabels: map[string]string{"app": "my-app"},
+    },
+    Endpoints: []monitoringv1.Endpoint{
+        {Path: "/metrics", Port: "http", Interval: "30s"},
+    },
+    JobLabel:     "app",
+    TargetLabels: []string{"app", "version"},
+})
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Name` | `string` | Resource name |
+| `Namespace` | `string` | Resource namespace |
+| `Selector` | `metav1.LabelSelector` | Label selector for target Services |
+| `Endpoints` | `[]monitoringv1.Endpoint` | Scrape endpoint configurations |
+| `JobLabel` | `string` | Label to use as the Prometheus `job` label |
+| `TargetLabels` | `[]string` | Service labels to transfer to scraped metrics |
+| `NamespaceSelector` | `*monitoringv1.NamespaceSelector` | Namespaces to select Services from |
+| `SampleLimit` | `*uint64` | Per-scrape sample limit |
+| `Labels` | `map[string]string` | Additional labels for the resource |
+
+### PodMonitor
+
+```go
+pm := prometheus.PodMonitor(&prometheus.PodMonitorConfig{
+    Name:      "my-app",
+    Namespace: "monitoring",
+    Selector:  metav1.LabelSelector{
+        MatchLabels: map[string]string{"app": "my-app"},
+    },
+    PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{
+        {Path: "/metrics", Port: "http", Interval: "30s"},
+    },
+})
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Name` | `string` | Resource name |
+| `Namespace` | `string` | Resource namespace |
+| `Selector` | `metav1.LabelSelector` | Label selector for target Pods |
+| `PodMetricsEndpoints` | `[]monitoringv1.PodMetricsEndpoint` | Scrape endpoint configurations |
+| `JobLabel` | `string` | Label to use as the Prometheus `job` label |
+| `PodTargetLabels` | `[]string` | Pod labels to transfer to scraped metrics |
+| `NamespaceSelector` | `*monitoringv1.NamespaceSelector` | Namespaces to select Pods from |
+| `SampleLimit` | `*uint64` | Per-scrape sample limit |
+| `Labels` | `map[string]string` | Additional labels for the resource |
+
+### PrometheusRule
+
+```go
+rule := prometheus.PrometheusRule(&prometheus.PrometheusRuleConfig{
+    Name:      "alerts",
+    Namespace: "monitoring",
+    Labels:    map[string]string{"role": "alert-rules"},
+    Groups: []monitoringv1.RuleGroup{
+        {
+            Name: "my-app.rules",
+            Rules: []monitoringv1.Rule{
+                {
+                    Alert: "HighErrorRate",
+                    Expr:  intstr.FromString(`rate(http_requests_total{code=~"5.."}[5m]) > 0.1`),
+                    For:   (*monitoringv1.Duration)(ptr("5m")),
+                },
+            },
+        },
+    },
+})
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Name` | `string` | Resource name |
+| `Namespace` | `string` | Resource namespace |
+| `Groups` | `[]monitoringv1.RuleGroup` | Rule groups containing alert and recording rules |
+| `Labels` | `map[string]string` | Additional labels for the resource |
+
+## Modifier Functions
+
+Update existing resources after construction:
+
+```go
+// ServiceMonitor modifiers
+prometheus.AddServiceMonitorEndpoint(sm, monitoringv1.Endpoint{Path: "/metrics", Port: "http"})
+prometheus.SetServiceMonitorJobLabel(sm, "app")
+prometheus.AddServiceMonitorTargetLabel(sm, "version")
+prometheus.SetServiceMonitorNamespaceSelector(sm, monitoringv1.NamespaceSelector{Any: true})
+prometheus.SetServiceMonitorSampleLimit(sm, 10000)
+
+// PodMonitor modifiers
+prometheus.AddPodMonitorEndpoint(pm, monitoringv1.PodMetricsEndpoint{Path: "/metrics", Port: "http"})
+prometheus.SetPodMonitorJobLabel(pm, "app")
+prometheus.AddPodMonitorPodTargetLabel(pm, "version")
+prometheus.SetPodMonitorNamespaceSelector(pm, monitoringv1.NamespaceSelector{Any: true})
+prometheus.SetPodMonitorSampleLimit(pm, 10000)
+
+// PrometheusRule modifiers
+prometheus.AddPrometheusRuleGroup(rule, monitoringv1.RuleGroup{Name: "extra.rules"})
+```
+
+## Related Packages
+
+- [kubernetes-builders](/api-reference/kubernetes-builders/) - Core Kubernetes resource constructors

--- a/site/content/api-reference/_index.md
+++ b/site/content/api-reference/_index.md
@@ -32,6 +32,7 @@ For full Go API documentation, see [pkg.go.dev/github.com/go-kure/kure](https://
 | [IO](io) | YAML/JSON serialization and resource printing | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/io) |
 | [Kubernetes Builders](kubernetes-builders) | Core K8s resource constructors (GVK, HPA, PDB) | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes) |
 | [FluxCD Builders](fluxcd-builders) | Low-level Flux resource constructors | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/fluxcd) |
+| [Prometheus Builders](prometheus-builders) | Prometheus Operator CRD constructors (ServiceMonitor, PodMonitor, PrometheusRule) | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/prometheus) |
 
 ## Utilities
 

--- a/site/scripts/inject-frontmatter.sh
+++ b/site/scripts/inject-frontmatter.sh
@@ -64,6 +64,7 @@ inject_fm "$KURE_ROOT/pkg/errors/README.md"                 "api-reference/error
 inject_fm "$KURE_ROOT/pkg/cli/README.md"                    "api-reference/cli.md"                        "CLI Utilities"                90
 inject_fm "$KURE_ROOT/pkg/kubernetes/README.md"             "api-reference/kubernetes-builders.md"        "Kubernetes Builders"           95
 inject_fm "$KURE_ROOT/pkg/kubernetes/fluxcd/README.md"      "api-reference/fluxcd-builders.md"            "FluxCD Builders"              100
+inject_fm "$KURE_ROOT/pkg/kubernetes/prometheus/README.md"  "api-reference/prometheus-builders.md"        "Prometheus Builders"          105
 inject_fm "$KURE_ROOT/pkg/logger/README.md"                 "api-reference/logger.md"                     "Logger"                       110
 inject_fm "$KURE_ROOT/docs/compatibility.md"                "api-reference/compatibility.md"              "Compatibility Matrix"         120
 


### PR DESCRIPTION
## Summary

- Add `pkg/kubernetes/prometheus/README.md` — the missing docs page for the existing prometheus sub-package (ServiceMonitor, PodMonitor, PrometheusRule)
- Wire it into `site/scripts/inject-frontmatter.sh` as `api-reference/prometheus-builders.md` (weight 105)
- Add Prometheus Builders row to `site/content/api-reference/_index.md`
- Fix broken relative link `prometheus/` → `/api-reference/prometheus-builders/` in `pkg/kubernetes/README.md`

Fixes two 404s reported by the link checker:
- `https://www.gokure.dev/dev/api-reference/prometheus-builders`
- `https://www.gokure.dev/dev/api-reference/kubernetes-builders/prometheus/`

## Test plan

- [ ] `bash site/scripts/inject-frontmatter.sh` produces `.generated/api-reference/prometheus-builders.md` with no warnings
- [ ] Site build renders `/api-reference/prometheus-builders/` correctly
- [ ] Link checker reports no more broken prometheus links