### PR TITLE
feat(deploy): move kure docs site to /kure/ subpath

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -580,7 +580,7 @@ jobs:
       env:
         HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
         HUGO_ENVIRONMENT: production
-      run: hugo --config hugo.toml,versions.toml --minify --baseURL "https://www.gokure.dev/"
+      run: hugo --config hugo.toml,versions.toml --minify --baseURL "https://www.gokure.dev/kure/"
 
     - name: Upload docs artifact
       uses: actions/upload-artifact@v7

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -105,23 +105,18 @@ jobs:
         HUGO_ENVIRONMENT: production
       run: |
         SLOT="${{ steps.version.outputs.slot }}"
-        if [[ "$SLOT" == "dev" ]]; then
-          BASE_URL="https://www.gokure.dev/dev/"
-        else
-          BASE_URL="https://www.gokure.dev/${SLOT}/"
-        fi
-        hugo --config hugo.toml,versions.toml --minify --baseURL "$BASE_URL"
+        hugo --config hugo.toml,versions.toml --minify --baseURL "https://www.gokure.dev/kure/${SLOT}/"
         # Save for deploy
         mv public public-slot
 
-    - name: Build Hugo site (root — latest)
+    - name: Build Hugo site (kure/ root — latest)
       if: steps.version.outputs.set_latest == 'true'
       working-directory: site
       env:
         HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
         HUGO_ENVIRONMENT: production
       run: |
-        hugo --config hugo.toml,versions.toml --minify --baseURL "https://www.gokure.dev/"
+        hugo --config hugo.toml,versions.toml --minify --baseURL "https://www.gokure.dev/kure/"
         mv public public-root
 
     - name: Checkout go-kure.github.io
@@ -141,24 +136,21 @@ jobs:
         echo "www.gokure.dev" > CNAME
         touch .nojekyll
 
-        # --- Deploy versioned slot ---
-        echo "Deploying to /${SLOT}/..."
-        rm -rf "${SLOT}"
-        cp -r ../site/public-slot "${SLOT}"
+        # --- Deploy versioned slot to kure/{slot}/ ---
+        echo "Deploying to /kure/${SLOT}/..."
+        mkdir -p kure
+        rm -rf "kure/${SLOT}"
+        cp -r ../site/public-slot "kure/${SLOT}"
 
-        # --- Deploy to root (latest stable) ---
+        # --- Deploy to kure/ root (latest stable) ---
         if [[ "$SET_LATEST" == "true" ]]; then
-          echo "Deploying to / (latest stable)..."
-          # Remove root content but preserve version subdirectories and infra files
-          find . -maxdepth 1 \
-            -not -name '.' \
-            -not -name '.git' \
-            -not -name 'CNAME' \
-            -not -name '.nojekyll' \
+          echo "Deploying to /kure/ (latest stable)..."
+          # Remove kure/ root content but preserve version subdirectories
+          find kure -maxdepth 1 -mindepth 1 \
             -not -name 'dev' \
             -not -name 'v*' \
             -exec rm -rf {} +
-          cp -r ../site/public-root/* .
+          cp -r ../site/public-root/* kure/
         fi
 
         # Get kure commit info for the deploy message
@@ -172,9 +164,9 @@ jobs:
         else
           LABEL="${{ steps.version.outputs.label }}"
           if [[ "$SET_LATEST" == "true" ]]; then
-            MSG="deploy: ${LABEL} → /${SLOT}/ + / (latest) from kure@${KURE_SHA}"
+            MSG="deploy: ${LABEL} → /kure/${SLOT}/ + /kure/ (latest) from kure@${KURE_SHA}"
           else
-            MSG="deploy: ${LABEL} → /${SLOT}/ from kure@${KURE_SHA}"
+            MSG="deploy: ${LABEL} → /kure/${SLOT}/ from kure@${KURE_SHA}"
           fi
           git commit -m "$MSG"
           git push

--- a/scripts/gen-versions-toml.sh
+++ b/scripts/gen-versions-toml.sh
@@ -27,7 +27,7 @@ set -euo pipefail
 
 VERSION=""
 LATEST=""
-BASE_URL="https://www.gokure.dev"
+BASE_URL="https://www.gokure.dev/kure"
 OUTPUT="site/versions.toml"
 
 while [[ $# -gt 0 ]]; do

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = 'https://www.gokure.dev/'
+baseURL = 'https://www.gokure.dev/kure/'
 languageCode = 'en-us'
 title = 'Go Kure'
 


### PR DESCRIPTION
Move kure docs from the `gh-pages` root to `kure/` so the site root can be managed as a shared homepage and `launcher/` can be a peer subpath.

## Changes

- `site/hugo.toml`: `baseURL` → `https://www.gokure.dev/kure/`
- `scripts/gen-versions-toml.sh`: default `BASE_URL` → `https://www.gokure.dev/kure`
- `.github/workflows/ci.yml`: docs-build `baseURL` → `https://www.gokure.dev/kure/`
- `.github/workflows/deploy-docs.yml`:
  - Slot deploy writes to `kure/{slot}/` instead of `{slot}/`
  - `set_latest` deploy cleans `kure/` root preserving `kure/dev` and `kure/v*`
  - Commit messages updated to reflect new paths

## Related

- Closes #447 (supersedes #452 — kure no longer writes to gh-pages root at all)
- Requires a companion commit to `go-kure/go-kure.github.io`: rename `dev/` → `kure/dev/` and add root homepage (done separately, after this merges)
