### PR TITLE
fix(docs): repair 5 broken links on deployed docs site

### DIFF
--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -110,6 +110,6 @@ Before merging any dependency update:
 
 ## See Also
 
-- [DEVELOPMENT.md](../DEVELOPMENT.md) § Dependabot Management — PR commands for managing Dependabot PRs
-- [compatibility.md](compatibility.md) — Generated compatibility matrix
-- [versions.yaml](../versions.yaml) — Version source of truth
+- [Development Guide § Dependabot Management](/contributing/guide/#dependabot-management) — PR commands for managing Dependabot PRs
+- [Compatibility Matrix](/api-reference/compatibility/) — Generated compatibility matrix
+- [versions.yaml](https://github.com/go-kure/kure/blob/main/versions.yaml) — Version source of truth

--- a/site/content/guides/kurel-packages.md
+++ b/site/content/guides/kurel-packages.md
@@ -108,6 +108,6 @@ my-app.local.kurel/
 
 ## Further Reading
 
-- [Launcher reference](/api-reference/launcher) for the package system API
+- [Launcher reference](https://pkg.go.dev/github.com/go-kure/launcher/pkg/launcher) for the package system API
 - [Kurel Frigate example](/examples/kurel-frigate) for a complete package
 - [Patching guide](/guides/patching/) for the patch format

--- a/site/content/guides/patching.md
+++ b/site/content/guides/patching.md
@@ -185,6 +185,6 @@ for _, r := range reports {
 
 ## Further Reading
 
-- [Patch reference](/api-reference/patch) for API details
+- [Patch reference](https://pkg.go.dev/github.com/go-kure/launcher/pkg/patch) for API details
 - [Patch examples](/examples/patches) for working samples
 - [Kurel packages](/guides/kurel-packages/) for patch-based package customization


### PR DESCRIPTION
## Summary

Fixes 5 newly-reported broken links on `https://www.gokure.dev/kure/dev/`. Two unrelated root causes, combined in one PR since the fix is small and mechanical.

### Cause 1 — stale links left after package extraction (links #1, #2)

Commit `ec2a4ba` extracted `pkg/launcher` and `pkg/patch` to `go-kure/launcher` and cleaned up Hugo mounts and `_index.md`, but missed the "Further Reading" links in two guide pages.

- `site/content/guides/patching.md` — `/api-reference/patch` → `pkg.go.dev/.../launcher/pkg/patch`
- `site/content/guides/kurel-packages.md` — `/api-reference/launcher` → `pkg.go.dev/.../launcher/pkg/launcher`

`pkg.go.dev` is the same reference style used in `site/content/api-reference/_index.md` for every other package. Not pointing at `/launcher/dev/…` because that sub-site has no API reference pages yet.

### Cause 2 — filesystem-relative paths in a Hugo-mounted doc (links #3, #4, #5)

Commit `bae4a02` mounted `docs/dependency-updates.md` into the Hugo site. The "See Also" section used filesystem-relative paths (`../DEVELOPMENT.md`, `compatibility.md`, `../versions.yaml`) that don't resolve once rendered under `/contributing/dependency-updates/`.

- `../DEVELOPMENT.md § Dependabot Management` → `/contributing/guide/#dependabot-management` (matches `inject-frontmatter.sh:71` mount)
- `compatibility.md` → `/api-reference/compatibility/` (matches `inject-frontmatter.sh:68` mount)
- `../versions.yaml` → GitHub blob URL (file is not part of the Hugo content tree)

### What this does NOT solve

Whether `guides/patching.md` and `guides/kurel-packages.md` should be relocated to the launcher repo entirely, given both packages now live there. Left for a separate docs-restructuring decision.

## Test plan

- [ ] CI: lint, test, build, rebase-check pass
- [ ] After merge, `deploy-docs.yml` runs and redeploys dev site
- [ ] Confirm the 5 previously-404 URLs now return 200:
  - [ ] `/kure/dev/guides/patching/` — link targets `pkg.go.dev/.../launcher/pkg/patch`
  - [ ] `/kure/dev/guides/kurel-packages/` — link targets `pkg.go.dev/.../launcher/pkg/launcher`
  - [ ] `/kure/dev/contributing/dependency-updates/` — all three "See Also" links resolve
