### PR TITLE
feat(stack): add Force and Suspend fields to Bundle

### DIFF
--- a/pkg/stack/bundle.go
+++ b/pkg/stack/bundle.go
@@ -56,6 +56,10 @@ type Bundle struct {
 	Timeout string
 	// RetryInterval is the interval between retry attempts for failed reconciliations (e.g. "2m").
 	RetryInterval string
+	// Force causes Flux to re-apply resources even if there are no detected changes.
+	Force *bool
+	// Suspend disables reconciliation when true. Set to false to resume.
+	Suspend *bool
 	// HealthChecks lists resources whose health is monitored during reconciliation.
 	// When specified, the Kustomization waits for these resources to become ready.
 	HealthChecks []HealthCheck

--- a/pkg/stack/fluxcd/resource_generator.go
+++ b/pkg/stack/fluxcd/resource_generator.go
@@ -209,6 +209,16 @@ func (g *ResourceGenerator) createKustomization(b *stack.Bundle) client.Object {
 		}
 	}
 
+	// Set force if specified
+	if b.Force != nil {
+		kust.Spec.Force = *b.Force
+	}
+
+	// Set suspend if specified
+	if b.Suspend != nil {
+		kust.Spec.Suspend = *b.Suspend
+	}
+
 	// Set source reference
 	if b.SourceRef != nil {
 		kust.Spec.SourceRef = kustv1.CrossNamespaceSourceReference{

--- a/pkg/stack/fluxcd/resource_generator_test.go
+++ b/pkg/stack/fluxcd/resource_generator_test.go
@@ -253,6 +253,44 @@ func TestGenerateFromBundle_RetryInterval(t *testing.T) {
 	}
 }
 
+func TestGenerateFromBundle_Force(t *testing.T) {
+	wf := fluxstack.Engine()
+	forceVal := true
+	b := &stack.Bundle{
+		Name:  "test",
+		Force: &forceVal,
+	}
+
+	objs, err := wf.GenerateFromBundle(b)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	k := objs[0].(*kustv1.Kustomization)
+	if !k.Spec.Force {
+		t.Error("expected Force to be true")
+	}
+}
+
+func TestGenerateFromBundle_Suspend(t *testing.T) {
+	wf := fluxstack.Engine()
+	suspendVal := true
+	b := &stack.Bundle{
+		Name:    "test",
+		Suspend: &suspendVal,
+	}
+
+	objs, err := wf.GenerateFromBundle(b)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	k := objs[0].(*kustv1.Kustomization)
+	if !k.Spec.Suspend {
+		t.Error("expected Suspend to be true")
+	}
+}
+
 func TestGenerateFromBundle_Labels(t *testing.T) {
 	wf := fluxstack.Engine()
 	b := &stack.Bundle{


### PR DESCRIPTION
## What

Adds `Force` and `Suspend` fields to `Bundle`, wired into the generated Kustomization spec:

- `Force *bool` → `spec.force` — re-applies resources even when Flux detects no changes
- `Suspend *bool` → `spec.suspend` — disables reconciliation when true

## Why

Required by two crane traits:
- crane force-apply trait (`bundle.Force`)
- crane suspend trait (`bundle.Suspend`)

## Files changed

- `pkg/stack/bundle.go` — new fields
- `pkg/stack/fluxcd/resource_generator.go` — spec wiring
- `pkg/stack/fluxcd/resource_generator_test.go` — `TestGenerateFromBundle_Force`, `TestGenerateFromBundle_Suspend`