### PR TITLE
docs: document OCI folder layout and rename infra to platform

### DIFF
--- a/docs/oci-layout.md
+++ b/docs/oci-layout.md
@@ -1,0 +1,158 @@
+# OCI Artifact Layout
+
+This document describes the folder structure inside a Wharf stack OCI artifact,
+how Flux Kustomization objects reference that structure, and how the layout
+changes when the artifact is split across multiple OCIs.
+
+Kure's `ManifestLayout` and `WriteToTar` are the primitives used to produce
+this layout. The structure described here is what crane emits; kure enforces it
+via the layout tree.
+
+---
+
+## Single OCI (monolithic)
+
+All directories are siblings at the same level. Either all at the OCI root, or all
+under a `<clustername>/` prefix — the nesting depth is consistent throughout.
+
+```
+cluster-prod/
+├── flux-system/                         Layer 1 — bootstrap root
+│   ├── gotk-components.yaml             Flux controller manifests (omitted when using flux-operator)
+│   ├── OCIRepository  stack-prod        url: oci://<registry>/<repository>:<tag>
+│   ├── Kustomization  flux-system       path: ./cluster-prod/flux-system
+│   │                                    sourceRef: stack-prod
+│   ├── Kustomization  flux-system-infrastructure
+│   │                                    path: ./cluster-prod/flux-system-infrastructure
+│   │                                    sourceRef: stack-prod
+│   └── Kustomization  flux-system-<group>
+│                                        path: ./cluster-prod/flux-system-<group>
+│                                        sourceRef: stack-prod
+│
+├── flux-system-infrastructure/          Layer 2 — platform infra group
+│   └── Kustomization  infra-<id>        path: ./cluster-prod/infrastructure/<id>
+│                                        sourceRef: stack-prod
+│
+├── flux-system-<group>/                 Layer 2 — application group
+│   └── Kustomization  <appname>         path: ./cluster-prod/<group>/<appname>
+│                                        sourceRef: stack-prod
+│
+├── infrastructure/<id>/                 Layer 3 — platform component payloads
+│   └── helmrelease.yaml, issuer.yaml …
+│
+└── <group>/<appname>/                   Layer 3 — application payloads
+    └── deployment.yaml, service.yaml …
+```
+
+**Bootstrap** applies exactly two objects: the `OCIRepository stack-prod` and the
+`Kustomization flux-system`. Everything else is reconciled from those two roots —
+Flux applies the Layer 2 Kustomization CRs which in turn apply Layer 3 payloads.
+
+**All Kustomization objects carry `sourceRef: stack-prod`** — the single
+OCIRepository defined in `flux-system/`.
+
+---
+
+## Split OCI (infra + per-group)
+
+The split layout is a packaging concern only. Directory structure, file names,
+Kustomization paths, and depends-on relationships are **identical** to the
+monolithic layout. Only `sourceRef` values change in affected Kustomization objects.
+
+### Rule
+
+- `flux-system/` always lives in the **infra OCI** (the bootstrap root).
+- Each `flux-system-<group>/` lives in the **same OCI as that group's payloads**.
+- `flux-system/` gains one additional `OCIRepository` CR per split group OCI.
+- The `Kustomization flux-system-<group>` CR inside `flux-system/` gets its
+  `sourceRef` updated to point at the group's own OCIRepository.
+
+### OCI naming convention
+
+Derived from the base repository path by appending the set name:
+
+| Set        | Repository suffix  | Example                           |
+|------------|--------------------|-----------------------------------|
+| Infra      | `-infra`           | `wharf/prod/stack-cluster-infra`  |
+| App group  | `-<groupname>`     | `wharf/prod/stack-cluster-frontend` |
+| Monolithic | *(none)*           | `wharf/prod/stack-cluster`        |
+
+### Example: infra + frontend split
+
+**OCI 1 — `stack-prod-infra`** (bootstrap root):
+```
+cluster-prod/
+├── flux-system/
+│   ├── gotk-components.yaml
+│   ├── OCIRepository  stack-prod-infra      url: oci://<registry>/…-infra:<tag>
+│   ├── OCIRepository  stack-prod-frontend   url: oci://<registry>/…-frontend:<tag>
+│   ├── Kustomization  flux-system           path: ./cluster-prod/flux-system
+│   │                                        sourceRef: stack-prod-infra
+│   ├── Kustomization  flux-system-infrastructure
+│   │                                        path: ./cluster-prod/flux-system-infrastructure
+│   │                                        sourceRef: stack-prod-infra
+│   └── Kustomization  flux-system-frontend  path: ./cluster-prod/flux-system-frontend
+│                                            sourceRef: stack-prod-frontend    ← changed
+├── flux-system-infrastructure/
+│   └── Kustomization  infra-cert-manager    path: ./cluster-prod/infrastructure/cert-manager
+│                                            sourceRef: stack-prod-infra
+└── infrastructure/
+    └── cert-manager/
+        └── helmrelease.yaml …
+```
+
+**OCI 2 — `stack-prod-frontend`**:
+```
+cluster-prod/
+├── flux-system-frontend/                    ← lives here, not in infra OCI
+│   ├── Kustomization  storefront            path: ./cluster-prod/frontend/storefront
+│   │                                        sourceRef: stack-prod-frontend    ← changed
+│   └── Kustomization  cart                  path: ./cluster-prod/frontend/cart
+│                                            sourceRef: stack-prod-frontend    ← changed
+└── frontend/
+    ├── storefront/
+    │   └── deployment.yaml …
+    └── cart/
+        └── deployment.yaml …
+```
+
+Bootstrap still applies only two objects from OCI 1: `OCIRepository stack-prod-infra`
+and `Kustomization flux-system`. Flux discovers OCI 2 when it reconciles
+`flux-system/` and finds the `OCIRepository stack-prod-frontend` CR there.
+
+---
+
+## Layer reference
+
+| Layer | Directory pattern          | Contents                                       |
+|-------|---------------------------|------------------------------------------------|
+| 1     | `flux-system/`             | OCIRepository CRs, root + group Kustomization CRs, gotk-components |
+| 2     | `flux-system-<group>/`     | Per-app Kustomization CRs for one group         |
+| 3     | `<group>/<appname>/`       | Application manifests (Deployment, Service, …)  |
+| 3     | `infrastructure/<id>/`     | Platform component manifests (HelmRelease, …)   |
+
+---
+
+## Kure responsibilities
+
+Kure's `ManifestLayout` tree represents the above structure. Key conventions:
+
+- `Namespace: "."` on the root layout node → tar root, no extra prefix directory
+- `FileNaming: layout.FileNamingKindName` on all nodes → `<Kind>-<name>.yaml` filenames
+- Per-app payload layouts have their `Namespace` rewritten to `<group>/<appname>`
+  by the caller (crane) before being attached as children
+- `WriteToTar` walks the tree depth-first and emits `kustomization.yaml` at each
+  node listing its children as resources
+
+---
+
+## Known pending changes
+
+- **Cluster prefix**: whether to use a `<clustername>/` prefix or place everything
+  at OCI root is not yet decided. Current crane output uses OCI root (no prefix).
+- **App group paths**: current crane emits `apps/<appname>/` for Layer 3 app
+  payloads. The correct pattern is `<group>/<appname>/`. This rename lands with
+  applicationGroups support (crane#155).
+- **Per-group split**: splitting individual app groups into their own OCIs is
+  deferred until crane#155. The current `splitInfra bool` only separates the
+  infra set from the combined apps set.

--- a/docs/oci-layout.md
+++ b/docs/oci-layout.md
@@ -22,22 +22,22 @@ cluster-prod/
 │   ├── OCIRepository  stack-prod        url: oci://<registry>/<repository>:<tag>
 │   ├── Kustomization  flux-system       path: ./cluster-prod/flux-system
 │   │                                    sourceRef: stack-prod
-│   ├── Kustomization  flux-system-infrastructure
-│   │                                    path: ./cluster-prod/flux-system-infrastructure
+│   ├── Kustomization  flux-system-platform
+│   │                                    path: ./cluster-prod/flux-system-platform
 │   │                                    sourceRef: stack-prod
 │   └── Kustomization  flux-system-<group>
 │                                        path: ./cluster-prod/flux-system-<group>
 │                                        sourceRef: stack-prod
 │
-├── flux-system-infrastructure/          Layer 2 — platform infra group
-│   └── Kustomization  infra-<id>        path: ./cluster-prod/infrastructure/<id>
+├── flux-system-platform/          Layer 2 — platform group
+│   └── Kustomization  platform-<id>        path: ./cluster-prod/platform/<id>
 │                                        sourceRef: stack-prod
 │
 ├── flux-system-<group>/                 Layer 2 — application group
 │   └── Kustomization  <appname>         path: ./cluster-prod/<group>/<appname>
 │                                        sourceRef: stack-prod
 │
-├── infrastructure/<id>/                 Layer 3 — platform component payloads
+├── platform/<id>/                 Layer 3 — platform component payloads
 │   └── helmrelease.yaml, issuer.yaml …
 │
 └── <group>/<appname>/                   Layer 3 — application payloads
@@ -53,7 +53,7 @@ OCIRepository defined in `flux-system/`.
 
 ---
 
-## Split OCI (infra + per-group)
+## Split OCI (platform + per-group)
 
 The split layout is a packaging concern only. Directory structure, file names,
 Kustomization paths, and depends-on relationships are **identical** to the
@@ -61,7 +61,7 @@ monolithic layout. Only `sourceRef` values change in affected Kustomization obje
 
 ### Rule
 
-- `flux-system/` always lives in the **infra OCI** (the bootstrap root).
+- `flux-system/` always lives in the **platform OCI** (the bootstrap root).
 - Each `flux-system-<group>/` lives in the **same OCI as that group's payloads**.
 - `flux-system/` gains one additional `OCIRepository` CR per split group OCI.
 - The `Kustomization flux-system-<group>` CR inside `flux-system/` gets its
@@ -73,30 +73,30 @@ Derived from the base repository path by appending the set name:
 
 | Set        | Repository suffix  | Example                           |
 |------------|--------------------|-----------------------------------|
-| Infra      | `-infra`           | `wharf/prod/stack-cluster-infra`  |
+| Platform      | `-platform`           | `wharf/prod/stack-cluster-platform`  |
 | App group  | `-<groupname>`     | `wharf/prod/stack-cluster-frontend` |
 | Monolithic | *(none)*           | `wharf/prod/stack-cluster`        |
 
-### Example: infra + frontend split
+### Example: platform + frontend split
 
-**OCI 1 — `stack-prod-infra`** (bootstrap root):
+**OCI 1 — `stack-prod-platform`** (bootstrap root):
 ```
 cluster-prod/
 ├── flux-system/
 │   ├── gotk-components.yaml
-│   ├── OCIRepository  stack-prod-infra      url: oci://<registry>/…-infra:<tag>
+│   ├── OCIRepository  stack-prod-platform      url: oci://<registry>/…-platform:<tag>
 │   ├── OCIRepository  stack-prod-frontend   url: oci://<registry>/…-frontend:<tag>
 │   ├── Kustomization  flux-system           path: ./cluster-prod/flux-system
-│   │                                        sourceRef: stack-prod-infra
-│   ├── Kustomization  flux-system-infrastructure
-│   │                                        path: ./cluster-prod/flux-system-infrastructure
-│   │                                        sourceRef: stack-prod-infra
+│   │                                        sourceRef: stack-prod-platform
+│   ├── Kustomization  flux-system-platform
+│   │                                        path: ./cluster-prod/flux-system-platform
+│   │                                        sourceRef: stack-prod-platform
 │   └── Kustomization  flux-system-frontend  path: ./cluster-prod/flux-system-frontend
 │                                            sourceRef: stack-prod-frontend    ← changed
-├── flux-system-infrastructure/
-│   └── Kustomization  infra-cert-manager    path: ./cluster-prod/infrastructure/cert-manager
-│                                            sourceRef: stack-prod-infra
-└── infrastructure/
+├── flux-system-platform/
+│   └── Kustomization  platform-cert-manager    path: ./cluster-prod/platform/cert-manager
+│                                            sourceRef: stack-prod-platform
+└── platform/
     └── cert-manager/
         └── helmrelease.yaml …
 ```
@@ -104,7 +104,7 @@ cluster-prod/
 **OCI 2 — `stack-prod-frontend`**:
 ```
 cluster-prod/
-├── flux-system-frontend/                    ← lives here, not in infra OCI
+├── flux-system-frontend/                    ← lives here, not in platform OCI
 │   ├── Kustomization  storefront            path: ./cluster-prod/frontend/storefront
 │   │                                        sourceRef: stack-prod-frontend    ← changed
 │   └── Kustomization  cart                  path: ./cluster-prod/frontend/cart
@@ -116,7 +116,7 @@ cluster-prod/
         └── deployment.yaml …
 ```
 
-Bootstrap still applies only two objects from OCI 1: `OCIRepository stack-prod-infra`
+Bootstrap still applies only two objects from OCI 1: `OCIRepository stack-prod-platform`
 and `Kustomization flux-system`. Flux discovers OCI 2 when it reconciles
 `flux-system/` and finds the `OCIRepository stack-prod-frontend` CR there.
 
@@ -129,7 +129,7 @@ and `Kustomization flux-system`. Flux discovers OCI 2 when it reconciles
 | 1     | `flux-system/`             | OCIRepository CRs, root + group Kustomization CRs, gotk-components |
 | 2     | `flux-system-<group>/`     | Per-app Kustomization CRs for one group         |
 | 3     | `<group>/<appname>/`       | Application manifests (Deployment, Service, …)  |
-| 3     | `infrastructure/<id>/`     | Platform component manifests (HelmRelease, …)   |
+| 3     | `platform/<id>/`     | Platform component manifests (HelmRelease, …)   |
 
 ---
 
@@ -155,4 +155,4 @@ Kure's `ManifestLayout` tree represents the above structure. Key conventions:
   applicationGroups support (crane#155).
 - **Per-group split**: splitting individual app groups into their own OCIs is
   deferred until crane#155. The current `splitInfra bool` only separates the
-  infra set from the combined apps set.
+  platform set from the combined apps set.

--- a/site/scripts/check-unmapped-docs.sh
+++ b/site/scripts/check-unmapped-docs.sh
@@ -48,6 +48,7 @@ MAPPED_FILES=(
   "docs/compatibility.md"
   "docs/github-workflows.md"
   "docs/dependency-updates.md"
+  "docs/oci-layout.md"
   "pkg/stack/README.md"
   "pkg/stack/fluxcd/README.md"
   "pkg/stack/generators/README.md"

--- a/site/scripts/inject-frontmatter.sh
+++ b/site/scripts/inject-frontmatter.sh
@@ -45,6 +45,7 @@ inject_fm "$KURE_ROOT/docs/quickstart.md"                  "getting-started/quic
 
 # Concepts
 inject_fm "$KURE_ROOT/docs/ARCHITECTURE.md"                 "concepts/architecture.md"                    "Architecture"                 10
+inject_fm "$KURE_ROOT/docs/oci-layout.md"                   "concepts/oci-layout.md"                      "OCI Artifact Layout"          20
 
 # Examples
 inject_fm "$KURE_ROOT/examples/patches/README.md"           "examples/patches.md"                         "Patches"                      10


### PR DESCRIPTION
## Summary

- Adds `docs/oci-layout.md` documenting the confirmed OCI folder layout: Layer 1/2/3 structure, monolithic vs split layout, sourceRef-only change principle, OCI naming convention, bootstrap requirements
- Renames infra to platform throughout: `flux-system-platform/`, `platform/id/`, `platform-id` KS names — aligning with crane's platform naming convention

## Test plan

- [ ] Doc renders correctly (no broken structure in the Markdown trees)
