### PR TITLE
fix(layout): use kustomize.config.k8s.io domain in generated kustomization.yaml

### DIFF
--- a/pkg/stack/layout/manifest.go
+++ b/pkg/stack/layout/manifest.go
@@ -264,7 +264,7 @@ func (ml *ManifestLayout) WriteToDisk(basePath string) error {
 		}
 
 		// Write proper YAML header
-		writeStr("apiVersion: kustomize.config.kubernetes.io/v1beta1\n")
+		writeStr("apiVersion: kustomize.config.k8s.io/v1beta1\n")
 		writeStr("kind: Kustomization\n")
 		writeStr("resources:\n")
 

--- a/pkg/stack/layout/manifest_test.go
+++ b/pkg/stack/layout/manifest_test.go
@@ -289,7 +289,7 @@ func TestManifestLayoutKustomizationFormat(t *testing.T) {
 	content := string(data)
 
 	// Verify proper kustomization format
-	if !strings.Contains(content, "apiVersion: kustomize.config.kubernetes.io/v1beta1") {
+	if !strings.Contains(content, "apiVersion: kustomize.config.k8s.io/v1beta1") {
 		t.Errorf("Expected proper apiVersion, got: %s", content)
 	}
 	if !strings.Contains(content, "kind: Kustomization") {
@@ -477,7 +477,7 @@ func TestLeafDirectoryKustomizationGeneration(t *testing.T) {
 	content := string(data)
 
 	// Verify kustomization.yaml contains the manifest files
-	if !strings.Contains(content, "apiVersion: kustomize.config.kubernetes.io/v1beta1") {
+	if !strings.Contains(content, "apiVersion: kustomize.config.k8s.io/v1beta1") {
 		t.Errorf("Expected proper apiVersion in leaf kustomization, got: %s", content)
 	}
 	if !strings.Contains(content, "kind: Kustomization") {

--- a/pkg/stack/layout/tar.go
+++ b/pkg/stack/layout/tar.go
@@ -102,7 +102,7 @@ func (ml *ManifestLayout) writeToTarRecursive(tw *tar.Writer, basePath string) e
 
 	if len(fileGroups) > 0 || len(ml.Children) > 0 {
 		var kustomBuf strings.Builder
-		kustomBuf.WriteString("apiVersion: kustomize.config.kubernetes.io/v1beta1\n")
+		kustomBuf.WriteString("apiVersion: kustomize.config.k8s.io/v1beta1\n")
 		kustomBuf.WriteString("kind: Kustomization\n")
 		kustomBuf.WriteString("resources:\n")
 

--- a/pkg/stack/layout/write.go
+++ b/pkg/stack/layout/write.go
@@ -120,7 +120,7 @@ func WriteManifest(basePath string, cfg Config, ml *ManifestLayout) error {
 		}
 
 		// Write proper YAML header
-		writeStr("apiVersion: kustomize.config.kubernetes.io/v1beta1\n")
+		writeStr("apiVersion: kustomize.config.k8s.io/v1beta1\n")
 		writeStr("kind: Kustomization\n")
 		writeStr("resources:\n")
 

--- a/pkg/stack/layout/write_test.go
+++ b/pkg/stack/layout/write_test.go
@@ -897,7 +897,7 @@ func TestWriteToDisk_KustomizationGenerated(t *testing.T) {
 	}
 
 	content := string(data)
-	if !strings.Contains(content, "apiVersion: kustomize.config.kubernetes.io/v1beta1") {
+	if !strings.Contains(content, "apiVersion: kustomize.config.k8s.io/v1beta1") {
 		t.Errorf("kustomization missing apiVersion, got:\n%s", content)
 	}
 	if !strings.Contains(content, "kind: Kustomization") {


### PR DESCRIPTION
## Summary

- Replace `apiVersion: kustomize.config.kubernetes.io/v1beta1` with the canonical `kustomize.config.k8s.io/v1beta1` in all generated `kustomization.yaml` index files.
- Recent `kustomize` CLI and `kubectl kustomize` versions reject the `kubernetes.io` variant with `KUSTOMIZE ERROR: apiVersion for Kustomization should be kustomize.config.k8s.io/v1beta1`.

Issue #471 mentioned only `pkg/stack/layout/manifest.go`, but the wrong domain appeared in three writers and three golden assertions:

- `pkg/stack/layout/manifest.go`
- `pkg/stack/layout/write.go`
- `pkg/stack/layout/tar.go`
- `pkg/stack/layout/manifest_test.go` (2 assertions)
- `pkg/stack/layout/write_test.go`

Closes #471

## Test plan

- [x] `rg "kustomize.config.kubernetes.io"` returns no matches
- [x] `mise run test` — all packages pass
- [x] `make lint LINT_FLAGS="--new-from-rev=origin/main"` (CI-equivalent diff lint) — 0 issues
- [ ] CI green