### PR TITLE
chore(ci): bump dorny/paths-filter from v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@v4
       id: filter
       with:
         filters: |


### PR DESCRIPTION
## Summary

Bumps `dorny/paths-filter` from v3 to v4 in `.github/workflows/ci.yml` (the `detect-changes` job).

Per the [v4.0.0 release notes](https://github.com/dorny/paths-filter/releases/tag/v4.0.0), the only change is updating the action runtime to node24. No input/output API changes — the existing `filters:` configuration and `steps.filter.outputs.*` consumers continue to work unchanged.

Kept separate from the FluxCD/CNPG bundle (PR #478) because:
- Major-version bump warrants an isolated revert path.
- Workflow-only change reviewed differently from `go.mod`.
- Different label/scope (`type/ci` vs `dependencies`).

Closes #464

## Test plan

- [ ] CI: `detect-changes` job runs on this PR and produces non-empty filter outputs (the file changed under `.github/workflows/**`).
- [ ] All required checks (`lint`, `test`, `build`, `rebase-check`) green.