### PR TITLE
feat(layout): add configMapGenerator support to ManifestLayout

### DIFF
--- a/pkg/stack/STATUS.md
+++ b/pkg/stack/STATUS.md
@@ -97,7 +97,7 @@ spec:
 
 #### 2. **Additional Generators**
 - [ ] **CronJobGenerator** - Kubernetes CronJob resources
-- [ ] **ConfigMapGenerator** - ConfigMaps from files/literals
+- [x] **ConfigMapGenerator** - ConfigMaps from files/literals (#473)
 - [ ] **SecretGenerator** - Secrets with encoding support
 - [ ] **NetworkPolicyGenerator** - Network policies
 - [ ] **KustomizationGenerator** - Flux Kustomizations

--- a/pkg/stack/layout/README.md
+++ b/pkg/stack/layout/README.md
@@ -112,6 +112,20 @@ Controls how resource YAML files are named:
 - **KustomizationRecursive**: References subdirectories only
 - Smart handling of cross-references and child relationships
 
+### Extra Files and ConfigMap Generators
+
+`ManifestLayout.ExtraFiles` lets callers attach arbitrary files (e.g. a `values.yaml`) into a layout's directory alongside the resource YAMLs. `ManifestLayout.ConfigMapGenerators` adds entries to a `configMapGenerator:` section in the generated `kustomization.yaml`. kustomize appends a content-hash suffix to the generated ConfigMap name and rewrites references (e.g. `HelmRelease.spec.valuesFrom`) on build, so any change to the source file forces re-reconciliation — the canonical FluxCD pattern for tracking Helm values changes.
+
+`LayoutAugmenter` is an optional interface on `stack.ApplicationConfig`:
+
+```go
+type LayoutAugmenter interface {
+    AugmentLayout(layout *ManifestLayout) error
+}
+```
+
+When `app.Config` implements it, the walker invokes `AugmentLayout` on the per-app `ManifestLayout` after resource generation, giving the config a chance to attach `ExtraFiles` and `ConfigMapGenerators`. Only invoked on per-app layouts produced by the non-flat (`GroupByName`) walker paths; `GroupFlat` and umbrella layouts merge resources into shared parent layouts and are not currently augmented.
+
 ### ClusterName-Aware Layouts
 
 Setting `LayoutRules.ClusterName` prepends the cluster name as a root directory, producing paths like `{clusterName}/{nodeName}/...` instead of `{nodeName}/...`. This is useful when a single repository manages multiple clusters.

--- a/pkg/stack/layout/augmenter.go
+++ b/pkg/stack/layout/augmenter.go
@@ -1,0 +1,67 @@
+package layout
+
+import (
+	"archive/tar"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-kure/kure/pkg/errors"
+)
+
+// LayoutAugmenter is an optional interface that ApplicationConfig
+// implementations can implement to attach extra files or configMapGenerator
+// entries to their per-app ManifestLayout after resource generation. The
+// walker invokes AugmentLayout when app.Config satisfies this interface.
+//
+// The interface lives in the layout package (rather than pkg/stack alongside
+// Validator) because ApplicationConfig — defined in pkg/stack — cannot
+// reference *ManifestLayout without creating an import cycle: the layout
+// package already imports pkg/stack.
+type LayoutAugmenter interface {
+	AugmentLayout(layout *ManifestLayout) error
+}
+
+// renderConfigMapGeneratorBlock renders the kustomization.yaml
+// configMapGenerator: section for the given specs. Returns the empty string
+// when no specs are present, so callers can append unconditionally.
+func renderConfigMapGeneratorBlock(specs []ConfigMapGeneratorSpec) string {
+	if len(specs) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("configMapGenerator:\n")
+	for _, spec := range specs {
+		b.WriteString(fmt.Sprintf("  - name: %s\n", spec.Name))
+		if len(spec.Files) > 0 {
+			b.WriteString("    files:\n")
+			for _, f := range spec.Files {
+				b.WriteString(fmt.Sprintf("      - %s\n", f))
+			}
+		}
+	}
+	return b.String()
+}
+
+// writeExtraFilesToDisk writes each ExtraFile into dir.
+func writeExtraFilesToDisk(dir string, files []ExtraFile) error {
+	for _, ef := range files {
+		fp := filepath.Join(dir, ef.Name)
+		if err := os.WriteFile(fp, ef.Content, 0644); err != nil {
+			return errors.NewFileError("write", fp, "extra file write failed", err)
+		}
+	}
+	return nil
+}
+
+// writeExtraFilesToTar writes each ExtraFile as a tar entry under fullPath.
+func writeExtraFilesToTar(tw *tar.Writer, fullPath string, files []ExtraFile) error {
+	for _, ef := range files {
+		if err := writeTarFile(tw, path.Join(fullPath, ef.Name), ef.Content); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/stack/layout/augmenter_test.go
+++ b/pkg/stack/layout/augmenter_test.go
@@ -1,0 +1,169 @@
+package layout
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestRenderConfigMapGeneratorBlock_Empty(t *testing.T) {
+	if got := renderConfigMapGeneratorBlock(nil); got != "" {
+		t.Errorf("expected empty string for nil specs, got %q", got)
+	}
+	if got := renderConfigMapGeneratorBlock([]ConfigMapGeneratorSpec{}); got != "" {
+		t.Errorf("expected empty string for empty specs, got %q", got)
+	}
+}
+
+func TestRenderConfigMapGeneratorBlock_Multiple(t *testing.T) {
+	specs := []ConfigMapGeneratorSpec{
+		{Name: "myapp-values", Files: []string{"values.yaml"}},
+		{Name: "extra", Files: []string{"a.txt", "b.txt"}},
+	}
+	got := renderConfigMapGeneratorBlock(specs)
+	want := "configMapGenerator:\n" +
+		"  - name: myapp-values\n" +
+		"    files:\n" +
+		"      - values.yaml\n" +
+		"  - name: extra\n" +
+		"    files:\n" +
+		"      - a.txt\n" +
+		"      - b.txt\n"
+	if got != want {
+		t.Errorf("unexpected block:\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
+func TestWriteToDisk_ExtraFilesAndConfigMapGenerator(t *testing.T) {
+	obj := testObject("v1", "ConfigMap", "test", "default")
+	ml := &ManifestLayout{
+		Name:      "test",
+		Namespace: "default",
+		FilePer:   FilePerResource,
+		Resources: []client.Object{obj},
+		ExtraFiles: []ExtraFile{
+			{Name: "values.yaml", Content: []byte("foo: bar\n")},
+		},
+		ConfigMapGenerators: []ConfigMapGeneratorSpec{
+			{Name: "myapp-values", Files: []string{"values.yaml"}},
+		},
+	}
+
+	dir := t.TempDir()
+	if err := ml.WriteToDisk(dir); err != nil {
+		t.Fatalf("WriteToDisk: %v", err)
+	}
+
+	valuesPath := filepath.Join(dir, "default", "test", "values.yaml")
+	got, err := os.ReadFile(valuesPath)
+	if err != nil {
+		t.Fatalf("read values.yaml: %v", err)
+	}
+	if string(got) != "foo: bar\n" {
+		t.Errorf("values.yaml content: got %q", string(got))
+	}
+
+	kustomBytes, err := os.ReadFile(filepath.Join(dir, "default", "test", "kustomization.yaml"))
+	if err != nil {
+		t.Fatalf("read kustomization.yaml: %v", err)
+	}
+	kustom := string(kustomBytes)
+	if !strings.Contains(kustom, "configMapGenerator:") {
+		t.Errorf("kustomization.yaml missing configMapGenerator: section:\n%s", kustom)
+	}
+	if !strings.Contains(kustom, "name: myapp-values") {
+		t.Errorf("kustomization.yaml missing generator name:\n%s", kustom)
+	}
+	if !strings.Contains(kustom, "- values.yaml") {
+		t.Errorf("kustomization.yaml missing generator file ref:\n%s", kustom)
+	}
+	if strings.Index(kustom, "resources:") > strings.Index(kustom, "configMapGenerator:") {
+		t.Errorf("configMapGenerator must follow resources:\n%s", kustom)
+	}
+}
+
+func TestWriteManifest_ExtraFilesAndConfigMapGenerator(t *testing.T) {
+	obj := testObject("v1", "ConfigMap", "test", "default")
+	ml := &ManifestLayout{
+		Name:      "test",
+		Namespace: "default",
+		FilePer:   FilePerResource,
+		Resources: []client.Object{obj},
+		ExtraFiles: []ExtraFile{
+			{Name: "values.yaml", Content: []byte("a: 1\n")},
+		},
+		ConfigMapGenerators: []ConfigMapGeneratorSpec{
+			{Name: "test-values", Files: []string{"values.yaml"}},
+		},
+	}
+
+	dir := t.TempDir()
+	cfg := Config{ManifestsDir: "clusters", FilePer: FilePerResource}
+	if err := WriteManifest(dir, cfg, ml); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+
+	base := filepath.Join(dir, "clusters", "default", "test")
+	if got, err := os.ReadFile(filepath.Join(base, "values.yaml")); err != nil {
+		t.Fatalf("read values.yaml: %v", err)
+	} else if string(got) != "a: 1\n" {
+		t.Errorf("values.yaml content: got %q", string(got))
+	}
+
+	kustomBytes, err := os.ReadFile(filepath.Join(base, "kustomization.yaml"))
+	if err != nil {
+		t.Fatalf("read kustomization.yaml: %v", err)
+	}
+	kustom := string(kustomBytes)
+	if !strings.Contains(kustom, "configMapGenerator:") {
+		t.Errorf("kustomization.yaml missing configMapGenerator:\n%s", kustom)
+	}
+	if !strings.Contains(kustom, "name: test-values") {
+		t.Errorf("kustomization.yaml missing generator name:\n%s", kustom)
+	}
+}
+
+func TestWriteToTar_ExtraFilesAndConfigMapGenerator(t *testing.T) {
+	obj := testObject("v1", "ConfigMap", "test", "default")
+	ml := &ManifestLayout{
+		Name:      "test",
+		Namespace: "default",
+		FilePer:   FilePerResource,
+		Resources: []client.Object{obj},
+		ExtraFiles: []ExtraFile{
+			{Name: "values.yaml", Content: []byte("hello: world\n")},
+		},
+		ConfigMapGenerators: []ConfigMapGeneratorSpec{
+			{Name: "tar-values", Files: []string{"values.yaml"}},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := ml.WriteToTar(&buf); err != nil {
+		t.Fatalf("WriteToTar: %v", err)
+	}
+
+	files := extractTarFiles(t, &buf)
+	values, ok := files["default/test/values.yaml"]
+	if !ok {
+		t.Fatalf("values.yaml missing from tar (got: %v)", fileNames(files))
+	}
+	if !bytes.Equal(values, []byte("hello: world\n")) {
+		t.Errorf("values.yaml content: got %q", string(values))
+	}
+
+	kustom, ok := files["default/test/kustomization.yaml"]
+	if !ok {
+		t.Fatalf("kustomization.yaml missing from tar")
+	}
+	if !bytes.Contains(kustom, []byte("configMapGenerator:")) {
+		t.Errorf("kustomization.yaml missing configMapGenerator:\n%s", kustom)
+	}
+	if !bytes.Contains(kustom, []byte("name: tar-values")) {
+		t.Errorf("kustomization.yaml missing generator name:\n%s", kustom)
+	}
+}

--- a/pkg/stack/layout/manifest.go
+++ b/pkg/stack/layout/manifest.go
@@ -25,6 +25,16 @@ type ManifestLayout struct {
 	FileNaming          FileNamingMode // Controls resource file naming pattern
 	Resources           []client.Object
 	Children            []*ManifestLayout
+	// ExtraFiles are arbitrary files written alongside resource YAMLs in this
+	// layout's directory. Typical use: a values.yaml referenced by a
+	// configMapGenerator entry. Augmenters (LayoutAugmenter) attach these.
+	ExtraFiles []ExtraFile
+	// ConfigMapGenerators emit a kustomize configMapGenerator: section in
+	// kustomization.yaml. kustomize appends a content-hash suffix to each
+	// generated ConfigMap name; resources referencing it (e.g.
+	// HelmRelease.spec.valuesFrom) are rewritten to the suffixed name on
+	// build, so any change to the source file forces re-reconciliation.
+	ConfigMapGenerators []ConfigMapGeneratorSpec
 	// UmbrellaChild marks this layout as rendered from a Bundle.Children
 	// entry. When true, kustomization.yaml writers emit a
 	// flux-system-kustomization-{Name}.yaml reference in the parent directory
@@ -32,6 +42,21 @@ type ManifestLayout struct {
 	// child's Flux Kustomization CR at the parent layout node rather than in
 	// the child's own directory.
 	UmbrellaChild bool
+}
+
+// ExtraFile is an arbitrary file written into a ManifestLayout's directory
+// alongside the resource YAMLs.
+type ExtraFile struct {
+	Name    string
+	Content []byte
+}
+
+// ConfigMapGeneratorSpec describes a single kustomize configMapGenerator entry.
+// Files are paths (relative to the layout directory) of files included in the
+// generated ConfigMap.
+type ConfigMapGeneratorSpec struct {
+	Name  string
+	Files []string
 }
 
 // resolveManifestFileName returns the effective ManifestFileNameFunc for this
@@ -241,6 +266,10 @@ func (ml *ManifestLayout) WriteToDisk(basePath string) error {
 		}
 	}
 
+	if err := writeExtraFilesToDisk(fullPath, ml.ExtraFiles); err != nil {
+		return err
+	}
+
 	kMode := ml.Mode
 	if kMode == KustomizationUnset {
 		kMode = KustomizationExplicit
@@ -310,6 +339,8 @@ func (ml *ManifestLayout) WriteToDisk(basePath string) error {
 				writeStr(fmt.Sprintf("  - %s\n", child.Name))
 			}
 		}
+
+		writeStr(renderConfigMapGeneratorBlock(ml.ConfigMapGenerators))
 
 		if writeErr != nil {
 			_ = kf.Close()

--- a/pkg/stack/layout/tar.go
+++ b/pkg/stack/layout/tar.go
@@ -94,6 +94,10 @@ func (ml *ManifestLayout) writeToTarRecursive(tw *tar.Writer, basePath string) e
 		}
 	}
 
+	if err := writeExtraFilesToTar(tw, fullPath, ml.ExtraFiles); err != nil {
+		return err
+	}
+
 	// Write kustomization.yaml
 	kMode := ml.Mode
 	if kMode == KustomizationUnset {
@@ -143,6 +147,8 @@ func (ml *ManifestLayout) writeToTarRecursive(tw *tar.Writer, basePath string) e
 				kustomBuf.WriteString(fmt.Sprintf("  - %s\n", child.Name))
 			}
 		}
+
+		kustomBuf.WriteString(renderConfigMapGeneratorBlock(ml.ConfigMapGenerators))
 
 		if err := writeTarFile(tw, path.Join(fullPath, "kustomization.yaml"), []byte(kustomBuf.String())); err != nil {
 			return err

--- a/pkg/stack/layout/walker.go
+++ b/pkg/stack/layout/walker.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/go-kure/kure/pkg/errors"
 	"github.com/go-kure/kure/pkg/stack"
 )
 
@@ -323,6 +324,9 @@ func walkNode(n *stack.Node, ancestors []string, nodeOnly bool, nodeFlat bool, f
 					FluxPlacement: fluxPlacement,
 					FileNaming:    fileNaming,
 				}
+				if err := augmentAppLayout(app, appLayout); err != nil {
+					return nil, err
+				}
 				bundleChildren = append(bundleChildren, appLayout)
 			}
 			// Umbrella: umbrella child sub-layouts are siblings of application
@@ -439,6 +443,24 @@ func walkUmbrellaChildLayouts(children []*stack.Bundle, currentPath []string, fi
 	return out, nil
 }
 
+// augmentAppLayout invokes the LayoutAugmenter on app.Config when it satisfies
+// the interface, attaching ExtraFiles and ConfigMapGenerators to the per-app
+// ManifestLayout. It is a no-op when the config does not implement the
+// interface.
+func augmentAppLayout(app *stack.Application, ml *ManifestLayout) error {
+	if app == nil || app.Config == nil {
+		return nil
+	}
+	augmenter, ok := app.Config.(LayoutAugmenter)
+	if !ok {
+		return nil
+	}
+	if err := augmenter.AugmentLayout(ml); err != nil {
+		return errors.Wrapf(err, "augment layout for application %q", app.Name)
+	}
+	return nil
+}
+
 // resolvePackageRef returns the effective PackageRef for a node, using inheritance from parent
 func resolvePackageRef(n *stack.Node, inheritedPackageRef *schema.GroupVersionKind) *schema.GroupVersionKind {
 	if n.PackageRef != nil {
@@ -542,6 +564,9 @@ func walkNodeForPackageInternal(n *stack.Node, ancestors []string, nodeOnly bool
 						Namespace:  filepath.Join(append(currentPath, b.Name)...),
 						Resources:  objs,
 						FileNaming: fileNaming,
+					}
+					if err := augmentAppLayout(app, appLayout); err != nil {
+						return nil, err
 					}
 					bundleChildren = append(bundleChildren, appLayout)
 				}

--- a/pkg/stack/layout/walker_test.go
+++ b/pkg/stack/layout/walker_test.go
@@ -1,6 +1,7 @@
 package layout_test
 
 import (
+	"errors"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -19,6 +20,31 @@ type fakeConfig struct {
 
 func (f *fakeConfig) Generate(*stack.Application) ([]*client.Object, error) {
 	return f.objs, f.err
+}
+
+// fakeAugmentingConfig implements both stack.ApplicationConfig and
+// layout.LayoutAugmenter. It records the layout it was called with.
+type fakeAugmentingConfig struct {
+	objs       []*client.Object
+	augmentErr error
+	called     *layout.ManifestLayout
+}
+
+func (f *fakeAugmentingConfig) Generate(*stack.Application) ([]*client.Object, error) {
+	return f.objs, nil
+}
+
+func (f *fakeAugmentingConfig) AugmentLayout(ml *layout.ManifestLayout) error {
+	f.called = ml
+	if f.augmentErr != nil {
+		return f.augmentErr
+	}
+	ml.ExtraFiles = append(ml.ExtraFiles, layout.ExtraFile{Name: "values.yaml", Content: []byte("k: v\n")})
+	ml.ConfigMapGenerators = append(ml.ConfigMapGenerators, layout.ConfigMapGeneratorSpec{
+		Name:  "augmented-values",
+		Files: []string{"values.yaml"},
+	})
+	return nil
 }
 
 func TestWalkCluster(t *testing.T) {
@@ -756,5 +782,70 @@ func TestWalkClusterByPackage_PropagatesFileNaming(t *testing.T) {
 			}
 		}
 		check(ml)
+	}
+}
+
+func TestWalkCluster_LayoutAugmenter(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("v1")
+	obj.SetKind("ConfigMap")
+	obj.SetName("cm")
+	obj.SetNamespace("default")
+	var o client.Object = obj
+
+	cfg := &fakeAugmentingConfig{objs: []*client.Object{&o}}
+	app := stack.NewApplication("app", "ns", cfg)
+	bundle := &stack.Bundle{Name: "bundle", Applications: []*stack.Application{app}}
+	root := &stack.Node{Name: "root", Bundle: bundle}
+	cluster := &stack.Cluster{Name: "demo", Node: root}
+
+	ml, err := layout.WalkCluster(cluster, layout.LayoutRules{
+		BundleGrouping:      layout.GroupByName,
+		ApplicationGrouping: layout.GroupByName,
+	})
+	if err != nil {
+		t.Fatalf("walk cluster: %v", err)
+	}
+
+	bundleLayout := ml.Children[0]
+	if len(bundleLayout.Children) != 1 {
+		t.Fatalf("expected one app layout, got %d", len(bundleLayout.Children))
+	}
+	appLayout := bundleLayout.Children[0]
+	if cfg.called != appLayout {
+		t.Errorf("AugmentLayout was not called with the per-app layout")
+	}
+	if len(appLayout.ExtraFiles) != 1 || appLayout.ExtraFiles[0].Name != "values.yaml" {
+		t.Errorf("expected ExtraFiles attached, got %+v", appLayout.ExtraFiles)
+	}
+	if len(appLayout.ConfigMapGenerators) != 1 || appLayout.ConfigMapGenerators[0].Name != "augmented-values" {
+		t.Errorf("expected ConfigMapGenerators attached, got %+v", appLayout.ConfigMapGenerators)
+	}
+}
+
+func TestWalkCluster_LayoutAugmenter_Error(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("v1")
+	obj.SetKind("ConfigMap")
+	obj.SetName("cm")
+	obj.SetNamespace("default")
+	var o client.Object = obj
+
+	wantErr := errors.New("augment failed")
+	cfg := &fakeAugmentingConfig{objs: []*client.Object{&o}, augmentErr: wantErr}
+	app := stack.NewApplication("app", "ns", cfg)
+	bundle := &stack.Bundle{Name: "bundle", Applications: []*stack.Application{app}}
+	root := &stack.Node{Name: "root", Bundle: bundle}
+	cluster := &stack.Cluster{Name: "demo", Node: root}
+
+	_, err := layout.WalkCluster(cluster, layout.LayoutRules{
+		BundleGrouping:      layout.GroupByName,
+		ApplicationGrouping: layout.GroupByName,
+	})
+	if err == nil {
+		t.Fatalf("expected error from augmenter, got nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("expected wrapped wantErr, got: %v", err)
 	}
 }

--- a/pkg/stack/layout/write.go
+++ b/pkg/stack/layout/write.go
@@ -99,6 +99,10 @@ func WriteManifest(basePath string, cfg Config, ml *ManifestLayout) error {
 		}
 	}
 
+	if err := writeExtraFilesToDisk(fullPath, ml.ExtraFiles); err != nil {
+		return err
+	}
+
 	// Don't generate root kustomization.yaml at cluster level (when namespace is just the cluster name)
 	isClusterRoot := strings.Count(ml.Namespace, string(filepath.Separator)) == 0 && ml.Name == ""
 
@@ -162,6 +166,8 @@ func WriteManifest(basePath string, cfg Config, ml *ManifestLayout) error {
 				}
 			}
 		}
+
+		writeStr(renderConfigMapGeneratorBlock(ml.ConfigMapGenerators))
 
 		if writeErr != nil {
 			_ = kf.Close()


### PR DESCRIPTION
## Summary

Adds `configMapGenerator` support to `ManifestLayout` so generated `kustomization.yaml` files can include a `configMapGenerator:` section. This is the canonical FluxCD pattern for triggering HelmRelease re-reconciliation when Helm values change (kustomize appends a content-hash suffix to the ConfigMap name and rewrites references).

- New types `ExtraFile` and `ConfigMapGeneratorSpec`; new `ManifestLayout` slice fields `ExtraFiles` and `ConfigMapGenerators`.
- New optional interface `LayoutAugmenter` (`pkg/stack/layout/augmenter.go`) — `ApplicationConfig` implementations attach extras after generation.
- Walker invokes `AugmentLayout(appLayout)` at the two per-app `ManifestLayout` construction sites.
- All three writers (`WriteToDisk`, `WriteManifest`, `WriteToTar`) write `ExtraFiles` alongside resource YAMLs and emit a `configMapGenerator:` section after `resources:` when the slice is non-empty.

Closes #473. Unblocks crane#179 (HelmRelease values via configMapGenerator).

## Design note — interface placement deviation from issue body

The issue proposes putting `LayoutAugmenter` in `pkg/stack/application.go` (alongside `Validator`). That can't work: `pkg/stack` cannot import `pkg/stack/layout` without an import cycle (the layout package imports `stack`). So `LayoutAugmenter` lives in `pkg/stack/layout/`. Consumers (e.g. crane's `HelmreleaseConfig`) already import `pkg/stack/layout` for `ManifestLayout` types, so the change is transparent to them.

## Scope — known limitations

- **Per-app layouts only**. Augmentation only fires on per-app `ManifestLayout` nodes built by non-flat (`GroupByName`) walker paths. `GroupFlat` and umbrella paths merge resources into shared parent layouts and aren't currently augmented; documented in README and `What this does NOT solve` in the plan.
- Minimal generator surface: `name` + `files` only. No `literals:`, `envs:`, `namespace`, or `options.disableNameSuffixHash` — matches the issue's stated design. Future PR can extend if needed.

## Test plan

- [x] New tests in `pkg/stack/layout/augmenter_test.go` cover: helper `renderConfigMapGeneratorBlock` (empty + multi-spec), `WriteToDisk` + `WriteManifest` + `WriteToTar` each with extras + generator block.
- [x] New walker tests in `walker_test.go`: `LayoutAugmenter` dispatch (asserts the per-app layout pointer is passed through and fields are set), and error propagation (`errors.Is(err, wantErr)`).
- [x] `make test` — all packages pass.
- [x] `make lint LINT_FLAGS="--new-from-rev=origin/main"` — 0 new issues.
- [ ] Manual: build a layout with extras, write to disk, run `kustomize build .` against it.
- [ ] CI green.

## Doc / status

- `pkg/stack/layout/README.md` gets a new "Extra Files and ConfigMap Generators" subsection.
- `pkg/stack/STATUS.md`: ConfigMapGenerator entry flipped to checked, with `(#473)` marker.