### PR TITLE
ci: optimize pipeline — parallel jobs, single test run, Hugo cache, path filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ env:
 
 # Avoid duplicate runs on the same commit
 concurrency:
-  group: ci-${{ github.sha }}
-  cancel-in-progress: false
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # =============================================================================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,15 +440,16 @@ jobs:
     name: build
     runs-on: autops-kube
     timeout-minutes: 1
-    needs: [build-binaries, docs-build, coverage-check]
+    needs: [test, build-binaries, docs-build, coverage-check]
     if: always()
     steps:
     - name: Check build results
       run: |
+        tt="${{ needs.test.result }}"
         bb="${{ needs.build-binaries.result }}"
         db="${{ needs.docs-build.result }}"
         cc="${{ needs.coverage-check.result }}"
-        for result in "$bb" "$db" "$cc"; do
+        for result in "$tt" "$bb" "$db" "$cc"; do
           if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
             echo "Required job failed or was cancelled (result: $result)"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,16 +440,17 @@ jobs:
     name: build
     runs-on: autops-kube
     timeout-minutes: 1
-    needs: [test, build-binaries, docs-build, coverage-check]
+    needs: [validate, test, build-binaries, docs-build, coverage-check]
     if: always()
     steps:
     - name: Check build results
       run: |
+        vl="${{ needs.validate.result }}"
         tt="${{ needs.test.result }}"
         bb="${{ needs.build-binaries.result }}"
         db="${{ needs.docs-build.result }}"
         cc="${{ needs.coverage-check.result }}"
-        for result in "$tt" "$bb" "$db" "$cc"; do
+        for result in "$vl" "$tt" "$bb" "$db" "$cc"; do
           if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
             echo "Required job failed or was cancelled (result: $result)"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,37 @@ jobs:
         echo "Branch is up to date with main."
 
   # =============================================================================
+  # Pre-flight: Detect Changed Paths
+  # =============================================================================
+
+  changes:
+    name: detect-changes
+    runs-on: autops-kube
+    timeout-minutes: 2
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+      docs: ${{ steps.filter.outputs.docs }}
+
+    steps:
+    - uses: actions/checkout@v6
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          go:
+            - '**.go'
+            - 'go.mod'
+            - 'go.sum'
+            - 'Makefile'
+            - '.github/workflows/ci.yml'
+          docs:
+            - 'site/**'
+            - 'docs/**'
+            - '*.md'
+            - 'scripts/**'
+            - '.github/workflows/ci.yml'
+
+  # =============================================================================
   # Stage 1: Fast Validation
   # =============================================================================
 
@@ -58,14 +89,17 @@ jobs:
     name: lint
     runs-on: autops-kube
     timeout-minutes: 15
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: [changes]
+    if: |
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.go == 'true')
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
 
     - name: Install build tools
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make
+      run: command -v make &>/dev/null || (sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends make)
 
     - name: Read Go version from mise.toml
       id: go-version
@@ -78,7 +112,6 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: ${{ steps.go-version.outputs.version }}
-        check-latest: true
         cache: false
 
     - name: Cache Go modules
@@ -143,22 +176,24 @@ jobs:
         fi
 
   # =============================================================================
-  # Stage 2: Tests and Security (parallel)
+  # Stage 2: Tests and Security (parallel with lint)
   # =============================================================================
 
   test:
     name: test
     runs-on: autops-kube
     timeout-minutes: 15
-    needs: validate
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: [changes]
+    if: |
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.go == 'true')
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
 
     - name: Install build tools
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends build-essential
+      run: sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends build-essential
 
     - name: Read Go version from mise.toml
       id: go-version
@@ -171,7 +206,6 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: ${{ steps.go-version.outputs.version }}
-        check-latest: true
         cache: false
 
     - name: Cache Go modules
@@ -187,10 +221,11 @@ jobs:
     - name: Install dependencies
       run: make deps
 
-    - name: Run unit tests
+    - name: Run tests
       run: |
         set -euo pipefail
-        go test -v -timeout 30s ./... 2>&1 | tee /tmp/gotest.log
+        mkdir -p coverage
+        go test -v -race -coverprofile=coverage/coverage.out -covermode=atomic -timeout 5m ./... 2>&1 | tee /tmp/gotest.log
 
     - name: Upload test log
       uses: actions/upload-artifact@v7
@@ -199,14 +234,6 @@ jobs:
         name: test-log
         path: /tmp/gotest.log
         if-no-files-found: error
-
-    - name: Run race tests
-      env:
-        CGO_ENABLED: "1"
-      run: make test-race
-
-    - name: Run tests with coverage
-      run: make test-coverage
 
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v7
@@ -219,15 +246,17 @@ jobs:
     name: Security
     runs-on: autops-kube
     timeout-minutes: 10
-    needs: validate
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: [changes]
+    if: |
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.go == 'true')
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
 
     - name: Install build tools
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make
+      run: command -v make &>/dev/null || (sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends make)
 
     - name: Read Go version from mise.toml
       id: go-version
@@ -240,7 +269,6 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: ${{ steps.go-version.outputs.version }}
-        check-latest: true
         cache: false
 
     - name: Install govulncheck
@@ -304,7 +332,6 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: ${{ steps.go-version.outputs.version }}
-        check-latest: true
         cache: false
 
     - name: Download coverage artifact
@@ -350,15 +377,17 @@ jobs:
           Coverage threshold: 85%
 
   # =============================================================================
-  # Stage 4: Build and K8s Compatibility (parallel)
+  # Stage 4: Build and K8s Compatibility (parallel with coverage-check)
   # =============================================================================
 
   build-binaries:
     name: Build ${{ matrix.target }}
     runs-on: autops-kube
     timeout-minutes: 10
-    needs: coverage-check
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: [changes, test]
+    if: |
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.go == 'true')
 
     strategy:
       matrix:
@@ -369,7 +398,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Install build tools
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make
+      run: command -v make &>/dev/null || (sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends make)
 
     - name: Read Go version from mise.toml
       id: go-version
@@ -382,7 +411,6 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: ${{ steps.go-version.outputs.version }}
-        check-latest: true
         cache: false
 
     - name: Cache Go modules
@@ -412,19 +440,20 @@ jobs:
     name: build
     runs-on: autops-kube
     timeout-minutes: 1
-    needs: [build-binaries, docs-build]
+    needs: [build-binaries, docs-build, coverage-check]
     if: always()
     steps:
     - name: Check build results
       run: |
-        if [ "${{ needs.build-binaries.result }}" != "success" ]; then
-          echo "Build matrix failed or was cancelled"
-          exit 1
-        fi
-        if [ "${{ needs.docs-build.result }}" != "success" ]; then
-          echo "Docs build failed or was cancelled"
-          exit 1
-        fi
+        bb="${{ needs.build-binaries.result }}"
+        db="${{ needs.docs-build.result }}"
+        cc="${{ needs.coverage-check.result }}"
+        for result in "$bb" "$db" "$cc"; do
+          if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+            echo "Required job failed or was cancelled (result: $result)"
+            exit 1
+          fi
+        done
 
   # =============================================================================
   # Stage 5: Cross-Platform Build (main/release only)
@@ -453,7 +482,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Install build tools
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make
+      run: command -v make &>/dev/null || (sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends make)
 
     - name: Read Go version from mise.toml
       id: go-version
@@ -466,7 +495,6 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: ${{ steps.go-version.outputs.version }}
-        check-latest: true
         cache: false
 
     - name: Cache Go modules
@@ -516,17 +544,44 @@ jobs:
     name: docs-build
     runs-on: autops-kube
     timeout-minutes: 15
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-
-    env:
-      HUGO_VERSION: '0.155.3'
+    needs: [changes]
+    if: |
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.docs == 'true')
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
 
     - name: Install build tools
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make
+      run: command -v make &>/dev/null || (sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends make)
+
+    - name: Read Hugo version from mise.toml
+      id: hugo-version
+      run: |
+        HUGO_VER=$(grep '^hugo = ' mise.toml | sed 's/hugo = "\(.*\)"/\1/')
+        echo "version=$HUGO_VER" >> $GITHUB_OUTPUT
+
+    - name: Restore Hugo from cache
+      id: hugo-cache
+      uses: actions/cache@v5
+      with:
+        path: ${{ runner.temp }}/hugo-bin
+        key: hugo-${{ steps.hugo-version.outputs.version }}-linux-amd64
+
+    - name: Install Hugo CLI
+      if: steps.hugo-cache.outputs.cache-hit != 'true'
+      run: |
+        HUGO_VER="${{ steps.hugo-version.outputs.version }}"
+        curl -fsSL -o ${{ runner.temp }}/hugo.deb \
+          "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VER}/hugo_extended_${HUGO_VER}_linux-amd64.deb"
+        sudo dpkg -i ${{ runner.temp }}/hugo.deb
+        mkdir -p ${{ runner.temp }}/hugo-bin
+        cp /usr/local/bin/hugo ${{ runner.temp }}/hugo-bin/hugo
+
+    - name: Add cached Hugo to PATH
+      if: steps.hugo-cache.outputs.cache-hit == 'true'
+      run: sudo install ${{ runner.temp }}/hugo-bin/hugo /usr/local/bin/hugo
 
     - name: Read Go version from mise.toml
       id: go-version
@@ -539,14 +594,7 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: ${{ steps.go-version.outputs.version }}
-        check-latest: true
         cache: false
-
-    - name: Install Hugo CLI
-      run: |
-        curl -fsSL -o ${{ runner.temp }}/hugo.deb \
-          https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
     - name: Check mounted files exist
       run: bash site/scripts/check-mounts.sh
@@ -644,7 +692,11 @@ jobs:
     name: Docs Check
     runs-on: autops-kube
     timeout-minutes: 5
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    needs: [changes]
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      needs.changes.outputs.docs == 'true'
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,6 +561,10 @@ jobs:
       id: hugo-version
       run: |
         HUGO_VER=$(grep '^hugo = ' mise.toml | sed 's/hugo = "\(.*\)"/\1/')
+        if [ -z "$HUGO_VER" ]; then
+          echo "::error::Failed to parse Hugo version from mise.toml"
+          exit 1
+        fi
         echo "version=$HUGO_VER" >> $GITHUB_OUTPUT
 
     - name: Restore Hugo from cache


### PR DESCRIPTION
## Summary

- **Parallel execution**: break the `lint → test → security` serial chain; all three start simultaneously once the new `changes` detector job completes (~30s overhead)
- **Single test run**: collapse unit + race + coverage into one `go test -v -race -coverprofile=... -timeout 5m ./...` — eliminates 3× compile and ~5 min of blocked wait time
- **Dependency fix**: `build-binaries` now starts immediately after `test` passes instead of waiting for `coverage-check`; `build` gate adds `coverage-check` to its needs and treats `skipped` as passing
- **Path-based skipping**: Go jobs skip on docs-only PRs; `docs-build` + `docs-check` skip on Go-only PRs — uses `dorny/paths-filter@v3`
- **Hugo version from mise.toml**: removes hardcoded `env: HUGO_VERSION: '0.155.3'` in `docs-build`; now reads from `mise.toml` (single source of truth)
- **Hugo binary cache**: cached by version, skips download on cache hit
- **Conditional apt-get**: check `command -v make` before calling apt; quieted with `-qq`; remove `check-latest: true` from all `setup-go` calls

### Critical path before
`lint (5m) → test (9m) → coverage-check (42s) → build-binaries → build` ≈ 16 min

### Critical path after
`changes (30s) → test (≈4m) → build-binaries → build` (lint, security, coverage-check all parallel) ≈ 6-7 min

## Test plan

- [ ] Open a Go-only PR and confirm `validate`, `test`, `security` all start at the same time
- [ ] Open a docs-only PR and confirm Go jobs are skipped; `build` gate passes with all-skipped
- [ ] Verify `test` job shows a single test step with race + coverage output
- [ ] Verify `build-binaries` starts as soon as `test` finishes (not waiting for coverage-check)
- [ ] Verify `docs-build` skips the Hugo download step on a second run (cache hit)