### PR TITLE
feat(stack): add Patches and PostBuild fields to Bundle

### DIFF
--- a/pkg/stack/bundle.go
+++ b/pkg/stack/bundle.go
@@ -59,6 +59,11 @@ type Bundle struct {
 	// HealthChecks lists resources whose health is monitored during reconciliation.
 	// When specified, the Kustomization waits for these resources to become ready.
 	HealthChecks []HealthCheck
+	// Patches lists strategic merge or JSON patches to apply to resources after
+	// kustomize build. Each patch targets resources matching its selector.
+	Patches []Patch
+	// PostBuild configures variable substitution performed after kustomize build.
+	PostBuild *PostBuild
 
 	// Internal fields for runtime hierarchy navigation (not serialized)
 	parent  *Bundle            `yaml:"-"` // Runtime parent reference for efficient traversal
@@ -91,6 +96,54 @@ type HealthCheck struct {
 	Name string
 	// Namespace of the resource. When empty, defaults to the Kustomization namespace.
 	Namespace string
+}
+
+// Patch defines a strategic merge or JSON patch applied to resources after kustomize build.
+type Patch struct {
+	// Patch is the patch content in strategic merge patch or JSON patch format.
+	Patch string
+	// Target selects which resources the patch applies to.
+	// When nil the patch applies to all resources.
+	Target *PatchSelector
+}
+
+// PatchSelector selects Kubernetes resources by GVK and metadata filters.
+type PatchSelector struct {
+	// Group of the target resource (e.g. "apps").
+	Group string
+	// Version of the target resource (e.g. "v1").
+	Version string
+	// Kind of the target resource (e.g. "Deployment").
+	Kind string
+	// Name of the target resource.
+	Name string
+	// Namespace of the target resource.
+	Namespace string
+	// LabelSelector is a label selector expression.
+	LabelSelector string
+	// AnnotationSelector is an annotation selector expression.
+	AnnotationSelector string
+}
+
+// PostBuild configures variable substitution performed after kustomize build.
+type PostBuild struct {
+	// Substitute contains inline key-value substitution variables.
+	// Values are substituted for ${VAR} occurrences in manifests.
+	Substitute map[string]string
+	// SubstituteFrom lists ConfigMaps and Secrets whose data is merged into
+	// the substitution variables.
+	SubstituteFrom []SubstituteRef
+}
+
+// SubstituteRef defines a reference to a ConfigMap or Secret used as a
+// source of PostBuild substitution variables.
+type SubstituteRef struct {
+	// Kind is ConfigMap or Secret.
+	Kind string
+	// Name of the ConfigMap or Secret.
+	Name string
+	// Optional allows the reference to be absent without causing an error.
+	Optional bool
 }
 
 // NewBundle constructs a Bundle with the given name, resources and labels.

--- a/pkg/stack/fluxcd/resource_generator.go
+++ b/pkg/stack/fluxcd/resource_generator.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	kustv1 "github.com/fluxcd/kustomize-controller/api/v1"
+	"github.com/fluxcd/pkg/apis/kustomize"
 	metaapi "github.com/fluxcd/pkg/apis/meta"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -248,6 +249,39 @@ func (g *ResourceGenerator) createKustomization(b *stack.Bundle) client.Object {
 			Name:       hc.Name,
 			Namespace:  hc.Namespace,
 		})
+	}
+
+	// Apply patches
+	for _, p := range b.Patches {
+		patch := kustomize.Patch{Patch: p.Patch}
+		if p.Target != nil {
+			patch.Target = &kustomize.Selector{
+				Group:              p.Target.Group,
+				Version:            p.Target.Version,
+				Kind:               p.Target.Kind,
+				Name:               p.Target.Name,
+				Namespace:          p.Target.Namespace,
+				LabelSelector:      p.Target.LabelSelector,
+				AnnotationSelector: p.Target.AnnotationSelector,
+			}
+		}
+		kust.Spec.Patches = append(kust.Spec.Patches, patch)
+	}
+
+	// Apply postBuild variable substitution
+	if b.PostBuild != nil {
+		pb := &kustv1.PostBuild{}
+		if len(b.PostBuild.Substitute) > 0 {
+			pb.Substitute = b.PostBuild.Substitute
+		}
+		for _, ref := range b.PostBuild.SubstituteFrom {
+			pb.SubstituteFrom = append(pb.SubstituteFrom, kustv1.SubstituteReference{
+				Kind:     ref.Kind,
+				Name:     ref.Name,
+				Optional: ref.Optional,
+			})
+		}
+		kust.Spec.PostBuild = pb
 	}
 
 	// Add dependencies


### PR DESCRIPTION
## What

Adds `Patches` and `PostBuild` fields to `Bundle`, along with four new types:
- `Patch` / `PatchSelector` — strategic merge or JSON patches wired to `spec.patches`
- `PostBuild` / `SubstituteRef` — variable substitution wired to `spec.postBuild`

The resource generator (`resource_generator.go`) already emits these fields when populated.

## Why

Required by two crane traits:
- crane#110 `fluxcd-patches` trait (`bundle.Patches`)
- crane#109 `fluxcd-postbuild` trait (`bundle.PostBuild`)

Both crane MRs (crane!122, crane!123) are blocked on this.

## Files changed

- `pkg/stack/bundle.go` — new fields + type definitions