### PR TITLE
ci: trigger Claude Code action automatically on PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,8 @@
 name: Claude Code
 
 on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -13,6 +15,7 @@ on:
 jobs:
   claude:
     if: |
+      (github.event_name == 'pull_request') ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||


### PR DESCRIPTION
## Summary

- `claude.yml` previously only fired when `@claude` was mentioned in a comment, review, or issue
- Now also triggers unconditionally on `pull_request` events (opened, synchronize, ready_for_review, reopened)

## Test plan

- [ ] Open a non-draft PR and confirm the Claude Code action runs without needing an `@claude` mention