### PR TITLE
test: add missing tests for Patches/PostBuild and stable helm output

### DIFF
--- a/pkg/stack/fluxcd/resource_generator_test.go
+++ b/pkg/stack/fluxcd/resource_generator_test.go
@@ -509,3 +509,232 @@ func TestGeneratePath_UmbrellaChild(t *testing.T) {
 		t.Errorf("Path = %q, want platform/infra", k.Spec.Path)
 	}
 }
+
+func TestGenerateFromBundle_Patches(t *testing.T) {
+	t.Run("empty patches leaves spec nil", func(t *testing.T) {
+		wf := fluxstack.Engine()
+		b := &stack.Bundle{Name: "test"}
+		objs, err := wf.GenerateFromBundle(b)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		k := objs[0].(*kustv1.Kustomization)
+		if k.Spec.Patches != nil {
+			t.Errorf("expected nil Patches, got %v", k.Spec.Patches)
+		}
+	})
+
+	t.Run("single patch without target", func(t *testing.T) {
+		wf := fluxstack.Engine()
+		b := &stack.Bundle{
+			Name: "test",
+			Patches: []stack.Patch{
+				{Patch: `{"op":"add","path":"/metadata/labels/env","value":"prod"}`},
+			},
+		}
+		objs, err := wf.GenerateFromBundle(b)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		k := objs[0].(*kustv1.Kustomization)
+		if len(k.Spec.Patches) != 1 {
+			t.Fatalf("expected 1 patch, got %d", len(k.Spec.Patches))
+		}
+		if k.Spec.Patches[0].Patch != `{"op":"add","path":"/metadata/labels/env","value":"prod"}` {
+			t.Errorf("Patch content mismatch: %q", k.Spec.Patches[0].Patch)
+		}
+		if k.Spec.Patches[0].Target != nil {
+			t.Errorf("expected nil Target, got %v", k.Spec.Patches[0].Target)
+		}
+	})
+
+	t.Run("patch with full selector", func(t *testing.T) {
+		wf := fluxstack.Engine()
+		b := &stack.Bundle{
+			Name: "test",
+			Patches: []stack.Patch{
+				{
+					Patch: "apiVersion: apps/v1\nkind: Deployment",
+					Target: &stack.PatchSelector{
+						Group:              "apps",
+						Version:            "v1",
+						Kind:               "Deployment",
+						Name:               "my-app",
+						Namespace:          "default",
+						LabelSelector:      "app=my-app",
+						AnnotationSelector: "tier=backend",
+					},
+				},
+			},
+		}
+		objs, err := wf.GenerateFromBundle(b)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		k := objs[0].(*kustv1.Kustomization)
+		if len(k.Spec.Patches) != 1 {
+			t.Fatalf("expected 1 patch, got %d", len(k.Spec.Patches))
+		}
+		sel := k.Spec.Patches[0].Target
+		if sel == nil {
+			t.Fatal("expected non-nil Target selector")
+		}
+		if sel.Group != "apps" {
+			t.Errorf("Group = %q, want %q", sel.Group, "apps")
+		}
+		if sel.Version != "v1" {
+			t.Errorf("Version = %q, want %q", sel.Version, "v1")
+		}
+		if sel.Kind != "Deployment" {
+			t.Errorf("Kind = %q, want %q", sel.Kind, "Deployment")
+		}
+		if sel.Name != "my-app" {
+			t.Errorf("Name = %q, want %q", sel.Name, "my-app")
+		}
+		if sel.Namespace != "default" {
+			t.Errorf("Namespace = %q, want %q", sel.Namespace, "default")
+		}
+		if sel.LabelSelector != "app=my-app" {
+			t.Errorf("LabelSelector = %q, want %q", sel.LabelSelector, "app=my-app")
+		}
+		if sel.AnnotationSelector != "tier=backend" {
+			t.Errorf("AnnotationSelector = %q, want %q", sel.AnnotationSelector, "tier=backend")
+		}
+	})
+
+	t.Run("multiple patches preserve order", func(t *testing.T) {
+		wf := fluxstack.Engine()
+		b := &stack.Bundle{
+			Name: "test",
+			Patches: []stack.Patch{
+				{Patch: "first"},
+				{Patch: "second"},
+				{Patch: "third"},
+			},
+		}
+		objs, err := wf.GenerateFromBundle(b)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		k := objs[0].(*kustv1.Kustomization)
+		if len(k.Spec.Patches) != 3 {
+			t.Fatalf("expected 3 patches, got %d", len(k.Spec.Patches))
+		}
+		for i, want := range []string{"first", "second", "third"} {
+			if k.Spec.Patches[i].Patch != want {
+				t.Errorf("Patches[%d].Patch = %q, want %q", i, k.Spec.Patches[i].Patch, want)
+			}
+		}
+	})
+}
+
+func TestGenerateFromBundle_PostBuild(t *testing.T) {
+	t.Run("nil PostBuild leaves spec nil", func(t *testing.T) {
+		wf := fluxstack.Engine()
+		b := &stack.Bundle{Name: "test"}
+		objs, err := wf.GenerateFromBundle(b)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		k := objs[0].(*kustv1.Kustomization)
+		if k.Spec.PostBuild != nil {
+			t.Errorf("expected nil PostBuild, got %v", k.Spec.PostBuild)
+		}
+	})
+
+	t.Run("Substitute only", func(t *testing.T) {
+		wf := fluxstack.Engine()
+		b := &stack.Bundle{
+			Name: "test",
+			PostBuild: &stack.PostBuild{
+				Substitute: map[string]string{
+					"CLUSTER_ENV": "production",
+					"REGION":      "eu-west-1",
+				},
+			},
+		}
+		objs, err := wf.GenerateFromBundle(b)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		k := objs[0].(*kustv1.Kustomization)
+		if k.Spec.PostBuild == nil {
+			t.Fatal("expected PostBuild to be set")
+		}
+		if k.Spec.PostBuild.Substitute["CLUSTER_ENV"] != "production" {
+			t.Errorf("CLUSTER_ENV = %q, want production", k.Spec.PostBuild.Substitute["CLUSTER_ENV"])
+		}
+		if k.Spec.PostBuild.Substitute["REGION"] != "eu-west-1" {
+			t.Errorf("REGION = %q, want eu-west-1", k.Spec.PostBuild.Substitute["REGION"])
+		}
+		if len(k.Spec.PostBuild.SubstituteFrom) != 0 {
+			t.Errorf("expected empty SubstituteFrom, got %d entries", len(k.Spec.PostBuild.SubstituteFrom))
+		}
+	})
+
+	t.Run("SubstituteFrom only", func(t *testing.T) {
+		wf := fluxstack.Engine()
+		b := &stack.Bundle{
+			Name: "test",
+			PostBuild: &stack.PostBuild{
+				SubstituteFrom: []stack.SubstituteRef{
+					{Kind: "ConfigMap", Name: "cluster-vars", Optional: false},
+					{Kind: "Secret", Name: "cluster-secrets", Optional: true},
+				},
+			},
+		}
+		objs, err := wf.GenerateFromBundle(b)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		k := objs[0].(*kustv1.Kustomization)
+		if k.Spec.PostBuild == nil {
+			t.Fatal("expected PostBuild to be set")
+		}
+		if len(k.Spec.PostBuild.SubstituteFrom) != 2 {
+			t.Fatalf("expected 2 SubstituteFrom entries, got %d", len(k.Spec.PostBuild.SubstituteFrom))
+		}
+		if k.Spec.PostBuild.SubstituteFrom[0].Kind != "ConfigMap" {
+			t.Errorf("SubstituteFrom[0].Kind = %q, want ConfigMap", k.Spec.PostBuild.SubstituteFrom[0].Kind)
+		}
+		if k.Spec.PostBuild.SubstituteFrom[0].Name != "cluster-vars" {
+			t.Errorf("SubstituteFrom[0].Name = %q, want cluster-vars", k.Spec.PostBuild.SubstituteFrom[0].Name)
+		}
+		if k.Spec.PostBuild.SubstituteFrom[0].Optional {
+			t.Error("SubstituteFrom[0].Optional = true, want false")
+		}
+		if k.Spec.PostBuild.SubstituteFrom[1].Kind != "Secret" {
+			t.Errorf("SubstituteFrom[1].Kind = %q, want Secret", k.Spec.PostBuild.SubstituteFrom[1].Kind)
+		}
+		if !k.Spec.PostBuild.SubstituteFrom[1].Optional {
+			t.Error("SubstituteFrom[1].Optional = false, want true")
+		}
+	})
+
+	t.Run("Substitute and SubstituteFrom combined", func(t *testing.T) {
+		wf := fluxstack.Engine()
+		b := &stack.Bundle{
+			Name: "test",
+			PostBuild: &stack.PostBuild{
+				Substitute: map[string]string{"ENV": "staging"},
+				SubstituteFrom: []stack.SubstituteRef{
+					{Kind: "ConfigMap", Name: "extra-vars"},
+				},
+			},
+		}
+		objs, err := wf.GenerateFromBundle(b)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		k := objs[0].(*kustv1.Kustomization)
+		if k.Spec.PostBuild == nil {
+			t.Fatal("expected PostBuild to be set")
+		}
+		if k.Spec.PostBuild.Substitute["ENV"] != "staging" {
+			t.Errorf("ENV = %q, want staging", k.Spec.PostBuild.Substitute["ENV"])
+		}
+		if len(k.Spec.PostBuild.SubstituteFrom) != 1 {
+			t.Fatalf("expected 1 SubstituteFrom entry, got %d", len(k.Spec.PostBuild.SubstituteFrom))
+		}
+	})
+}

--- a/pkg/stack/helm/render_test.go
+++ b/pkg/stack/helm/render_test.go
@@ -127,3 +127,30 @@ func TestAssembleManifests_EmptyInput(t *testing.T) {
 		t.Errorf("expected empty output for empty input, got: %q", out)
 	}
 }
+
+func TestAssembleManifests_StableOrder(t *testing.T) {
+	rendered := map[string]string{
+		"mychart/templates/z-last.yaml":   "kind: Z",
+		"mychart/templates/a-first.yaml":  "kind: A",
+		"mychart/templates/m-middle.yaml": "kind: M",
+	}
+
+	out1 := assembleManifests(rendered)
+	out2 := assembleManifests(rendered)
+
+	if string(out1) != string(out2) {
+		t.Errorf("assembleManifests is non-deterministic:\nfirst:  %s\nsecond: %s", out1, out2)
+	}
+
+	// sorted key order: a-first < m-middle < z-last
+	s := string(out1)
+	posA := strings.Index(s, "kind: A")
+	posM := strings.Index(s, "kind: M")
+	posZ := strings.Index(s, "kind: Z")
+	if posA < 0 || posM < 0 || posZ < 0 {
+		t.Fatalf("expected all three kinds in output, got:\n%s", s)
+	}
+	if !(posA < posM && posM < posZ) {
+		t.Errorf("expected sorted order A < M < Z, got positions A=%d M=%d Z=%d in:\n%s", posA, posM, posZ, s)
+	}
+}

--- a/pkg/stack/layout/tar_test.go
+++ b/pkg/stack/layout/tar_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"sort"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -421,6 +422,252 @@ func TestWriteToTar_FilePerKind_FluxIntegrated(t *testing.T) {
 	}
 	if !bytes.Contains([]byte(rootKustom), []byte("flux-system-kustomization-team-b.yaml")) {
 		t.Errorf("expected flux-system-kustomization-team-b.yaml reference, got:\n%s", rootKustom)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OCI layout pattern tests (docs/oci-layout.md)
+// ---------------------------------------------------------------------------
+
+// TestWriteToTar_NamespaceDot_TarRoot verifies that Namespace:"." on a layout
+// node produces paths relative to the archive root (no extra prefix directory).
+// This is the convention used by crane when emitting OCI artifact layouts;
+// see docs/oci-layout.md §Kure responsibilities.
+func TestWriteToTar_NamespaceDot_TarRoot(t *testing.T) {
+	child := &ManifestLayout{
+		Name:       "flux-system",
+		Namespace:  ".",
+		FilePer:    FilePerResource,
+		FileNaming: FileNamingKindName,
+		Mode:       KustomizationExplicit,
+		Resources: []client.Object{
+			&corev1.ConfigMap{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+				ObjectMeta: metav1.ObjectMeta{Name: "gotk-components", Namespace: "flux-system"},
+			},
+		},
+	}
+	root := &ManifestLayout{
+		Name:      "",
+		Namespace: ".",
+		FilePer:   FilePerResource,
+		Mode:      KustomizationExplicit,
+		Children:  []*ManifestLayout{child},
+	}
+
+	var buf bytes.Buffer
+	if err := root.WriteToTar(&buf); err != nil {
+		t.Fatalf("WriteToTar failed: %v", err)
+	}
+
+	files := extractTarFiles(t, &buf)
+
+	// Directory must be at archive root, not under "cluster/" or any prefix.
+	if _, ok := files["flux-system/"]; !ok {
+		t.Errorf("expected flux-system/ at tar root, got: %v", fileNames(files))
+	}
+	// File uses kind-name naming and lives directly under flux-system/.
+	if _, ok := files["flux-system/configmap-gotk-components.yaml"]; !ok {
+		t.Errorf("expected configmap-gotk-components.yaml in flux-system/, got: %v", fileNames(files))
+	}
+	// No spurious "cluster/" prefix anywhere.
+	for name := range files {
+		if strings.HasPrefix(name, "cluster/") {
+			t.Errorf("unexpected 'cluster/' prefix in tar entry %q", name)
+		}
+	}
+}
+
+// TestWriteToTar_OCILayer2GroupNaming verifies that a Layer 2 directory uses the
+// flux-system-<group> naming convention (e.g. flux-system-frontend/) and that
+// Kustomization CRs inside it use kind-name filenames (kustomization-<app>.yaml).
+// See docs/oci-layout.md Layer 2 row.
+func TestWriteToTar_OCILayer2GroupNaming(t *testing.T) {
+	kustCR := &unstructured.Unstructured{}
+	kustCR.SetAPIVersion("kustomize.toolkit.fluxcd.io/v1")
+	kustCR.SetKind("Kustomization")
+	kustCR.SetName("storefront")
+	kustCR.SetNamespace("flux-system")
+
+	ml := &ManifestLayout{
+		Name:       "flux-system-frontend",
+		Namespace:  ".",
+		FilePer:    FilePerResource,
+		FileNaming: FileNamingKindName,
+		Mode:       KustomizationExplicit,
+		Resources:  []client.Object{kustCR},
+	}
+
+	var buf bytes.Buffer
+	if err := ml.WriteToTar(&buf); err != nil {
+		t.Fatalf("WriteToTar failed: %v", err)
+	}
+
+	files := extractTarFiles(t, &buf)
+
+	if _, ok := files["flux-system-frontend/"]; !ok {
+		t.Errorf("expected flux-system-frontend/ at tar root, got: %v", fileNames(files))
+	}
+	// Layer 2 Kustomization CR uses kind-name format: kustomization-<appname>.yaml
+	if _, ok := files["flux-system-frontend/kustomization-storefront.yaml"]; !ok {
+		t.Errorf("expected kustomization-storefront.yaml in flux-system-frontend/, got: %v", fileNames(files))
+	}
+	kustom := string(files["flux-system-frontend/kustomization.yaml"])
+	if !bytes.Contains([]byte(kustom), []byte("kustomization-storefront.yaml")) {
+		t.Errorf("flux-system-frontend kustomization.yaml should reference kustomization-storefront.yaml:\n%s", kustom)
+	}
+}
+
+// TestWriteToTar_OCILayer3PayloadPath verifies that a Layer 3 application
+// payload directory follows the <group>/<appname>/ path convention (e.g.
+// frontend/storefront/), constructed from Namespace:<group> and Name:<appname>.
+// See docs/oci-layout.md Layer 3 row.
+func TestWriteToTar_OCILayer3PayloadPath(t *testing.T) {
+	ml := &ManifestLayout{
+		Name:       "storefront",
+		Namespace:  "frontend",
+		FilePer:    FilePerResource,
+		FileNaming: FileNamingKindName,
+		Mode:       KustomizationExplicit,
+		Resources: []client.Object{
+			&appsv1.Deployment{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
+				ObjectMeta: metav1.ObjectMeta{Name: "storefront", Namespace: "frontend"},
+			},
+			&corev1.Service{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+				ObjectMeta: metav1.ObjectMeta{Name: "storefront", Namespace: "frontend"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := ml.WriteToTar(&buf); err != nil {
+		t.Fatalf("WriteToTar failed: %v", err)
+	}
+
+	files := extractTarFiles(t, &buf)
+
+	// Layer 3 path: <group>/<appname>/ — both path segments present.
+	if _, ok := files["frontend/storefront/"]; !ok {
+		t.Errorf("expected frontend/storefront/ (Layer 3 path), got: %v", fileNames(files))
+	}
+	// FileNamingKindName: {kind}-{name}.yaml (no namespace prefix).
+	if _, ok := files["frontend/storefront/deployment-storefront.yaml"]; !ok {
+		t.Errorf("expected deployment-storefront.yaml in Layer 3 dir, got: %v", fileNames(files))
+	}
+	if _, ok := files["frontend/storefront/service-storefront.yaml"]; !ok {
+		t.Errorf("expected service-storefront.yaml in Layer 3 dir, got: %v", fileNames(files))
+	}
+	// Must NOT use namespace-prefixed names.
+	for name := range files {
+		if strings.HasPrefix(name, "frontend/storefront/frontend-") {
+			t.Errorf("namespace-prefixed filename found in Layer 3: %s", name)
+		}
+	}
+}
+
+// TestWriteToTar_OCIMonolithic_SiblingLayers verifies that the three OCI layers
+// are siblings at the archive root (no nesting under a prefix directory) and
+// that each layer uses the correct naming and file conventions:
+//
+//	Layer 1: flux-system/               – bootstrap root
+//	Layer 2: flux-system-platform/      – group Kustomization CRs
+//	Layer 3: platform/cert-manager/     – application manifests
+//
+// All nodes use Namespace:"." and FileNamingKindName, matching the contract
+// documented in docs/oci-layout.md §Kure responsibilities.
+func TestWriteToTar_OCIMonolithic_SiblingLayers(t *testing.T) {
+	// Layer 1: flux-system/ with an OCIRepository CR
+	ociCR := &unstructured.Unstructured{}
+	ociCR.SetAPIVersion("source.toolkit.fluxcd.io/v1beta2")
+	ociCR.SetKind("OCIRepository")
+	ociCR.SetName("stack-prod")
+	ociCR.SetNamespace("flux-system")
+
+	fluxSystem := &ManifestLayout{
+		Name:       "flux-system",
+		Namespace:  ".",
+		FilePer:    FilePerResource,
+		FileNaming: FileNamingKindName,
+		Mode:       KustomizationExplicit,
+		Resources:  []client.Object{ociCR},
+	}
+
+	// Layer 2: flux-system-platform/ with a Kustomization CR
+	kustCR := &unstructured.Unstructured{}
+	kustCR.SetAPIVersion("kustomize.toolkit.fluxcd.io/v1")
+	kustCR.SetKind("Kustomization")
+	kustCR.SetName("cert-manager")
+	kustCR.SetNamespace("flux-system")
+
+	fluxSystemPlatform := &ManifestLayout{
+		Name:       "flux-system-platform",
+		Namespace:  ".",
+		FilePer:    FilePerResource,
+		FileNaming: FileNamingKindName,
+		Mode:       KustomizationExplicit,
+		Resources:  []client.Object{kustCR},
+	}
+
+	// Layer 3: platform/cert-manager/ with application manifests
+	certManagerPayload := &ManifestLayout{
+		Name:       "cert-manager",
+		Namespace:  "platform",
+		FilePer:    FilePerResource,
+		FileNaming: FileNamingKindName,
+		Mode:       KustomizationExplicit,
+		Resources: []client.Object{
+			&corev1.ConfigMap{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+				ObjectMeta: metav1.ObjectMeta{Name: "cert-manager-config", Namespace: "cert-manager"},
+			},
+		},
+	}
+
+	// Root at archive root (Namespace:"."), children are all three layers.
+	root := &ManifestLayout{
+		Name:      "",
+		Namespace: ".",
+		FilePer:   FilePerResource,
+		Mode:      KustomizationExplicit,
+		Children:  []*ManifestLayout{fluxSystem, fluxSystemPlatform, certManagerPayload},
+	}
+
+	var buf bytes.Buffer
+	if err := root.WriteToTar(&buf); err != nil {
+		t.Fatalf("WriteToTar failed: %v", err)
+	}
+
+	files := extractTarFiles(t, &buf)
+
+	// All three layers must be at the archive root (no intermediate prefix).
+	for _, dir := range []string{"flux-system/", "flux-system-platform/", "platform/cert-manager/"} {
+		if _, ok := files[dir]; !ok {
+			t.Errorf("expected %s at tar root (sibling), got: %v", dir, fileNames(files))
+		}
+	}
+
+	// Layer 1 contents.
+	if _, ok := files["flux-system/ocirepository-stack-prod.yaml"]; !ok {
+		t.Errorf("Layer 1: missing ocirepository-stack-prod.yaml, got: %v", fileNames(files))
+	}
+
+	// Layer 2 contents — Kustomization CR uses kind-name format.
+	if _, ok := files["flux-system-platform/kustomization-cert-manager.yaml"]; !ok {
+		t.Errorf("Layer 2: missing kustomization-cert-manager.yaml, got: %v", fileNames(files))
+	}
+
+	// Layer 3 contents.
+	if _, ok := files["platform/cert-manager/configmap-cert-manager-config.yaml"]; !ok {
+		t.Errorf("Layer 3: missing resource file in platform/cert-manager/, got: %v", fileNames(files))
+	}
+
+	// Nothing has a "cluster/" prefix — Namespace:"." means archive root.
+	for name := range files {
+		if strings.HasPrefix(name, "cluster/") {
+			t.Errorf("unexpected 'cluster/' prefix in tar entry: %s", name)
+		}
 	}
 }
 

--- a/pkg/stack/layout/tar_test.go
+++ b/pkg/stack/layout/tar_test.go
@@ -488,6 +488,13 @@ func TestWriteToTar_OCILayer2GroupNaming(t *testing.T) {
 	kustCR.SetKind("Kustomization")
 	kustCR.SetName("storefront")
 	kustCR.SetNamespace("flux-system")
+	kustCR.Object["spec"] = map[string]interface{}{
+		"path": "./frontend/storefront",
+		"sourceRef": map[string]interface{}{
+			"kind": "OCIRepository",
+			"name": "stack-prod",
+		},
+	}
 
 	ml := &ManifestLayout{
 		Name:       "flux-system-frontend",
@@ -515,6 +522,15 @@ func TestWriteToTar_OCILayer2GroupNaming(t *testing.T) {
 	kustom := string(files["flux-system-frontend/kustomization.yaml"])
 	if !bytes.Contains([]byte(kustom), []byte("kustomization-storefront.yaml")) {
 		t.Errorf("flux-system-frontend kustomization.yaml should reference kustomization-storefront.yaml:\n%s", kustom)
+	}
+	// spec.path and spec.sourceRef must survive serialization — a regression that
+	// drops these fields passes the directory/naming checks above but breaks Flux.
+	kustContent := string(files["flux-system-frontend/kustomization-storefront.yaml"])
+	if !strings.Contains(kustContent, "path: ./frontend/storefront") {
+		t.Errorf("Layer 2 Kustomization must have spec.path ./frontend/storefront:\n%s", kustContent)
+	}
+	if !strings.Contains(kustContent, "name: stack-prod") {
+		t.Errorf("Layer 2 Kustomization must have spec.sourceRef.name stack-prod:\n%s", kustContent)
 	}
 }
 
@@ -600,6 +616,13 @@ func TestWriteToTar_OCIMonolithic_SiblingLayers(t *testing.T) {
 	kustCR.SetKind("Kustomization")
 	kustCR.SetName("cert-manager")
 	kustCR.SetNamespace("flux-system")
+	kustCR.Object["spec"] = map[string]interface{}{
+		"path": "./platform/cert-manager",
+		"sourceRef": map[string]interface{}{
+			"kind": "OCIRepository",
+			"name": "stack-prod",
+		},
+	}
 
 	fluxSystemPlatform := &ManifestLayout{
 		Name:       "flux-system-platform",
@@ -656,6 +679,14 @@ func TestWriteToTar_OCIMonolithic_SiblingLayers(t *testing.T) {
 	// Layer 2 contents — Kustomization CR uses kind-name format.
 	if _, ok := files["flux-system-platform/kustomization-cert-manager.yaml"]; !ok {
 		t.Errorf("Layer 2: missing kustomization-cert-manager.yaml, got: %v", fileNames(files))
+	}
+	// spec.path (Layer 3 dir) and spec.sourceRef must survive serialization.
+	layer2Content := string(files["flux-system-platform/kustomization-cert-manager.yaml"])
+	if !strings.Contains(layer2Content, "path: ./platform/cert-manager") {
+		t.Errorf("Layer 2 Kustomization must have spec.path ./platform/cert-manager:\n%s", layer2Content)
+	}
+	if !strings.Contains(layer2Content, "name: stack-prod") {
+		t.Errorf("Layer 2 Kustomization must have spec.sourceRef.name stack-prod:\n%s", layer2Content)
 	}
 
 	// Layer 3 contents.

--- a/pkg/stack/layout/write_test.go
+++ b/pkg/stack/layout/write_test.go
@@ -1100,14 +1100,25 @@ func TestWriteToDisk_NamespaceDot_RootPaths(t *testing.T) {
 			testObject("v1", "ConfigMap", "gotk-components", "flux-system"),
 		},
 	}
-	fluxSystemPlatform := &ManifestLayout{
-		Name:      "flux-system-platform",
-		Namespace: ".",
-		FilePer:   FilePerResource,
-		Mode:      KustomizationExplicit,
-		Resources: []client.Object{
-			testObject("kustomize.toolkit.fluxcd.io/v1", "Kustomization", "cert-manager", "flux-system"),
+	kustPlatform := &unstructured.Unstructured{}
+	kustPlatform.SetAPIVersion("kustomize.toolkit.fluxcd.io/v1")
+	kustPlatform.SetKind("Kustomization")
+	kustPlatform.SetName("cert-manager")
+	kustPlatform.SetNamespace("flux-system")
+	kustPlatform.Object["spec"] = map[string]interface{}{
+		"path": "./platform/cert-manager",
+		"sourceRef": map[string]interface{}{
+			"kind": "OCIRepository",
+			"name": "stack-prod",
 		},
+	}
+	fluxSystemPlatform := &ManifestLayout{
+		Name:       "flux-system-platform",
+		Namespace:  ".",
+		FilePer:    FilePerResource,
+		FileNaming: FileNamingKindName,
+		Mode:       KustomizationExplicit,
+		Resources:  []client.Object{kustPlatform},
 	}
 	certManager := &ManifestLayout{
 		Name:       "cert-manager",
@@ -1131,9 +1142,24 @@ func TestWriteToDisk_NamespaceDot_RootPaths(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dir, "flux-system", "configmap-gotk-components.yaml")); err != nil {
 		t.Errorf("Layer 1: expected configmap-gotk-components.yaml at flux-system/: %v", err)
 	}
-	// Layer 2: flux-system-platform/ directly under basePath
-	if _, err := os.Stat(filepath.Join(dir, "flux-system-platform")); err != nil {
-		t.Errorf("Layer 2: expected flux-system-platform/ at basePath root: %v", err)
+	// Layer 2: kind-name filename (not namespace-prefixed), spec fields preserved.
+	kustFile := filepath.Join(dir, "flux-system-platform", "kustomization-cert-manager.yaml")
+	if _, err := os.Stat(kustFile); err != nil {
+		t.Errorf("Layer 2: expected kustomization-cert-manager.yaml (FileNamingKindName): %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "flux-system-platform", "flux-system-kustomization-cert-manager.yaml")); err == nil {
+		t.Error("Layer 2: namespace-prefixed filename found; FileNamingKindName must suppress it")
+	}
+	kustData, err := os.ReadFile(kustFile)
+	if err != nil {
+		t.Fatalf("read Layer 2 Kustomization: %v", err)
+	}
+	kustContent := string(kustData)
+	if !strings.Contains(kustContent, "path: ./platform/cert-manager") {
+		t.Errorf("Layer 2 Kustomization must have spec.path ./platform/cert-manager:\n%s", kustContent)
+	}
+	if !strings.Contains(kustContent, "name: stack-prod") {
+		t.Errorf("Layer 2 Kustomization must have spec.sourceRef.name stack-prod:\n%s", kustContent)
 	}
 	// Layer 3: <group>/<appname>/ path
 	if _, err := os.Stat(filepath.Join(dir, "platform", "cert-manager")); err != nil {

--- a/pkg/stack/layout/write_test.go
+++ b/pkg/stack/layout/write_test.go
@@ -1086,6 +1086,68 @@ func TestWriteToDisk_FileNamingKindName(t *testing.T) {
 	}
 }
 
+// TestWriteToDisk_NamespaceDot_RootPaths verifies that Namespace:"." on layout
+// nodes produces paths relative to basePath (no "cluster/" prefix), mirroring
+// the tar behaviour. This is the OCI root convention from docs/oci-layout.md.
+func TestWriteToDisk_NamespaceDot_RootPaths(t *testing.T) {
+	fluxSystem := &ManifestLayout{
+		Name:       "flux-system",
+		Namespace:  ".",
+		FilePer:    FilePerResource,
+		FileNaming: FileNamingKindName,
+		Mode:       KustomizationExplicit,
+		Resources: []client.Object{
+			testObject("v1", "ConfigMap", "gotk-components", "flux-system"),
+		},
+	}
+	fluxSystemPlatform := &ManifestLayout{
+		Name:      "flux-system-platform",
+		Namespace: ".",
+		FilePer:   FilePerResource,
+		Mode:      KustomizationExplicit,
+		Resources: []client.Object{
+			testObject("kustomize.toolkit.fluxcd.io/v1", "Kustomization", "cert-manager", "flux-system"),
+		},
+	}
+	certManager := &ManifestLayout{
+		Name:       "cert-manager",
+		Namespace:  "platform",
+		FilePer:    FilePerResource,
+		FileNaming: FileNamingKindName,
+		Mode:       KustomizationExplicit,
+		Resources: []client.Object{
+			testObject("v1", "ConfigMap", "cert-manager-config", "cert-manager"),
+		},
+	}
+
+	dir := t.TempDir()
+	for _, ml := range []*ManifestLayout{fluxSystem, fluxSystemPlatform, certManager} {
+		if err := ml.WriteToDisk(dir); err != nil {
+			t.Fatalf("WriteToDisk(%s) failed: %v", ml.Name, err)
+		}
+	}
+
+	// Layer 1: directly under basePath, not under basePath/cluster/
+	if _, err := os.Stat(filepath.Join(dir, "flux-system", "configmap-gotk-components.yaml")); err != nil {
+		t.Errorf("Layer 1: expected configmap-gotk-components.yaml at flux-system/: %v", err)
+	}
+	// Layer 2: flux-system-platform/ directly under basePath
+	if _, err := os.Stat(filepath.Join(dir, "flux-system-platform")); err != nil {
+		t.Errorf("Layer 2: expected flux-system-platform/ at basePath root: %v", err)
+	}
+	// Layer 3: <group>/<appname>/ path
+	if _, err := os.Stat(filepath.Join(dir, "platform", "cert-manager")); err != nil {
+		t.Errorf("Layer 3: expected platform/cert-manager/ at basePath root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "platform", "cert-manager", "configmap-cert-manager-config.yaml")); err != nil {
+		t.Errorf("Layer 3: expected resource file in platform/cert-manager/: %v", err)
+	}
+	// Must NOT have a "cluster/" directory.
+	if _, err := os.Stat(filepath.Join(dir, "cluster")); err == nil {
+		t.Error("unexpected 'cluster/' directory: Namespace:'.' should not create it")
+	}
+}
+
 func TestWriteToDisk_FileNamingKindName_FluxIntegrated(t *testing.T) {
 	child := &ManifestLayout{
 		Name:       "team-a",


### PR DESCRIPTION
## Summary

### Missing tests from recent commits (audit of last 15 days)

- `pkg/stack/fluxcd/resource_generator_test.go`: adds `TestGenerateFromBundle_Patches` (4 subtests) and `TestGenerateFromBundle_PostBuild` (4 subtests) — covering the Kustomization spec wiring introduced in 088fc8b (Patches and PostBuild fields on Bundle) which shipped without tests
- `pkg/stack/helm/render_test.go`: adds `TestAssembleManifests_StableOrder` — regression test for the sort fix in 35b64c5, asserting deterministic output and correct alphabetical key ordering

### OCI layout patterns (docs/oci-layout.md)

Five new tests covering the OCI artifact conventions that were undocumented in test form:

- `TestWriteToTar_NamespaceDot_TarRoot` — `Namespace:"."` produces archive-root paths with no "cluster/" prefix; this is the convention crane uses
- `TestWriteToTar_OCILayer2GroupNaming` — `flux-system-<group>/` naming with `kustomization-<app>.yaml` inside (Layer 2)
- `TestWriteToTar_OCILayer3PayloadPath` — `<group>/<appname>/` path from `Namespace:<group>` + `Name:<appname>` (Layer 3)
- `TestWriteToTar_OCIMonolithic_SiblingLayers` — full 3-layer monolithic structure as siblings at archive root with `FileNamingKindName`
- `TestWriteToDisk_NamespaceDot_RootPaths` — same `Namespace:"."` convention verified on disk

## Test plan

- [ ] `mise run test` — all new tests pass, full suite green