### PR TITLE
chore: update issue template labels to post-rename names

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
 name: Bug Report
-description: Report a bug in Kure
-labels: [bug]
+description: Report a bug
+labels: ["type/bug"]
 body:
   - type: textarea
     id: description
@@ -26,7 +26,7 @@ body:
   - type: input
     id: version
     attributes:
-      label: Kure Version
+      label: Version
       placeholder: e.g. v0.1.0 or commit hash
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest a new feature or enhancement
-labels: [enhancement]
+labels: ["type/feature"]
 body:
   - type: textarea
     id: problem


### PR DESCRIPTION
## Summary

Updates issue template label references from GitHub default names to our standard label names, required before `apply-settings.yml --apply` renames the labels.

## Changes

- `bug.yml`: `labels: [bug]` → `labels: ["type/bug"]`; description and "Kure Version" field de-kure'd to be generic
- `feature.yml`: `labels: [enhancement]` → `labels: ["type/feature"]`

## Test Plan

- [ ] `make lint` passes
- [ ] No Go code changed — CI checks not required

## Related Issues

Relates to go-kure/.github settings automation setup
