### PR TITLE
feat(kubernetes): add public pkg/kubernetes/cnpg wrapper

### DIFF
--- a/pkg/kubernetes/cnpg/README.md
+++ b/pkg/kubernetes/cnpg/README.md
@@ -1,0 +1,98 @@
+# CNPG Builders - CloudNativePG Resource Constructors
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/go-kure/kure/pkg/kubernetes/cnpg.svg)](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/cnpg)
+
+The `cnpg` package provides strongly-typed constructor functions for creating CloudNativePG (CNPG) and Barman Cloud Kubernetes resources. These are the low-level building blocks used by Kure's higher-level stack and workflow packages.
+
+## Overview
+
+Each function takes a configuration struct and returns a fully initialized custom resource. The builders handle API version and kind metadata, letting you focus on the resource specification.
+
+## Supported Resources
+
+### Cluster
+
+```go
+import "github.com/go-kure/kure/pkg/kubernetes/cnpg"
+
+cluster := cnpg.Cluster(&cnpg.ClusterConfig{
+    Name:      "pg-main",
+    Namespace: "databases",
+    Spec:      cnpgv1.ClusterSpec{Instances: 3},
+})
+
+cnpg.AddClusterLabel(cluster, "env", "prod")
+cnpg.AddClusterManagedRole(cluster, cnpgv1.RoleConfiguration{Name: "appuser"})
+```
+
+### Database
+
+```go
+db := cnpg.Database(&cnpg.DatabaseConfig{
+    Name:      "app-db",
+    Namespace: "databases",
+    Spec:      cnpgv1.DatabaseSpec{Name: "appdb"},
+})
+
+cnpg.SetDatabaseClusterRef(db, "pg-main")
+cnpg.SetDatabaseOwner(db, "appuser")
+cnpg.AddDatabaseExtension(db, cnpgv1.ExtensionSpec{Name: "pgcrypto"})
+```
+
+### ObjectStore
+
+```go
+store := cnpg.ObjectStore(&cnpg.ObjectStoreConfig{
+    Name:      "backup-store",
+    Namespace: "databases",
+    Spec:      barmanv1.ObjectStoreSpec{},
+})
+
+cnpg.SetObjectStoreDestinationPath(store, "s3://my-bucket/backups")
+cnpg.SetObjectStoreS3Credentials(store, &barmanapi.S3Credentials{...})
+cnpg.SetObjectStoreRetentionPolicy(store, "30d")
+```
+
+### ScheduledBackup
+
+```go
+backup := cnpg.ScheduledBackup(&cnpg.ScheduledBackupConfig{
+    Name:      "daily-backup",
+    Namespace: "databases",
+    Spec:      cnpgv1.ScheduledBackupSpec{Schedule: "0 2 * * *"},
+})
+
+cnpg.SetScheduledBackupMethod(backup, cnpgv1.BackupMethodBarmanObjectStore)
+cnpg.SetScheduledBackupImmediate(backup, true)
+```
+
+## Modifier Functions
+
+All `Add*` and `Set*` functions from the internal package are re-exported here:
+
+```go
+// Labels and annotations
+cnpg.AddClusterLabel(cluster, "app", "my-app")
+cnpg.AddDatabaseAnnotation(db, "note", "production")
+
+// Cluster
+cnpg.AddClusterManagedRole(cluster, role)
+
+// Database
+cnpg.SetDatabaseClusterRef(db, "pg-main")
+cnpg.SetDatabaseOwner(db, "appuser")
+cnpg.SetDatabaseReclaimPolicy(db, cnpgv1.DatabaseReclaimDelete)
+cnpg.SetDatabaseEnsure(db, cnpgv1.EnsurePresent)
+
+// ObjectStore
+cnpg.SetObjectStoreWalConfig(store, walConfig)
+cnpg.SetObjectStoreDataConfig(store, dataConfig)
+
+// ScheduledBackup
+cnpg.SetScheduledBackupSuspend(backup, true)
+cnpg.SetScheduledBackupBackupOwnerReference(backup, "self")
+```
+
+## Related Packages
+
+- [stack](/api-reference/stack/) - Domain model that produces Kubernetes resources

--- a/pkg/kubernetes/cnpg/create.go
+++ b/pkg/kubernetes/cnpg/create.go
@@ -1,0 +1,40 @@
+package cnpg
+
+import (
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	barmanv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
+
+	intcnpg "github.com/go-kure/kure/internal/cnpg"
+)
+
+// Cluster converts the config to a CNPG Cluster object.
+func Cluster(cfg *ClusterConfig) *cnpgv1.Cluster {
+	if cfg == nil {
+		return nil
+	}
+	return intcnpg.CreateCluster(cfg.Name, cfg.Namespace, cfg.Spec)
+}
+
+// Database converts the config to a CNPG Database object.
+func Database(cfg *DatabaseConfig) *cnpgv1.Database {
+	if cfg == nil {
+		return nil
+	}
+	return intcnpg.CreateDatabase(cfg.Name, cfg.Namespace, cfg.Spec)
+}
+
+// ObjectStore converts the config to a Barman Cloud ObjectStore object.
+func ObjectStore(cfg *ObjectStoreConfig) *barmanv1.ObjectStore {
+	if cfg == nil {
+		return nil
+	}
+	return intcnpg.CreateObjectStore(cfg.Name, cfg.Namespace, cfg.Spec)
+}
+
+// ScheduledBackup converts the config to a CNPG ScheduledBackup object.
+func ScheduledBackup(cfg *ScheduledBackupConfig) *cnpgv1.ScheduledBackup {
+	if cfg == nil {
+		return nil
+	}
+	return intcnpg.CreateScheduledBackup(cfg.Name, cfg.Namespace, cfg.Spec)
+}

--- a/pkg/kubernetes/cnpg/create_test.go
+++ b/pkg/kubernetes/cnpg/create_test.go
@@ -1,0 +1,125 @@
+package cnpg
+
+import (
+	"testing"
+
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	barmanv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
+)
+
+func TestCluster_Success(t *testing.T) {
+	cfg := &ClusterConfig{
+		Name:      "pg-main",
+		Namespace: "databases",
+		Spec:      cnpgv1.ClusterSpec{Instances: 3},
+	}
+
+	obj := Cluster(cfg)
+
+	if obj == nil {
+		t.Fatal("expected non-nil Cluster")
+	}
+	if obj.Name != "pg-main" {
+		t.Errorf("expected Name 'pg-main', got %s", obj.Name)
+	}
+	if obj.Namespace != "databases" {
+		t.Errorf("expected Namespace 'databases', got %s", obj.Namespace)
+	}
+	if obj.Spec.Instances != 3 {
+		t.Errorf("expected Instances 3, got %d", obj.Spec.Instances)
+	}
+}
+
+func TestCluster_NilConfig(t *testing.T) {
+	obj := Cluster(nil)
+	if obj != nil {
+		t.Error("expected nil result for nil config")
+	}
+}
+
+func TestDatabase_Success(t *testing.T) {
+	cfg := &DatabaseConfig{
+		Name:      "app-db",
+		Namespace: "databases",
+		Spec:      cnpgv1.DatabaseSpec{Name: "appdb"},
+	}
+
+	obj := Database(cfg)
+
+	if obj == nil {
+		t.Fatal("expected non-nil Database")
+	}
+	if obj.Name != "app-db" {
+		t.Errorf("expected Name 'app-db', got %s", obj.Name)
+	}
+	if obj.Namespace != "databases" {
+		t.Errorf("expected Namespace 'databases', got %s", obj.Namespace)
+	}
+	if obj.Spec.Name != "appdb" {
+		t.Errorf("expected Spec.Name 'appdb', got %s", obj.Spec.Name)
+	}
+}
+
+func TestDatabase_NilConfig(t *testing.T) {
+	obj := Database(nil)
+	if obj != nil {
+		t.Error("expected nil result for nil config")
+	}
+}
+
+func TestObjectStore_Success(t *testing.T) {
+	cfg := &ObjectStoreConfig{
+		Name:      "backup-store",
+		Namespace: "databases",
+		Spec:      barmanv1.ObjectStoreSpec{},
+	}
+
+	obj := ObjectStore(cfg)
+
+	if obj == nil {
+		t.Fatal("expected non-nil ObjectStore")
+	}
+	if obj.Name != "backup-store" {
+		t.Errorf("expected Name 'backup-store', got %s", obj.Name)
+	}
+	if obj.Namespace != "databases" {
+		t.Errorf("expected Namespace 'databases', got %s", obj.Namespace)
+	}
+}
+
+func TestObjectStore_NilConfig(t *testing.T) {
+	obj := ObjectStore(nil)
+	if obj != nil {
+		t.Error("expected nil result for nil config")
+	}
+}
+
+func TestScheduledBackup_Success(t *testing.T) {
+	cfg := &ScheduledBackupConfig{
+		Name:      "daily-backup",
+		Namespace: "databases",
+		Spec:      cnpgv1.ScheduledBackupSpec{Schedule: "0 2 * * *"},
+	}
+
+	obj := ScheduledBackup(cfg)
+
+	if obj == nil {
+		t.Fatal("expected non-nil ScheduledBackup")
+	}
+	if obj.Name != "daily-backup" {
+		t.Errorf("expected Name 'daily-backup', got %s", obj.Name)
+	}
+	if obj.Namespace != "databases" {
+		t.Errorf("expected Namespace 'databases', got %s", obj.Namespace)
+	}
+	if obj.Spec.Schedule != "0 2 * * *" {
+		t.Errorf("expected Schedule '0 2 * * *', got %s", obj.Spec.Schedule)
+	}
+}
+
+func TestScheduledBackup_NilConfig(t *testing.T) {
+	obj := ScheduledBackup(nil)
+	if obj != nil {
+		t.Error("expected nil result for nil config")
+	}
+}

--- a/pkg/kubernetes/cnpg/doc.go
+++ b/pkg/kubernetes/cnpg/doc.go
@@ -1,0 +1,36 @@
+// Package cnpg exposes helper functions for constructing resources used by
+// CloudNativePG (CNPG) and the Barman Cloud plugin.  Each function returns a
+// fully initialized controller-runtime object that can be serialized to YAML or
+// modified further by the calling application.
+//
+// ## Overview
+//
+// The package mirrors the constructors and setters found under
+// `internal/cnpg` so applications can build CNPG manifests programmatically
+// without depending on the internal packages directly.  All constructors accept
+// a configuration struct and delegate to the internal package.
+//
+// Resources covered include `Cluster`, `Database`, `ObjectStore`, and
+// `ScheduledBackup`.
+//
+// ## Constructors
+//
+// Constructors accept a configuration struct and return the corresponding CNPG
+// object.  A minimal example creating a `Cluster` looks like:
+//
+//	cluster := cnpg.Cluster(&cnpg.ClusterConfig{
+//	        Name:      "pg-main",
+//	        Namespace: "databases",
+//	        Spec:      cnpgv1.ClusterSpec{Instances: 3},
+//	})
+//
+// ## Update helpers
+//
+// Additional functions prefixed with `Set` or `Add` expose granular control
+// over the generated objects.  They delegate to the internal package while
+// keeping the public API stable.  For example:
+//
+//	cluster := cnpg.Cluster(&cnpg.ClusterConfig{...})
+//	cnpg.AddClusterLabel(cluster, "env", "prod")
+//	cnpg.AddClusterManagedRole(cluster, cnpgv1.RoleConfiguration{Name: "app"})
+package cnpg

--- a/pkg/kubernetes/cnpg/types.go
+++ b/pkg/kubernetes/cnpg/types.go
@@ -1,0 +1,34 @@
+package cnpg
+
+import (
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	barmanv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
+)
+
+// ClusterConfig describes a CNPG Cluster resource.
+type ClusterConfig struct {
+	Name      string             `yaml:"name"`
+	Namespace string             `yaml:"namespace"`
+	Spec      cnpgv1.ClusterSpec `yaml:"spec"`
+}
+
+// DatabaseConfig describes a CNPG Database resource.
+type DatabaseConfig struct {
+	Name      string              `yaml:"name"`
+	Namespace string              `yaml:"namespace"`
+	Spec      cnpgv1.DatabaseSpec `yaml:"spec"`
+}
+
+// ObjectStoreConfig describes a Barman Cloud ObjectStore resource.
+type ObjectStoreConfig struct {
+	Name      string                   `yaml:"name"`
+	Namespace string                   `yaml:"namespace"`
+	Spec      barmanv1.ObjectStoreSpec `yaml:"spec"`
+}
+
+// ScheduledBackupConfig describes a CNPG ScheduledBackup resource.
+type ScheduledBackupConfig struct {
+	Name      string                     `yaml:"name"`
+	Namespace string                     `yaml:"namespace"`
+	Spec      cnpgv1.ScheduledBackupSpec `yaml:"spec"`
+}

--- a/pkg/kubernetes/cnpg/update.go
+++ b/pkg/kubernetes/cnpg/update.go
@@ -1,0 +1,141 @@
+package cnpg
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	barmanapi "github.com/cloudnative-pg/barman-cloud/pkg/api"
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	barmanv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
+
+	intcnpg "github.com/go-kure/kure/internal/cnpg"
+)
+
+// AddClusterLabel delegates to the internal helper.
+func AddClusterLabel(obj *cnpgv1.Cluster, key, value string) {
+	intcnpg.AddClusterLabel(obj, key, value)
+}
+
+// AddClusterAnnotation delegates to the internal helper.
+func AddClusterAnnotation(obj *cnpgv1.Cluster, key, value string) {
+	intcnpg.AddClusterAnnotation(obj, key, value)
+}
+
+// AddClusterManagedRole delegates to the internal helper.
+func AddClusterManagedRole(obj *cnpgv1.Cluster, role cnpgv1.RoleConfiguration) {
+	intcnpg.AddClusterManagedRole(obj, role)
+}
+
+// AddDatabaseLabel delegates to the internal helper.
+func AddDatabaseLabel(obj *cnpgv1.Database, key, value string) {
+	intcnpg.AddDatabaseLabel(obj, key, value)
+}
+
+// AddDatabaseAnnotation delegates to the internal helper.
+func AddDatabaseAnnotation(obj *cnpgv1.Database, key, value string) {
+	intcnpg.AddDatabaseAnnotation(obj, key, value)
+}
+
+// AddDatabaseExtension delegates to the internal helper.
+func AddDatabaseExtension(obj *cnpgv1.Database, ext cnpgv1.ExtensionSpec) {
+	intcnpg.AddDatabaseExtension(obj, ext)
+}
+
+// SetDatabaseClusterRef delegates to the internal helper.
+func SetDatabaseClusterRef(obj *cnpgv1.Database, clusterName string) {
+	intcnpg.SetDatabaseClusterRef(obj, clusterName)
+}
+
+// SetDatabaseOwner delegates to the internal helper.
+func SetDatabaseOwner(obj *cnpgv1.Database, owner string) {
+	intcnpg.SetDatabaseOwner(obj, owner)
+}
+
+// SetDatabaseReclaimPolicy delegates to the internal helper.
+func SetDatabaseReclaimPolicy(obj *cnpgv1.Database, policy cnpgv1.DatabaseReclaimPolicy) {
+	intcnpg.SetDatabaseReclaimPolicy(obj, policy)
+}
+
+// SetDatabaseEnsure delegates to the internal helper.
+func SetDatabaseEnsure(obj *cnpgv1.Database, ensure cnpgv1.EnsureOption) {
+	intcnpg.SetDatabaseEnsure(obj, ensure)
+}
+
+// AddObjectStoreLabel delegates to the internal helper.
+func AddObjectStoreLabel(obj *barmanv1.ObjectStore, key, value string) {
+	intcnpg.AddObjectStoreLabel(obj, key, value)
+}
+
+// AddObjectStoreAnnotation delegates to the internal helper.
+func AddObjectStoreAnnotation(obj *barmanv1.ObjectStore, key, value string) {
+	intcnpg.AddObjectStoreAnnotation(obj, key, value)
+}
+
+// AddObjectStoreEnvVar delegates to the internal helper.
+func AddObjectStoreEnvVar(obj *barmanv1.ObjectStore, envVar corev1.EnvVar) {
+	intcnpg.AddObjectStoreEnvVar(obj, envVar)
+}
+
+// SetObjectStoreDestinationPath delegates to the internal helper.
+func SetObjectStoreDestinationPath(obj *barmanv1.ObjectStore, path string) {
+	intcnpg.SetObjectStoreDestinationPath(obj, path)
+}
+
+// SetObjectStoreEndpointURL delegates to the internal helper.
+func SetObjectStoreEndpointURL(obj *barmanv1.ObjectStore, url string) {
+	intcnpg.SetObjectStoreEndpointURL(obj, url)
+}
+
+// SetObjectStoreS3Credentials delegates to the internal helper.
+func SetObjectStoreS3Credentials(obj *barmanv1.ObjectStore, creds *barmanapi.S3Credentials) {
+	intcnpg.SetObjectStoreS3Credentials(obj, creds)
+}
+
+// SetObjectStoreRetentionPolicy delegates to the internal helper.
+func SetObjectStoreRetentionPolicy(obj *barmanv1.ObjectStore, policy string) {
+	intcnpg.SetObjectStoreRetentionPolicy(obj, policy)
+}
+
+// SetObjectStoreWalConfig delegates to the internal helper.
+func SetObjectStoreWalConfig(obj *barmanv1.ObjectStore, wal *barmanapi.WalBackupConfiguration) {
+	intcnpg.SetObjectStoreWalConfig(obj, wal)
+}
+
+// SetObjectStoreDataConfig delegates to the internal helper.
+func SetObjectStoreDataConfig(obj *barmanv1.ObjectStore, data *barmanapi.DataBackupConfiguration) {
+	intcnpg.SetObjectStoreDataConfig(obj, data)
+}
+
+// AddScheduledBackupLabel delegates to the internal helper.
+func AddScheduledBackupLabel(obj *cnpgv1.ScheduledBackup, key, value string) {
+	intcnpg.AddScheduledBackupLabel(obj, key, value)
+}
+
+// AddScheduledBackupAnnotation delegates to the internal helper.
+func AddScheduledBackupAnnotation(obj *cnpgv1.ScheduledBackup, key, value string) {
+	intcnpg.AddScheduledBackupAnnotation(obj, key, value)
+}
+
+// SetScheduledBackupMethod delegates to the internal helper.
+func SetScheduledBackupMethod(obj *cnpgv1.ScheduledBackup, method cnpgv1.BackupMethod) {
+	intcnpg.SetScheduledBackupMethod(obj, method)
+}
+
+// SetScheduledBackupPluginConfiguration delegates to the internal helper.
+func SetScheduledBackupPluginConfiguration(obj *cnpgv1.ScheduledBackup, name string, params map[string]string) {
+	intcnpg.SetScheduledBackupPluginConfiguration(obj, name, params)
+}
+
+// SetScheduledBackupImmediate delegates to the internal helper.
+func SetScheduledBackupImmediate(obj *cnpgv1.ScheduledBackup, immediate bool) {
+	intcnpg.SetScheduledBackupImmediate(obj, immediate)
+}
+
+// SetScheduledBackupBackupOwnerReference delegates to the internal helper.
+func SetScheduledBackupBackupOwnerReference(obj *cnpgv1.ScheduledBackup, ref string) {
+	intcnpg.SetScheduledBackupBackupOwnerReference(obj, ref)
+}
+
+// SetScheduledBackupSuspend delegates to the internal helper.
+func SetScheduledBackupSuspend(obj *cnpgv1.ScheduledBackup, suspend bool) {
+	intcnpg.SetScheduledBackupSuspend(obj, suspend)
+}

--- a/pkg/kubernetes/cnpg/update_test.go
+++ b/pkg/kubernetes/cnpg/update_test.go
@@ -1,0 +1,244 @@
+package cnpg
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	barmanapi "github.com/cloudnative-pg/barman-cloud/pkg/api"
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	barmanv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
+)
+
+func TestAddClusterLabel(t *testing.T) {
+	obj := Cluster(&ClusterConfig{Name: "pg", Namespace: "db", Spec: cnpgv1.ClusterSpec{}})
+	AddClusterLabel(obj, "env", "prod")
+	if obj.Labels["env"] != "prod" {
+		t.Error("expected label 'env' to be 'prod'")
+	}
+}
+
+func TestAddClusterAnnotation(t *testing.T) {
+	obj := Cluster(&ClusterConfig{Name: "pg", Namespace: "db", Spec: cnpgv1.ClusterSpec{}})
+	AddClusterAnnotation(obj, "note", "value")
+	if obj.Annotations["note"] != "value" {
+		t.Error("expected annotation 'note' to be 'value'")
+	}
+}
+
+func TestAddClusterManagedRole(t *testing.T) {
+	obj := Cluster(&ClusterConfig{Name: "pg", Namespace: "db", Spec: cnpgv1.ClusterSpec{}})
+	role := cnpgv1.RoleConfiguration{Name: "app"}
+	AddClusterManagedRole(obj, role)
+	if len(obj.Spec.Managed.Roles) != 1 {
+		t.Fatalf("expected 1 managed role, got %d", len(obj.Spec.Managed.Roles))
+	}
+	if obj.Spec.Managed.Roles[0].Name != "app" {
+		t.Errorf("expected role name 'app', got %s", obj.Spec.Managed.Roles[0].Name)
+	}
+}
+
+func TestAddDatabaseLabel(t *testing.T) {
+	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Spec: cnpgv1.DatabaseSpec{}})
+	AddDatabaseLabel(obj, "env", "prod")
+	if obj.Labels["env"] != "prod" {
+		t.Error("expected label 'env' to be 'prod'")
+	}
+}
+
+func TestAddDatabaseAnnotation(t *testing.T) {
+	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Spec: cnpgv1.DatabaseSpec{}})
+	AddDatabaseAnnotation(obj, "note", "value")
+	if obj.Annotations["note"] != "value" {
+		t.Error("expected annotation 'note' to be 'value'")
+	}
+}
+
+func TestAddDatabaseExtension(t *testing.T) {
+	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Spec: cnpgv1.DatabaseSpec{}})
+	ext := cnpgv1.ExtensionSpec{DatabaseObjectSpec: cnpgv1.DatabaseObjectSpec{Name: "pgcrypto"}}
+	AddDatabaseExtension(obj, ext)
+	if len(obj.Spec.Extensions) != 1 {
+		t.Fatalf("expected 1 extension, got %d", len(obj.Spec.Extensions))
+	}
+	if obj.Spec.Extensions[0].Name != "pgcrypto" {
+		t.Errorf("expected extension name 'pgcrypto', got %s", obj.Spec.Extensions[0].Name)
+	}
+}
+
+func TestSetDatabaseClusterRef(t *testing.T) {
+	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Spec: cnpgv1.DatabaseSpec{}})
+	SetDatabaseClusterRef(obj, "pg-main")
+	if obj.Spec.ClusterRef.Name != "pg-main" {
+		t.Errorf("expected cluster ref 'pg-main', got %s", obj.Spec.ClusterRef.Name)
+	}
+}
+
+func TestSetDatabaseOwner(t *testing.T) {
+	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Spec: cnpgv1.DatabaseSpec{}})
+	SetDatabaseOwner(obj, "appuser")
+	if obj.Spec.Owner != "appuser" {
+		t.Errorf("expected owner 'appuser', got %s", obj.Spec.Owner)
+	}
+}
+
+func TestSetDatabaseReclaimPolicy(t *testing.T) {
+	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Spec: cnpgv1.DatabaseSpec{}})
+	SetDatabaseReclaimPolicy(obj, cnpgv1.DatabaseReclaimDelete)
+	if obj.Spec.ReclaimPolicy != cnpgv1.DatabaseReclaimDelete {
+		t.Errorf("expected reclaim policy Delete, got %s", obj.Spec.ReclaimPolicy)
+	}
+}
+
+func TestSetDatabaseEnsure(t *testing.T) {
+	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Spec: cnpgv1.DatabaseSpec{}})
+	SetDatabaseEnsure(obj, cnpgv1.EnsurePresent)
+	if obj.Spec.Ensure != cnpgv1.EnsurePresent {
+		t.Errorf("expected ensure Present, got %s", obj.Spec.Ensure)
+	}
+}
+
+func TestAddObjectStoreLabel(t *testing.T) {
+	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Spec: barmanv1.ObjectStoreSpec{}})
+	AddObjectStoreLabel(obj, "env", "prod")
+	if obj.Labels["env"] != "prod" {
+		t.Error("expected label 'env' to be 'prod'")
+	}
+}
+
+func TestAddObjectStoreAnnotation(t *testing.T) {
+	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Spec: barmanv1.ObjectStoreSpec{}})
+	AddObjectStoreAnnotation(obj, "note", "value")
+	if obj.Annotations["note"] != "value" {
+		t.Error("expected annotation 'note' to be 'value'")
+	}
+}
+
+func TestAddObjectStoreEnvVar(t *testing.T) {
+	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Spec: barmanv1.ObjectStoreSpec{}})
+	env := corev1.EnvVar{Name: "AWS_REGION", Value: "us-east-1"}
+	AddObjectStoreEnvVar(obj, env)
+	if len(obj.Spec.InstanceSidecarConfiguration.Env) != 1 {
+		t.Fatalf("expected 1 env var, got %d", len(obj.Spec.InstanceSidecarConfiguration.Env))
+	}
+	if obj.Spec.InstanceSidecarConfiguration.Env[0].Name != "AWS_REGION" {
+		t.Errorf("expected env var 'AWS_REGION', got %s", obj.Spec.InstanceSidecarConfiguration.Env[0].Name)
+	}
+}
+
+func TestSetObjectStoreDestinationPath(t *testing.T) {
+	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Spec: barmanv1.ObjectStoreSpec{}})
+	SetObjectStoreDestinationPath(obj, "s3://my-bucket/backups")
+	if obj.Spec.Configuration.DestinationPath != "s3://my-bucket/backups" {
+		t.Errorf("expected DestinationPath 's3://my-bucket/backups', got %s", obj.Spec.Configuration.DestinationPath)
+	}
+}
+
+func TestSetObjectStoreEndpointURL(t *testing.T) {
+	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Spec: barmanv1.ObjectStoreSpec{}})
+	SetObjectStoreEndpointURL(obj, "https://s3.example.com")
+	if obj.Spec.Configuration.EndpointURL != "https://s3.example.com" {
+		t.Errorf("expected EndpointURL 'https://s3.example.com', got %s", obj.Spec.Configuration.EndpointURL)
+	}
+}
+
+func TestSetObjectStoreS3Credentials(t *testing.T) {
+	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Spec: barmanv1.ObjectStoreSpec{}})
+	creds := &barmanapi.S3Credentials{}
+	SetObjectStoreS3Credentials(obj, creds)
+	if obj.Spec.Configuration.AWS == nil {
+		t.Error("expected non-nil S3Credentials (AWS field)")
+	}
+}
+
+func TestSetObjectStoreRetentionPolicy(t *testing.T) {
+	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Spec: barmanv1.ObjectStoreSpec{}})
+	SetObjectStoreRetentionPolicy(obj, "30d")
+	if obj.Spec.RetentionPolicy != "30d" {
+		t.Errorf("expected RetentionPolicy '30d', got %s", obj.Spec.RetentionPolicy)
+	}
+}
+
+func TestSetObjectStoreWalConfig(t *testing.T) {
+	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Spec: barmanv1.ObjectStoreSpec{}})
+	wal := &barmanapi.WalBackupConfiguration{Compression: barmanapi.CompressionTypeGzip}
+	SetObjectStoreWalConfig(obj, wal)
+	if obj.Spec.Configuration.Wal == nil {
+		t.Fatal("expected non-nil Wal config")
+	}
+	if obj.Spec.Configuration.Wal.Compression != barmanapi.CompressionTypeGzip {
+		t.Error("expected Wal Compression to be Gzip")
+	}
+}
+
+func TestSetObjectStoreDataConfig(t *testing.T) {
+	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Spec: barmanv1.ObjectStoreSpec{}})
+	data := &barmanapi.DataBackupConfiguration{Compression: barmanapi.CompressionTypeGzip}
+	SetObjectStoreDataConfig(obj, data)
+	if obj.Spec.Configuration.Data == nil {
+		t.Fatal("expected non-nil Data config")
+	}
+	if obj.Spec.Configuration.Data.Compression != barmanapi.CompressionTypeGzip {
+		t.Error("expected Data Compression to be Gzip")
+	}
+}
+
+func TestAddScheduledBackupLabel(t *testing.T) {
+	obj := ScheduledBackup(&ScheduledBackupConfig{Name: "bk", Namespace: "ns", Spec: cnpgv1.ScheduledBackupSpec{}})
+	AddScheduledBackupLabel(obj, "env", "prod")
+	if obj.Labels["env"] != "prod" {
+		t.Error("expected label 'env' to be 'prod'")
+	}
+}
+
+func TestAddScheduledBackupAnnotation(t *testing.T) {
+	obj := ScheduledBackup(&ScheduledBackupConfig{Name: "bk", Namespace: "ns", Spec: cnpgv1.ScheduledBackupSpec{}})
+	AddScheduledBackupAnnotation(obj, "note", "value")
+	if obj.Annotations["note"] != "value" {
+		t.Error("expected annotation 'note' to be 'value'")
+	}
+}
+
+func TestSetScheduledBackupMethod(t *testing.T) {
+	obj := ScheduledBackup(&ScheduledBackupConfig{Name: "bk", Namespace: "ns", Spec: cnpgv1.ScheduledBackupSpec{}})
+	SetScheduledBackupMethod(obj, cnpgv1.BackupMethodBarmanObjectStore)
+	if obj.Spec.Method != cnpgv1.BackupMethodBarmanObjectStore {
+		t.Errorf("expected method BarmanObjectStore, got %s", obj.Spec.Method)
+	}
+}
+
+func TestSetScheduledBackupPluginConfiguration(t *testing.T) {
+	obj := ScheduledBackup(&ScheduledBackupConfig{Name: "bk", Namespace: "ns", Spec: cnpgv1.ScheduledBackupSpec{}})
+	params := map[string]string{"key": "value"}
+	SetScheduledBackupPluginConfiguration(obj, "barman-cloud.cloudnative-pg.io", params)
+	if obj.Spec.PluginConfiguration == nil {
+		t.Fatal("expected non-nil PluginConfiguration")
+	}
+	if obj.Spec.PluginConfiguration.Name != "barman-cloud.cloudnative-pg.io" {
+		t.Errorf("expected plugin name 'barman-cloud.cloudnative-pg.io', got %s", obj.Spec.PluginConfiguration.Name)
+	}
+}
+
+func TestSetScheduledBackupImmediate(t *testing.T) {
+	obj := ScheduledBackup(&ScheduledBackupConfig{Name: "bk", Namespace: "ns", Spec: cnpgv1.ScheduledBackupSpec{}})
+	SetScheduledBackupImmediate(obj, true)
+	if obj.Spec.Immediate == nil || !*obj.Spec.Immediate {
+		t.Error("expected Immediate to be true")
+	}
+}
+
+func TestSetScheduledBackupBackupOwnerReference(t *testing.T) {
+	obj := ScheduledBackup(&ScheduledBackupConfig{Name: "bk", Namespace: "ns", Spec: cnpgv1.ScheduledBackupSpec{}})
+	SetScheduledBackupBackupOwnerReference(obj, "self")
+	if obj.Spec.BackupOwnerReference != "self" {
+		t.Errorf("expected BackupOwnerReference 'self', got %s", obj.Spec.BackupOwnerReference)
+	}
+}
+
+func TestSetScheduledBackupSuspend(t *testing.T) {
+	obj := ScheduledBackup(&ScheduledBackupConfig{Name: "bk", Namespace: "ns", Spec: cnpgv1.ScheduledBackupSpec{}})
+	SetScheduledBackupSuspend(obj, true)
+	if obj.Spec.Suspend == nil || !*obj.Spec.Suspend {
+		t.Error("expected Suspend to be true")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `pkg/kubernetes/cnpg/` exposing all `internal/cnpg` builders through a typed public API
- Covers 4 resources: `Cluster`, `Database`, `ObjectStore`, `ScheduledBackup`
- Follows the same pattern as `pkg/kubernetes/certmanager`: `types.go` (config structs), `create.go` (nil-guarded constructors), `update.go` (26 pass-through helpers), `doc.go`, `README.md`, and full test coverage

## Test plan

- [x] `make build` passes
- [x] `make lint` passes (0 issues)
- [x] `make test` passes (all tests green)
- [x] `go doc ./pkg/kubernetes/cnpg/` produces package documentation

Closes #441
