### PR TITLE
fix(deploy): protect launcher/ subdir from stable-release wipe

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -156,6 +156,7 @@ jobs:
             -not -name 'CNAME' \
             -not -name '.nojekyll' \
             -not -name 'dev' \
+            -not -name 'launcher' \
             -not -name 'v*' \
             -exec rm -rf {} +
           cp -r ../site/public-root/* .


### PR DESCRIPTION
Add `-not -name 'launcher'` to the `find` exclusion list in the stable-release deploy step so that a future `launcher/` subdirectory on `gh-pages` is not deleted when kure publishes a new stable release.

Closes #447