### PR TITLE
feat(volsync): add ReplicationSource and ReplicationDestination builders

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -464,6 +464,51 @@ All builders maintain consistency through:
 - **Standard Patterns**: Uniform function naming across resource types
 - **Boundary Validation**: Public facade functions handle nil-config checks
 
+### One-of Constraints (Sealed Interfaces)
+
+Some upstream CRDs encode an *exactly-one-of* constraint as a struct with multiple optional pointer fields — the user is expected to set exactly one. Examples: cert-manager `IssuerSpec` (ACME / CA / Vault / SelfSigned / Venafi); VolSync `ReplicationSourceSpec` (Restic / Rsync / RsyncTLS / Rclone / Syncthing / External). Go's type system can't statically express "set exactly one of these fields", so the constraint is a CRD-level (apply-time) check.
+
+Kure encodes these as a **sealed-interface sum type** so violations are a compile error rather than an apply-time error. Pattern:
+
+1. **Sealed marker interface** with an unexported method, so only types in the same package can satisfy it:
+   ```go
+   type SourceMover interface {
+       isSourceMover()
+   }
+   ```
+2. **Per-variant Configs** as defined types over the upstream specs (or hand-rolled structs where simplification adds value), each attaching the marker:
+   ```go
+   type SourceResticConfig volsyncv1alpha1.ReplicationSourceResticSpec
+   func (*SourceResticConfig) isSourceMover() {}
+
+   type SourceRcloneConfig volsyncv1alpha1.ReplicationSourceRcloneSpec
+   func (*SourceRcloneConfig) isSourceMover() {}
+   // ... etc.
+   ```
+3. **Single field** of the interface type on the parent Config — the compiler enforces "at most one variant":
+   ```go
+   type ReplicationSourceConfig struct {
+       Name, Namespace string
+       SourcePVC       string
+       Trigger         *TriggerConfig
+       Mover           SourceMover  // exactly one variant
+   }
+   ```
+4. **Type-switch dispatch** in the public constructor:
+   ```go
+   switch m := cfg.Mover.(type) {
+   case *SourceResticConfig:
+       spec := volsyncv1alpha1.ReplicationSourceResticSpec(*m)
+       rs.Spec.Restic = &spec
+   case *SourceRcloneConfig:
+       // ...
+   }
+   ```
+
+This is the kure idiom for one-of: setting two variants is a compile error (single field), and missing variants are caught at construction (nil case in the type switch).
+
+`pkg/kubernetes/volsync` is the reference implementation. `pkg/kubernetes/certmanager` predates this convention and uses the older multi-pointer + first-match-precedence pattern; refactoring it to the sealed-interface idiom is tracked as a follow-up before v1.0.
+
 ---
 
 ## Patch System Architecture

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ replace (
 )
 
 require (
+	github.com/backube/volsync v0.15.0
 	github.com/cert-manager/cert-manager v1.20.2
 	github.com/cloudnative-pg/barman-cloud v0.5.1
 	github.com/cloudnative-pg/cloudnative-pg v1.29.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/avast/retry-go/v5 v5.0.0 h1:kf1Qc2UsTZ4qq8elDymqfbISvkyMuhgRxuJqX2NHP7k=
 github.com/avast/retry-go/v5 v5.0.0/go.mod h1://d+usmKWio1agtZfS1H/ltTqwtIfBnRq9zEwjc3eH8=
+github.com/backube/volsync v0.15.0 h1:S7QasY5AceYD89RuirMLh75iOR8HBKKzjY2H1+zK3wk=
+github.com/backube/volsync v0.15.0/go.mod h1:voDWlAuT/+vGWeqye5mq7qyhjrjUcFgt7IybSmviU30=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
@@ -189,8 +191,8 @@ github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/S
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru/arc/v2 v2.0.5 h1:l2zaLDubNhW4XO3LnliVj0GXO3+/CGNJAg1dcN2Fpfw=
 github.com/hashicorp/golang-lru/arc/v2 v2.0.5/go.mod h1:ny6zBSQZi2JxIeYcv7kt2sH2PXJtirBN7RDhRpxPkxU=
-github.com/hashicorp/golang-lru/v2 v2.0.5 h1:wW7h1TG88eUIJ2i69gaE3uNVtEPIagzhGvHgwfx2Vm4=
-github.com/hashicorp/golang-lru/v2 v2.0.5/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/internal/volsync/doc.go
+++ b/internal/volsync/doc.go
@@ -1,0 +1,8 @@
+// Package volsync contains the internal builders for VolSync resources.
+// Public callers should use github.com/go-kure/kure/pkg/kubernetes/volsync.
+//
+// The internal layer is intentionally thin: per-mover Specs are upstream
+// types reused directly via defined-type wrappers in the public package, so
+// only the resource constructors (ReplicationSource, ReplicationDestination)
+// live here.
+package volsync

--- a/internal/volsync/replicationdestination.go
+++ b/internal/volsync/replicationdestination.go
@@ -1,0 +1,23 @@
+package volsync
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+)
+
+// CreateReplicationDestination returns a typed ReplicationDestination with
+// TypeMeta and ObjectMeta populated. Spec fields are filled by the public
+// package's dispatcher.
+func CreateReplicationDestination(name, namespace string) *volsyncv1alpha1.ReplicationDestination {
+	return &volsyncv1alpha1.ReplicationDestination{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: volsyncv1alpha1.GroupVersion.String(),
+			Kind:       "ReplicationDestination",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}

--- a/internal/volsync/replicationsource.go
+++ b/internal/volsync/replicationsource.go
@@ -1,0 +1,23 @@
+package volsync
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+)
+
+// CreateReplicationSource returns a typed ReplicationSource with TypeMeta and
+// ObjectMeta populated. Spec fields are left zero — the public package fills
+// them via the dispatcher in pkg/kubernetes/volsync/create.go.
+func CreateReplicationSource(name, namespace string) *volsyncv1alpha1.ReplicationSource {
+	return &volsyncv1alpha1.ReplicationSource{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: volsyncv1alpha1.GroupVersion.String(),
+			Kind:       "ReplicationSource",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}

--- a/internal/volsync/replicationsource_test.go
+++ b/internal/volsync/replicationsource_test.go
@@ -1,0 +1,41 @@
+package volsync
+
+import "testing"
+
+func TestCreateReplicationSource(t *testing.T) {
+	rs := CreateReplicationSource("backup", "data")
+	if rs == nil {
+		t.Fatal("expected non-nil ReplicationSource")
+	}
+	if rs.Kind != "ReplicationSource" {
+		t.Errorf("Kind = %q, want ReplicationSource", rs.Kind)
+	}
+	if rs.APIVersion != "volsync.backube/v1alpha1" {
+		t.Errorf("APIVersion = %q, want volsync.backube/v1alpha1", rs.APIVersion)
+	}
+	if rs.Name != "backup" {
+		t.Errorf("Name = %q, want backup", rs.Name)
+	}
+	if rs.Namespace != "data" {
+		t.Errorf("Namespace = %q, want data", rs.Namespace)
+	}
+}
+
+func TestCreateReplicationDestination(t *testing.T) {
+	rd := CreateReplicationDestination("restore", "dr")
+	if rd == nil {
+		t.Fatal("expected non-nil ReplicationDestination")
+	}
+	if rd.Kind != "ReplicationDestination" {
+		t.Errorf("Kind = %q, want ReplicationDestination", rd.Kind)
+	}
+	if rd.APIVersion != "volsync.backube/v1alpha1" {
+		t.Errorf("APIVersion = %q, want volsync.backube/v1alpha1", rd.APIVersion)
+	}
+	if rd.Name != "restore" {
+		t.Errorf("Name = %q, want restore", rd.Name)
+	}
+	if rd.Namespace != "dr" {
+		t.Errorf("Namespace = %q, want dr", rd.Namespace)
+	}
+}

--- a/pkg/kubernetes/scheme.go
+++ b/pkg/kubernetes/scheme.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"sync"
 
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -73,6 +74,7 @@ func registerAllSchemes() error {
 		metallbv1beta1.AddToScheme,
 		gwapiv1.Install,
 		monitoringv1.AddToScheme,
+		volsyncv1alpha1.AddToScheme,
 	}
 
 	// Register each scheme, returning the first error

--- a/pkg/kubernetes/volsync/README.md
+++ b/pkg/kubernetes/volsync/README.md
@@ -1,0 +1,103 @@
+# VolSync Builders - ReplicationSource and ReplicationDestination
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/go-kure/kure/pkg/kubernetes/volsync.svg)](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/volsync)
+
+The `volsync` package provides strongly-typed constructor functions for VolSync (`volsync.backube/v1alpha1`) resources. It is the canonical entry point for building `ReplicationSource` and `ReplicationDestination` objects in kure.
+
+## Overview
+
+VolSync replicates persistent volume data between Kubernetes clusters. Each replication direction (source and destination) selects exactly one *mover* — the data-transfer backend — from a sum of choices: Restic, Rsync (legacy SSH), RsyncTLS, Rclone, Syncthing (source-only), or an External passthrough.
+
+This package encodes the mover one-of as a **sealed-interface sum type**: `Mover` on the parent Config holds exactly one variant. Setting two movers is a compile error; setting none is detected at construction. See [`docs/ARCHITECTURE.md` § One-of Constraints](/concepts/architecture/#one-of-constraints-sealed-interfaces) for the rationale.
+
+## Supported Resources
+
+| Resource | Movers |
+|---|---|
+| `ReplicationSource` | Restic · Rsync · RsyncTLS · Rclone · Syncthing · External |
+| `ReplicationDestination` | Restic · Rsync · RsyncTLS · Rclone · External |
+
+## ReplicationSource
+
+```go
+import (
+    volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+
+    "github.com/go-kure/kure/pkg/kubernetes/volsync"
+)
+
+schedule := "@hourly"
+rs := volsync.ReplicationSource(&volsync.ReplicationSourceConfig{
+    Name:      "db-backup",
+    Namespace: "data",
+    SourcePVC: "postgres-data",
+    Trigger:   &volsync.TriggerConfig{Schedule: &schedule},
+    Mover: &volsync.SourceResticConfig{
+        Repository: "restic-creds",
+        ReplicationSourceVolumeOptions: volsyncv1alpha1.ReplicationSourceVolumeOptions{
+            CopyMethod: volsync.CopyMethodSnapshot,
+        },
+        Retain: &volsyncv1alpha1.ResticRetainPolicy{
+            Daily:   ptr.Int32(7),
+            Weekly:  ptr.Int32(4),
+            Monthly: ptr.Int32(12),
+        },
+    },
+})
+```
+
+## ReplicationDestination
+
+```go
+rd := volsync.ReplicationDestination(&volsync.ReplicationDestinationConfig{
+    Name:      "db-restore",
+    Namespace: "dr",
+    Trigger:   &volsync.TriggerConfig{Manual: "restore-1"},
+    Mover: &volsync.DestinationResticConfig{
+        Repository: "restic-creds",
+        ReplicationDestinationVolumeOptions: volsyncv1alpha1.ReplicationDestinationVolumeOptions{
+            CopyMethod:  volsync.CopyMethodSnapshot,
+            Capacity:    resource.MustParse("10Gi").DeepCopy(),
+            AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+        },
+    },
+})
+```
+
+## Movers
+
+| Mover | Purpose |
+|---|---|
+| `Restic` | Encrypted, deduplicated snapshots to a restic repository (S3, B2, etc.). |
+| `Rsync` | Legacy SSH-based rsync. Prefer `RsyncTLS` for new deployments. |
+| `RsyncTLS` | rsync over a TLS pre-shared key. |
+| `Rclone` | Sync to/from any rclone-supported backend (S3, GCS, Azure, etc.). |
+| `Syncthing` | Continuous bidirectional sync over the Syncthing protocol (source resource only). |
+| `External` | Passthrough for custom replication providers — opaque `provider` + `parameters`. |
+
+## Modifier Functions
+
+```go
+// Trigger
+volsync.SetReplicationSourceSchedule(rs, "@daily")
+volsync.SetReplicationSourceManualTrigger(rs, "go")
+volsync.SetReplicationDestinationSchedule(rd, "@weekly")
+volsync.SetReplicationDestinationManualTrigger(rd, "go")
+
+// Spec fields
+volsync.SetReplicationSourceSourcePVC(rs, "data")
+volsync.SetReplicationSourcePaused(rs, true)
+volsync.SetReplicationDestinationPaused(rd, true)
+
+// Replace mover (clears any existing mover first)
+volsync.SetReplicationSourceMover(rs, &volsync.SourceRcloneConfig{ /* ... */ })
+volsync.SetReplicationDestinationMover(rd, &volsync.DestinationResticConfig{ /* ... */ })
+
+// Syncthing peers
+volsync.AddSyncthingPeer(syncCfg, "tcp://peer:22000", "PEER-ID", false)
+```
+
+## Related Packages
+
+- [kubernetes-builders](/api-reference/kubernetes-builders/) — broader resource builder family
+- [stack](/api-reference/stack/) — domain model that produces Kubernetes resources

--- a/pkg/kubernetes/volsync/create.go
+++ b/pkg/kubernetes/volsync/create.go
@@ -1,0 +1,113 @@
+package volsync
+
+import (
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+
+	intvol "github.com/go-kure/kure/internal/volsync"
+)
+
+// ReplicationSource constructs a typed ReplicationSource from cfg. The Mover
+// variant is dispatched via type switch; if Mover is nil, no mover spec is
+// set and CRD validation will reject at apply time.
+func ReplicationSource(cfg *ReplicationSourceConfig) *volsyncv1alpha1.ReplicationSource {
+	if cfg == nil {
+		return nil
+	}
+	rs := intvol.CreateReplicationSource(cfg.Name, cfg.Namespace)
+	rs.Spec.SourcePVC = cfg.SourcePVC
+	rs.Spec.Paused = cfg.Paused
+	if cfg.Trigger != nil {
+		rs.Spec.Trigger = &volsyncv1alpha1.ReplicationSourceTriggerSpec{
+			Schedule: cfg.Trigger.Schedule,
+			Manual:   cfg.Trigger.Manual,
+		}
+	}
+	// Each case guards against typed-nil pointers stored in the interface:
+	// `var m *SourceResticConfig; cfg.Mover = m` matches the case but `*m`
+	// would panic. Treat typed-nil as "no mover for this variant" — same
+	// effective behaviour as a nil interface value.
+	switch m := cfg.Mover.(type) {
+	case *SourceResticConfig:
+		if m != nil {
+			spec := volsyncv1alpha1.ReplicationSourceResticSpec(*m)
+			rs.Spec.Restic = &spec
+		}
+	case *SourceRsyncConfig:
+		if m != nil {
+			spec := volsyncv1alpha1.ReplicationSourceRsyncSpec(*m)
+			rs.Spec.Rsync = &spec
+		}
+	case *SourceRsyncTLSConfig:
+		if m != nil {
+			spec := volsyncv1alpha1.ReplicationSourceRsyncTLSSpec(*m)
+			rs.Spec.RsyncTLS = &spec
+		}
+	case *SourceRcloneConfig:
+		if m != nil {
+			spec := volsyncv1alpha1.ReplicationSourceRcloneSpec(*m)
+			rs.Spec.Rclone = &spec
+		}
+	case *SourceSyncthingConfig:
+		if m != nil {
+			spec := volsyncv1alpha1.ReplicationSourceSyncthingSpec(*m)
+			rs.Spec.Syncthing = &spec
+		}
+	case *ExternalConfig:
+		if m != nil {
+			rs.Spec.External = &volsyncv1alpha1.ReplicationSourceExternalSpec{
+				Provider:   m.Provider,
+				Parameters: m.Parameters,
+			}
+		}
+	}
+	return rs
+}
+
+// ReplicationDestination constructs a typed ReplicationDestination from cfg.
+// Mover is dispatched via type switch; if Mover is nil, no mover spec is set
+// and CRD validation will reject at apply time.
+func ReplicationDestination(cfg *ReplicationDestinationConfig) *volsyncv1alpha1.ReplicationDestination {
+	if cfg == nil {
+		return nil
+	}
+	rd := intvol.CreateReplicationDestination(cfg.Name, cfg.Namespace)
+	rd.Spec.Paused = cfg.Paused
+	if cfg.Trigger != nil {
+		rd.Spec.Trigger = &volsyncv1alpha1.ReplicationDestinationTriggerSpec{
+			Schedule: cfg.Trigger.Schedule,
+			Manual:   cfg.Trigger.Manual,
+		}
+	}
+	// Each case guards against typed-nil pointers stored in the interface;
+	// see the matching comment in ReplicationSource.
+	switch m := cfg.Mover.(type) {
+	case *DestinationResticConfig:
+		if m != nil {
+			spec := volsyncv1alpha1.ReplicationDestinationResticSpec(*m)
+			rd.Spec.Restic = &spec
+		}
+	case *DestinationRsyncConfig:
+		if m != nil {
+			spec := volsyncv1alpha1.ReplicationDestinationRsyncSpec(*m)
+			rd.Spec.Rsync = &spec
+		}
+	case *DestinationRsyncTLSConfig:
+		if m != nil {
+			spec := volsyncv1alpha1.ReplicationDestinationRsyncTLSSpec(*m)
+			rd.Spec.RsyncTLS = &spec
+		}
+	case *DestinationRcloneConfig:
+		if m != nil {
+			spec := volsyncv1alpha1.ReplicationDestinationRcloneSpec(*m)
+			rd.Spec.Rclone = &spec
+		}
+	case *ExternalConfig:
+		if m != nil {
+			rd.Spec.External = &volsyncv1alpha1.ReplicationDestinationExternalSpec{
+				Provider:   m.Provider,
+				Parameters: m.Parameters,
+			}
+		}
+	}
+	return rd
+}

--- a/pkg/kubernetes/volsync/create_test.go
+++ b/pkg/kubernetes/volsync/create_test.go
@@ -1,0 +1,288 @@
+package volsync_test
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+
+	"github.com/go-kure/kure/pkg/kubernetes/volsync"
+)
+
+func strPtr(s string) *string { return &s }
+func i32Ptr(i int32) *int32   { return &i }
+
+func TestReplicationSource_Nil(t *testing.T) {
+	if got := volsync.ReplicationSource(nil); got != nil {
+		t.Errorf("expected nil for nil cfg, got %+v", got)
+	}
+}
+
+func TestReplicationSource_Restic(t *testing.T) {
+	rs := volsync.ReplicationSource(&volsync.ReplicationSourceConfig{
+		Name:      "db-backup",
+		Namespace: "data",
+		SourcePVC: "postgres-data",
+		Trigger:   &volsync.TriggerConfig{Schedule: strPtr("@hourly")},
+		Mover: &volsync.SourceResticConfig{
+			Repository: "restic-creds",
+			ReplicationSourceVolumeOptions: volsyncv1alpha1.ReplicationSourceVolumeOptions{
+				CopyMethod: volsync.CopyMethodSnapshot,
+			},
+			Retain: &volsyncv1alpha1.ResticRetainPolicy{
+				Daily:   i32Ptr(7),
+				Weekly:  i32Ptr(4),
+				Monthly: i32Ptr(12),
+			},
+		},
+	})
+
+	if rs == nil {
+		t.Fatal("nil result")
+	}
+	if rs.Spec.Restic == nil {
+		t.Fatal("restic spec not set")
+	}
+	if rs.Spec.Rsync != nil || rs.Spec.RsyncTLS != nil || rs.Spec.Rclone != nil ||
+		rs.Spec.Syncthing != nil || rs.Spec.External != nil {
+		t.Errorf("only Restic should be set, got: rsync=%v rsyncTLS=%v rclone=%v syncthing=%v external=%v",
+			rs.Spec.Rsync, rs.Spec.RsyncTLS, rs.Spec.Rclone, rs.Spec.Syncthing, rs.Spec.External)
+	}
+	if rs.Spec.SourcePVC != "postgres-data" {
+		t.Errorf("SourcePVC = %q, want postgres-data", rs.Spec.SourcePVC)
+	}
+	if rs.Spec.Trigger == nil || rs.Spec.Trigger.Schedule == nil || *rs.Spec.Trigger.Schedule != "@hourly" {
+		t.Errorf("Trigger schedule mismatch: %+v", rs.Spec.Trigger)
+	}
+	if rs.Spec.Restic.Repository != "restic-creds" {
+		t.Errorf("Repository = %q, want restic-creds", rs.Spec.Restic.Repository)
+	}
+	if rs.Spec.Restic.CopyMethod != volsync.CopyMethodSnapshot {
+		t.Errorf("CopyMethod = %v, want Snapshot", rs.Spec.Restic.CopyMethod)
+	}
+	if rs.Spec.Restic.Retain == nil || rs.Spec.Restic.Retain.Daily == nil || *rs.Spec.Restic.Retain.Daily != 7 {
+		t.Errorf("Retain.Daily mismatch: %+v", rs.Spec.Restic.Retain)
+	}
+}
+
+func TestReplicationSource_Rsync(t *testing.T) {
+	rs := volsync.ReplicationSource(&volsync.ReplicationSourceConfig{
+		Name: "rsync-src", Namespace: "ns",
+		Mover: &volsync.SourceRsyncConfig{
+			Address: strPtr("dst.example.com"),
+		},
+	})
+	if rs.Spec.Rsync == nil || rs.Spec.Rsync.Address == nil || *rs.Spec.Rsync.Address != "dst.example.com" {
+		t.Errorf("rsync address not propagated: %+v", rs.Spec.Rsync)
+	}
+}
+
+func TestReplicationSource_RsyncTLS(t *testing.T) {
+	rs := volsync.ReplicationSource(&volsync.ReplicationSourceConfig{
+		Name: "tls-src", Namespace: "ns",
+		Mover: &volsync.SourceRsyncTLSConfig{
+			KeySecret: strPtr("tls-key"),
+		},
+	})
+	if rs.Spec.RsyncTLS == nil || rs.Spec.RsyncTLS.KeySecret == nil || *rs.Spec.RsyncTLS.KeySecret != "tls-key" {
+		t.Errorf("rsyncTLS keySecret not propagated: %+v", rs.Spec.RsyncTLS)
+	}
+}
+
+func TestReplicationSource_Rclone(t *testing.T) {
+	rs := volsync.ReplicationSource(&volsync.ReplicationSourceConfig{
+		Name: "rclone-src", Namespace: "ns",
+		Mover: &volsync.SourceRcloneConfig{
+			RcloneConfig:        strPtr("rclone-config-secret"),
+			RcloneConfigSection: strPtr("backup"),
+			RcloneDestPath:      strPtr("remote:bucket/path"),
+		},
+	})
+	if rs.Spec.Rclone == nil ||
+		rs.Spec.Rclone.RcloneConfig == nil || *rs.Spec.Rclone.RcloneConfig != "rclone-config-secret" {
+		t.Errorf("rclone config not propagated: %+v", rs.Spec.Rclone)
+	}
+}
+
+func TestReplicationSource_Syncthing(t *testing.T) {
+	cap := resource.MustParse("1Gi")
+	rs := volsync.ReplicationSource(&volsync.ReplicationSourceConfig{
+		Name: "sync-src", Namespace: "ns",
+		Mover: &volsync.SourceSyncthingConfig{
+			Peers: []volsyncv1alpha1.SyncthingPeer{
+				{Address: "tcp://peer:22000", ID: "PEER-ID-XX"},
+			},
+			ConfigCapacity: &cap,
+		},
+	})
+	if rs.Spec.Syncthing == nil || len(rs.Spec.Syncthing.Peers) != 1 {
+		t.Errorf("syncthing peers not propagated: %+v", rs.Spec.Syncthing)
+	}
+}
+
+func TestReplicationSource_External(t *testing.T) {
+	rs := volsync.ReplicationSource(&volsync.ReplicationSourceConfig{
+		Name: "ext-src", Namespace: "ns",
+		Mover: &volsync.ExternalConfig{
+			Provider:   "example.com/foo",
+			Parameters: map[string]string{"k": "v"},
+		},
+	})
+	if rs.Spec.External == nil || rs.Spec.External.Provider != "example.com/foo" {
+		t.Errorf("external provider not propagated: %+v", rs.Spec.External)
+	}
+	if rs.Spec.External.Parameters["k"] != "v" {
+		t.Errorf("external params not propagated: %+v", rs.Spec.External)
+	}
+}
+
+func TestReplicationSource_NilMover(t *testing.T) {
+	rs := volsync.ReplicationSource(&volsync.ReplicationSourceConfig{
+		Name: "no-mover", Namespace: "ns",
+	})
+	if rs.Spec.Restic != nil || rs.Spec.Rsync != nil || rs.Spec.RsyncTLS != nil ||
+		rs.Spec.Rclone != nil || rs.Spec.Syncthing != nil || rs.Spec.External != nil {
+		t.Errorf("expected no mover spec set, got: %+v", rs.Spec)
+	}
+}
+
+func TestReplicationDestination_Nil(t *testing.T) {
+	if got := volsync.ReplicationDestination(nil); got != nil {
+		t.Errorf("expected nil for nil cfg, got %+v", got)
+	}
+}
+
+func TestReplicationDestination_Restic(t *testing.T) {
+	cap := resource.MustParse("10Gi")
+	rd := volsync.ReplicationDestination(&volsync.ReplicationDestinationConfig{
+		Name: "db-restore", Namespace: "dr",
+		Trigger: &volsync.TriggerConfig{Manual: "restore-1"},
+		Mover: &volsync.DestinationResticConfig{
+			Repository: "restic-creds",
+			ReplicationDestinationVolumeOptions: volsyncv1alpha1.ReplicationDestinationVolumeOptions{
+				CopyMethod:  volsync.CopyMethodSnapshot,
+				Capacity:    &cap,
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			},
+		},
+	})
+	if rd == nil || rd.Spec.Restic == nil {
+		t.Fatal("destination restic spec not set")
+	}
+	if rd.Spec.Restic.Repository != "restic-creds" {
+		t.Errorf("Repository = %q", rd.Spec.Restic.Repository)
+	}
+	if rd.Spec.Restic.CopyMethod != volsync.CopyMethodSnapshot {
+		t.Errorf("CopyMethod = %v", rd.Spec.Restic.CopyMethod)
+	}
+	if rd.Spec.Trigger == nil || rd.Spec.Trigger.Manual != "restore-1" {
+		t.Errorf("manual trigger not set: %+v", rd.Spec.Trigger)
+	}
+}
+
+func TestReplicationDestination_Rsync(t *testing.T) {
+	rd := volsync.ReplicationDestination(&volsync.ReplicationDestinationConfig{
+		Name: "rsync-dst", Namespace: "ns",
+		Mover: &volsync.DestinationRsyncConfig{
+			SSHKeys: strPtr("ssh-secret"),
+		},
+	})
+	if rd.Spec.Rsync == nil || rd.Spec.Rsync.SSHKeys == nil || *rd.Spec.Rsync.SSHKeys != "ssh-secret" {
+		t.Errorf("dst rsync sshKeys not propagated: %+v", rd.Spec.Rsync)
+	}
+}
+
+func TestReplicationDestination_RsyncTLS(t *testing.T) {
+	rd := volsync.ReplicationDestination(&volsync.ReplicationDestinationConfig{
+		Name: "tls-dst", Namespace: "ns",
+		Mover: &volsync.DestinationRsyncTLSConfig{
+			KeySecret: strPtr("psk"),
+		},
+	})
+	if rd.Spec.RsyncTLS == nil || rd.Spec.RsyncTLS.KeySecret == nil || *rd.Spec.RsyncTLS.KeySecret != "psk" {
+		t.Errorf("dst rsyncTLS keySecret not propagated: %+v", rd.Spec.RsyncTLS)
+	}
+}
+
+func TestReplicationDestination_Rclone(t *testing.T) {
+	rd := volsync.ReplicationDestination(&volsync.ReplicationDestinationConfig{
+		Name: "rclone-dst", Namespace: "ns",
+		Mover: &volsync.DestinationRcloneConfig{
+			RcloneConfig: strPtr("rclone-config-secret"),
+		},
+	})
+	if rd.Spec.Rclone == nil || rd.Spec.Rclone.RcloneConfig == nil || *rd.Spec.Rclone.RcloneConfig != "rclone-config-secret" {
+		t.Errorf("dst rclone config not propagated: %+v", rd.Spec.Rclone)
+	}
+}
+
+func TestReplicationDestination_External(t *testing.T) {
+	rd := volsync.ReplicationDestination(&volsync.ReplicationDestinationConfig{
+		Name: "ext-dst", Namespace: "ns",
+		Mover: &volsync.ExternalConfig{Provider: "example.com/foo"},
+	})
+	if rd.Spec.External == nil || rd.Spec.External.Provider != "example.com/foo" {
+		t.Errorf("dst external not propagated: %+v", rd.Spec.External)
+	}
+}
+
+func TestReplicationDestination_NilMover(t *testing.T) {
+	rd := volsync.ReplicationDestination(&volsync.ReplicationDestinationConfig{
+		Name: "no-mover", Namespace: "ns",
+	})
+	if rd.Spec.Restic != nil || rd.Spec.Rsync != nil || rd.Spec.RsyncTLS != nil ||
+		rd.Spec.Rclone != nil || rd.Spec.External != nil {
+		t.Errorf("expected no mover spec set, got: %+v", rd.Spec)
+	}
+}
+
+func TestReplicationSource_TypedNilMoverDoesNotPanic(t *testing.T) {
+	// A typed-nil pointer stored in the interface must not panic the dispatcher.
+	var resticNil *volsync.SourceResticConfig
+	rs := volsync.ReplicationSource(&volsync.ReplicationSourceConfig{
+		Name: "n", Namespace: "ns", Mover: resticNil,
+	})
+	if rs == nil {
+		t.Fatal("nil result")
+	}
+	if rs.Spec.Restic != nil {
+		t.Errorf("typed-nil Restic should leave spec.Restic unset")
+	}
+
+	var externalNil *volsync.ExternalConfig
+	rs = volsync.ReplicationSource(&volsync.ReplicationSourceConfig{
+		Name: "n", Namespace: "ns", Mover: externalNil,
+	})
+	if rs == nil || rs.Spec.External != nil {
+		t.Errorf("typed-nil External should leave spec.External unset, got: %+v", rs)
+	}
+}
+
+func TestReplicationDestination_TypedNilMoverDoesNotPanic(t *testing.T) {
+	var rsyncNil *volsync.DestinationRsyncConfig
+	rd := volsync.ReplicationDestination(&volsync.ReplicationDestinationConfig{
+		Name: "n", Namespace: "ns", Mover: rsyncNil,
+	})
+	if rd == nil {
+		t.Fatal("nil result")
+	}
+	if rd.Spec.Rsync != nil {
+		t.Errorf("typed-nil Rsync should leave spec.Rsync unset")
+	}
+}
+
+// Compile-time check: each per-mover Config must satisfy its mover interface.
+// If any line fails to compile, the sealed-interface invariant is broken.
+var _ volsync.SourceMover = (*volsync.SourceResticConfig)(nil)
+var _ volsync.SourceMover = (*volsync.SourceRsyncConfig)(nil)
+var _ volsync.SourceMover = (*volsync.SourceRsyncTLSConfig)(nil)
+var _ volsync.SourceMover = (*volsync.SourceRcloneConfig)(nil)
+var _ volsync.SourceMover = (*volsync.SourceSyncthingConfig)(nil)
+var _ volsync.SourceMover = (*volsync.ExternalConfig)(nil)
+var _ volsync.DestinationMover = (*volsync.DestinationResticConfig)(nil)
+var _ volsync.DestinationMover = (*volsync.DestinationRsyncConfig)(nil)
+var _ volsync.DestinationMover = (*volsync.DestinationRsyncTLSConfig)(nil)
+var _ volsync.DestinationMover = (*volsync.DestinationRcloneConfig)(nil)
+var _ volsync.DestinationMover = (*volsync.ExternalConfig)(nil)

--- a/pkg/kubernetes/volsync/doc.go
+++ b/pkg/kubernetes/volsync/doc.go
@@ -1,0 +1,23 @@
+// Package volsync provides builders for VolSync (volsync.backube/v1alpha1)
+// resources: ReplicationSource and ReplicationDestination.
+//
+// The package follows the kure builder convention (see
+// pkg/kubernetes/certmanager) for file split and modifier shape, but encodes
+// the mover one-of as a sealed-interface sum type rather than a multi-pointer
+// Config. See docs/ARCHITECTURE.md § "One-of Constraints (Sealed Interfaces)"
+// for the rationale.
+//
+// Example:
+//
+//	rs := volsync.ReplicationSource(&volsync.ReplicationSourceConfig{
+//	    Name: "db-backup", Namespace: "data",
+//	    SourcePVC: "postgres-data",
+//	    Trigger: &volsync.TriggerConfig{Schedule: ptr.String("@hourly")},
+//	    Mover: &volsync.SourceResticConfig{
+//	        Repository: "restic-creds",
+//	        ReplicationSourceVolumeOptions: volsyncv1alpha1.ReplicationSourceVolumeOptions{
+//	            CopyMethod: volsync.CopyMethodSnapshot,
+//	        },
+//	    },
+//	})
+package volsync

--- a/pkg/kubernetes/volsync/types.go
+++ b/pkg/kubernetes/volsync/types.go
@@ -1,0 +1,113 @@
+package volsync
+
+import (
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+)
+
+// SourceMover is implemented by exactly the per-mover Config types valid for a
+// ReplicationSource. The marker method is unexported to seal the interface;
+// external packages cannot satisfy it.
+type SourceMover interface {
+	isSourceMover()
+}
+
+// DestinationMover is the analogous sealed interface for ReplicationDestination.
+// Note: Syncthing is source-only upstream (bidirectional sync uses a single
+// ReplicationSource), so SourceSyncthingConfig has no destination counterpart.
+type DestinationMover interface {
+	isDestinationMover()
+}
+
+// ReplicationSourceConfig is the public input for ReplicationSource construction.
+// Mover holds exactly one variant; the constructor dispatches on the concrete type.
+type ReplicationSourceConfig struct {
+	Name      string
+	Namespace string
+	SourcePVC string
+	Paused    bool
+	Trigger   *TriggerConfig
+	Mover     SourceMover
+}
+
+// ReplicationDestinationConfig is the public input for ReplicationDestination
+// construction. Mover holds exactly one variant; the constructor dispatches on
+// the concrete type.
+type ReplicationDestinationConfig struct {
+	Name      string
+	Namespace string
+	Paused    bool
+	Trigger   *TriggerConfig
+	Mover     DestinationMover
+}
+
+// TriggerConfig is the schedule/manual trigger for both source and destination.
+// Schedule is a cron expression (or @hourly/@daily/etc.); Manual is an opaque
+// token bumped by the caller to request a one-shot sync.
+type TriggerConfig struct {
+	Schedule *string
+	Manual   string
+}
+
+// ExternalConfig is the passthrough mover for custom replication providers.
+// Implements both SourceMover and DestinationMover.
+type ExternalConfig struct {
+	Provider   string
+	Parameters map[string]string
+}
+
+func (*ExternalConfig) isSourceMover()      {}
+func (*ExternalConfig) isDestinationMover() {}
+
+// Per-mover Configs are defined types over upstream Specs. Field shape is
+// identical to upstream so callers can populate them directly. Internal cast
+// at construction time keeps the public surface free of upstream pointer wiring.
+//
+// Source-side movers:
+
+type SourceResticConfig volsyncv1alpha1.ReplicationSourceResticSpec
+
+func (*SourceResticConfig) isSourceMover() {}
+
+type SourceRsyncConfig volsyncv1alpha1.ReplicationSourceRsyncSpec
+
+func (*SourceRsyncConfig) isSourceMover() {}
+
+type SourceRsyncTLSConfig volsyncv1alpha1.ReplicationSourceRsyncTLSSpec
+
+func (*SourceRsyncTLSConfig) isSourceMover() {}
+
+type SourceRcloneConfig volsyncv1alpha1.ReplicationSourceRcloneSpec
+
+func (*SourceRcloneConfig) isSourceMover() {}
+
+type SourceSyncthingConfig volsyncv1alpha1.ReplicationSourceSyncthingSpec
+
+func (*SourceSyncthingConfig) isSourceMover() {}
+
+// Destination-side movers:
+
+type DestinationResticConfig volsyncv1alpha1.ReplicationDestinationResticSpec
+
+func (*DestinationResticConfig) isDestinationMover() {}
+
+type DestinationRsyncConfig volsyncv1alpha1.ReplicationDestinationRsyncSpec
+
+func (*DestinationRsyncConfig) isDestinationMover() {}
+
+type DestinationRsyncTLSConfig volsyncv1alpha1.ReplicationDestinationRsyncTLSSpec
+
+func (*DestinationRsyncTLSConfig) isDestinationMover() {}
+
+type DestinationRcloneConfig volsyncv1alpha1.ReplicationDestinationRcloneSpec
+
+func (*DestinationRcloneConfig) isDestinationMover() {}
+
+// CopyMethod re-exports the upstream CopyMethodType for caller convenience.
+type CopyMethod = volsyncv1alpha1.CopyMethodType
+
+const (
+	CopyMethodDirect   = volsyncv1alpha1.CopyMethodDirect
+	CopyMethodNone     = volsyncv1alpha1.CopyMethodNone
+	CopyMethodClone    = volsyncv1alpha1.CopyMethodClone
+	CopyMethodSnapshot = volsyncv1alpha1.CopyMethodSnapshot
+)

--- a/pkg/kubernetes/volsync/update.go
+++ b/pkg/kubernetes/volsync/update.go
@@ -1,0 +1,182 @@
+package volsync
+
+import (
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+)
+
+// SetReplicationSourceSchedule sets the cron schedule on a ReplicationSource.
+// Replaces any existing trigger.
+func SetReplicationSourceSchedule(rs *volsyncv1alpha1.ReplicationSource, schedule string) {
+	if rs == nil {
+		return
+	}
+	if rs.Spec.Trigger == nil {
+		rs.Spec.Trigger = &volsyncv1alpha1.ReplicationSourceTriggerSpec{}
+	}
+	s := schedule
+	rs.Spec.Trigger.Schedule = &s
+}
+
+// SetReplicationSourceManualTrigger sets the manual trigger token on a
+// ReplicationSource. Replaces any existing trigger.
+func SetReplicationSourceManualTrigger(rs *volsyncv1alpha1.ReplicationSource, manual string) {
+	if rs == nil {
+		return
+	}
+	if rs.Spec.Trigger == nil {
+		rs.Spec.Trigger = &volsyncv1alpha1.ReplicationSourceTriggerSpec{}
+	}
+	rs.Spec.Trigger.Manual = manual
+}
+
+// SetReplicationSourceSourcePVC sets the source PVC name.
+func SetReplicationSourceSourcePVC(rs *volsyncv1alpha1.ReplicationSource, pvc string) {
+	if rs == nil {
+		return
+	}
+	rs.Spec.SourcePVC = pvc
+}
+
+// SetReplicationSourcePaused sets the paused flag.
+func SetReplicationSourcePaused(rs *volsyncv1alpha1.ReplicationSource, paused bool) {
+	if rs == nil {
+		return
+	}
+	rs.Spec.Paused = paused
+}
+
+// SetReplicationSourceMover replaces the mover spec on a ReplicationSource. Any
+// previously set mover is cleared. The mover must be a sealed SourceMover
+// variant; nil clears all movers.
+func SetReplicationSourceMover(rs *volsyncv1alpha1.ReplicationSource, mover SourceMover) {
+	if rs == nil {
+		return
+	}
+	rs.Spec.Restic = nil
+	rs.Spec.Rsync = nil
+	rs.Spec.RsyncTLS = nil
+	rs.Spec.Rclone = nil
+	rs.Spec.Syncthing = nil
+	rs.Spec.External = nil
+	switch m := mover.(type) {
+	case *SourceResticConfig:
+		if m != nil {
+			spec := volsyncv1alpha1.ReplicationSourceResticSpec(*m)
+			rs.Spec.Restic = &spec
+		}
+	case *SourceRsyncConfig:
+		if m != nil {
+			spec := volsyncv1alpha1.ReplicationSourceRsyncSpec(*m)
+			rs.Spec.Rsync = &spec
+		}
+	case *SourceRsyncTLSConfig:
+		if m != nil {
+			spec := volsyncv1alpha1.ReplicationSourceRsyncTLSSpec(*m)
+			rs.Spec.RsyncTLS = &spec
+		}
+	case *SourceRcloneConfig:
+		if m != nil {
+			spec := volsyncv1alpha1.ReplicationSourceRcloneSpec(*m)
+			rs.Spec.Rclone = &spec
+		}
+	case *SourceSyncthingConfig:
+		if m != nil {
+			spec := volsyncv1alpha1.ReplicationSourceSyncthingSpec(*m)
+			rs.Spec.Syncthing = &spec
+		}
+	case *ExternalConfig:
+		if m != nil {
+			rs.Spec.External = &volsyncv1alpha1.ReplicationSourceExternalSpec{
+				Provider:   m.Provider,
+				Parameters: m.Parameters,
+			}
+		}
+	}
+}
+
+// SetReplicationDestinationSchedule sets the cron schedule on a
+// ReplicationDestination. Replaces any existing trigger.
+func SetReplicationDestinationSchedule(rd *volsyncv1alpha1.ReplicationDestination, schedule string) {
+	if rd == nil {
+		return
+	}
+	if rd.Spec.Trigger == nil {
+		rd.Spec.Trigger = &volsyncv1alpha1.ReplicationDestinationTriggerSpec{}
+	}
+	s := schedule
+	rd.Spec.Trigger.Schedule = &s
+}
+
+// SetReplicationDestinationManualTrigger sets the manual trigger token on a
+// ReplicationDestination. Replaces any existing trigger.
+func SetReplicationDestinationManualTrigger(rd *volsyncv1alpha1.ReplicationDestination, manual string) {
+	if rd == nil {
+		return
+	}
+	if rd.Spec.Trigger == nil {
+		rd.Spec.Trigger = &volsyncv1alpha1.ReplicationDestinationTriggerSpec{}
+	}
+	rd.Spec.Trigger.Manual = manual
+}
+
+// SetReplicationDestinationPaused sets the paused flag.
+func SetReplicationDestinationPaused(rd *volsyncv1alpha1.ReplicationDestination, paused bool) {
+	if rd == nil {
+		return
+	}
+	rd.Spec.Paused = paused
+}
+
+// SetReplicationDestinationMover replaces the mover spec on a
+// ReplicationDestination. Any previously set mover is cleared. nil clears all.
+func SetReplicationDestinationMover(rd *volsyncv1alpha1.ReplicationDestination, mover DestinationMover) {
+	if rd == nil {
+		return
+	}
+	rd.Spec.Restic = nil
+	rd.Spec.Rsync = nil
+	rd.Spec.RsyncTLS = nil
+	rd.Spec.Rclone = nil
+	rd.Spec.External = nil
+	switch m := mover.(type) {
+	case *DestinationResticConfig:
+		if m != nil {
+			spec := volsyncv1alpha1.ReplicationDestinationResticSpec(*m)
+			rd.Spec.Restic = &spec
+		}
+	case *DestinationRsyncConfig:
+		if m != nil {
+			spec := volsyncv1alpha1.ReplicationDestinationRsyncSpec(*m)
+			rd.Spec.Rsync = &spec
+		}
+	case *DestinationRsyncTLSConfig:
+		if m != nil {
+			spec := volsyncv1alpha1.ReplicationDestinationRsyncTLSSpec(*m)
+			rd.Spec.RsyncTLS = &spec
+		}
+	case *DestinationRcloneConfig:
+		if m != nil {
+			spec := volsyncv1alpha1.ReplicationDestinationRcloneSpec(*m)
+			rd.Spec.Rclone = &spec
+		}
+	case *ExternalConfig:
+		if m != nil {
+			rd.Spec.External = &volsyncv1alpha1.ReplicationDestinationExternalSpec{
+				Provider:   m.Provider,
+				Parameters: m.Parameters,
+			}
+		}
+	}
+}
+
+// AddSyncthingPeer appends a peer to a SourceSyncthingConfig.
+func AddSyncthingPeer(cfg *SourceSyncthingConfig, address, id string, introducer bool) {
+	if cfg == nil {
+		return
+	}
+	cfg.Peers = append(cfg.Peers, volsyncv1alpha1.SyncthingPeer{
+		Address:    address,
+		ID:         id,
+		Introducer: introducer,
+	})
+}

--- a/pkg/kubernetes/volsync/update_test.go
+++ b/pkg/kubernetes/volsync/update_test.go
@@ -1,0 +1,131 @@
+package volsync_test
+
+import (
+	"testing"
+
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+
+	"github.com/go-kure/kure/pkg/kubernetes/volsync"
+)
+
+func TestSetReplicationSourceSchedule(t *testing.T) {
+	rs := &volsyncv1alpha1.ReplicationSource{}
+	volsync.SetReplicationSourceSchedule(rs, "@daily")
+	if rs.Spec.Trigger == nil || rs.Spec.Trigger.Schedule == nil || *rs.Spec.Trigger.Schedule != "@daily" {
+		t.Errorf("schedule not set: %+v", rs.Spec.Trigger)
+	}
+}
+
+func TestSetReplicationSourceManualTrigger(t *testing.T) {
+	rs := &volsyncv1alpha1.ReplicationSource{}
+	volsync.SetReplicationSourceManualTrigger(rs, "now")
+	if rs.Spec.Trigger == nil || rs.Spec.Trigger.Manual != "now" {
+		t.Errorf("manual trigger not set: %+v", rs.Spec.Trigger)
+	}
+}
+
+func TestSetReplicationSourceSourcePVC(t *testing.T) {
+	rs := &volsyncv1alpha1.ReplicationSource{}
+	volsync.SetReplicationSourceSourcePVC(rs, "data-pvc")
+	if rs.Spec.SourcePVC != "data-pvc" {
+		t.Errorf("SourcePVC = %q", rs.Spec.SourcePVC)
+	}
+}
+
+func TestSetReplicationSourcePaused(t *testing.T) {
+	rs := &volsyncv1alpha1.ReplicationSource{}
+	volsync.SetReplicationSourcePaused(rs, true)
+	if !rs.Spec.Paused {
+		t.Errorf("Paused not set")
+	}
+}
+
+func TestSetReplicationSourceMover_ReplacesOldMover(t *testing.T) {
+	rs := &volsyncv1alpha1.ReplicationSource{}
+	rs.Spec.Restic = &volsyncv1alpha1.ReplicationSourceResticSpec{Repository: "old"}
+	volsync.SetReplicationSourceMover(rs, &volsync.SourceRcloneConfig{
+		RcloneConfig: strPtr("new"),
+	})
+	if rs.Spec.Restic != nil {
+		t.Errorf("expected Restic to be cleared")
+	}
+	if rs.Spec.Rclone == nil || rs.Spec.Rclone.RcloneConfig == nil || *rs.Spec.Rclone.RcloneConfig != "new" {
+		t.Errorf("rclone not set: %+v", rs.Spec.Rclone)
+	}
+}
+
+func TestSetReplicationSourceMover_NilClearsAll(t *testing.T) {
+	rs := &volsyncv1alpha1.ReplicationSource{}
+	rs.Spec.Restic = &volsyncv1alpha1.ReplicationSourceResticSpec{Repository: "old"}
+	volsync.SetReplicationSourceMover(rs, nil)
+	if rs.Spec.Restic != nil {
+		t.Errorf("expected Restic to be cleared")
+	}
+}
+
+func TestSetReplicationDestinationSchedule(t *testing.T) {
+	rd := &volsyncv1alpha1.ReplicationDestination{}
+	volsync.SetReplicationDestinationSchedule(rd, "@weekly")
+	if rd.Spec.Trigger == nil || rd.Spec.Trigger.Schedule == nil || *rd.Spec.Trigger.Schedule != "@weekly" {
+		t.Errorf("schedule not set: %+v", rd.Spec.Trigger)
+	}
+}
+
+func TestSetReplicationDestinationManualTrigger(t *testing.T) {
+	rd := &volsyncv1alpha1.ReplicationDestination{}
+	volsync.SetReplicationDestinationManualTrigger(rd, "go")
+	if rd.Spec.Trigger == nil || rd.Spec.Trigger.Manual != "go" {
+		t.Errorf("manual trigger not set: %+v", rd.Spec.Trigger)
+	}
+}
+
+func TestSetReplicationDestinationPaused(t *testing.T) {
+	rd := &volsyncv1alpha1.ReplicationDestination{}
+	volsync.SetReplicationDestinationPaused(rd, true)
+	if !rd.Spec.Paused {
+		t.Errorf("Paused not set")
+	}
+}
+
+func TestSetReplicationDestinationMover_ReplacesOldMover(t *testing.T) {
+	rd := &volsyncv1alpha1.ReplicationDestination{}
+	rd.Spec.Restic = &volsyncv1alpha1.ReplicationDestinationResticSpec{Repository: "old"}
+	volsync.SetReplicationDestinationMover(rd, &volsync.DestinationRcloneConfig{
+		RcloneConfig: strPtr("new"),
+	})
+	if rd.Spec.Restic != nil {
+		t.Errorf("expected Restic to be cleared")
+	}
+	if rd.Spec.Rclone == nil || rd.Spec.Rclone.RcloneConfig == nil || *rd.Spec.Rclone.RcloneConfig != "new" {
+		t.Errorf("rclone not set: %+v", rd.Spec.Rclone)
+	}
+}
+
+func TestSetReplicationSourceMover_TypedNilDoesNotPanic(t *testing.T) {
+	rs := &volsyncv1alpha1.ReplicationSource{}
+	var rcloneNil *volsync.SourceRcloneConfig
+	volsync.SetReplicationSourceMover(rs, rcloneNil)
+	if rs.Spec.Rclone != nil {
+		t.Errorf("typed-nil Rclone should leave spec.Rclone unset")
+	}
+}
+
+func TestSetReplicationDestinationMover_TypedNilDoesNotPanic(t *testing.T) {
+	rd := &volsyncv1alpha1.ReplicationDestination{}
+	var resticNil *volsync.DestinationResticConfig
+	volsync.SetReplicationDestinationMover(rd, resticNil)
+	if rd.Spec.Restic != nil {
+		t.Errorf("typed-nil Restic should leave spec.Restic unset")
+	}
+}
+
+func TestAddSyncthingPeer(t *testing.T) {
+	cfg := &volsync.SourceSyncthingConfig{}
+	volsync.AddSyncthingPeer(cfg, "tcp://peer:22000", "PEER-ID", true)
+	if len(cfg.Peers) != 1 {
+		t.Fatalf("expected 1 peer, got %d", len(cfg.Peers))
+	}
+	if cfg.Peers[0].ID != "PEER-ID" || cfg.Peers[0].Address != "tcp://peer:22000" || !cfg.Peers[0].Introducer {
+		t.Errorf("peer not set correctly: %+v", cfg.Peers[0])
+	}
+}

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -75,6 +75,9 @@ title = 'Go Kure'
     source = ".generated/api-reference/prometheus-builders.md"
     target = "content/api-reference/prometheus-builders.md"
   [[module.mounts]]
+    source = ".generated/api-reference/volsync-builders.md"
+    target = "content/api-reference/volsync-builders.md"
+  [[module.mounts]]
     source = ".generated/api-reference/logger.md"
     target = "content/api-reference/logger.md"
   [[module.mounts]]

--- a/site/scripts/check-mounts.sh
+++ b/site/scripts/check-mounts.sh
@@ -28,6 +28,7 @@ MOUNTED_FILES=(
   "pkg/cli/README.md"
   "pkg/kubernetes/fluxcd/README.md"
   "pkg/kubernetes/prometheus/README.md"
+  "pkg/kubernetes/volsync/README.md"
   "pkg/logger/README.md"
   "examples/patches/README.md"
   "examples/generators/README.md"

--- a/site/scripts/inject-frontmatter.sh
+++ b/site/scripts/inject-frontmatter.sh
@@ -64,6 +64,7 @@ inject_fm "$KURE_ROOT/pkg/cli/README.md"                    "api-reference/cli.m
 inject_fm "$KURE_ROOT/pkg/kubernetes/README.md"             "api-reference/kubernetes-builders.md"        "Kubernetes Builders"           95
 inject_fm "$KURE_ROOT/pkg/kubernetes/fluxcd/README.md"      "api-reference/fluxcd-builders.md"            "FluxCD Builders"              100
 inject_fm "$KURE_ROOT/pkg/kubernetes/prometheus/README.md"  "api-reference/prometheus-builders.md"        "Prometheus Builders"          105
+inject_fm "$KURE_ROOT/pkg/kubernetes/volsync/README.md"     "api-reference/volsync-builders.md"           "VolSync Builders"             107
 inject_fm "$KURE_ROOT/pkg/logger/README.md"                 "api-reference/logger.md"                     "Logger"                       110
 inject_fm "$KURE_ROOT/docs/compatibility.md"                "api-reference/compatibility.md"              "Compatibility Matrix"         120
 


### PR DESCRIPTION
## Summary

Adds `pkg/kubernetes/volsync/` covering the full `volsync.backube/v1alpha1` API surface:

- `ReplicationSource` and `ReplicationDestination` constructors.
- All upstream movers: **Restic**, **Rsync**, **RsyncTLS**, **Rclone**, **Syncthing** (source-only), and **External** passthrough.
- Trigger (`Schedule` / `Manual`), pause flag, and per-mover modifier helpers.
- `volsyncv1alpha1` registered in `pkg/kubernetes/scheme.go`.
- New README mounted to docs site under `api-reference/volsync-builders`.

Closes #475. Unblocks crane#181 (volsync OAM trait migration off `unstructured.Unstructured`).

## Design — sealed-interface sum type for the mover one-of

Upstream `ReplicationSource{,Destination}Spec` carry one pointer per mover and require **exactly one** to be set — a CRD-level constraint not enforceable in Go types. Kure encodes this as a **sealed-interface sum type**: `Mover SourceMover` / `Mover DestinationMover` on the parent Config holds exactly one variant.

```go
type SourceMover interface { isSourceMover() }
type SourceResticConfig volsyncv1alpha1.ReplicationSourceResticSpec
func (*SourceResticConfig) isSourceMover() {}
// ... per-mover Configs as defined types over upstream Specs

type ReplicationSourceConfig struct {
    Name, Namespace string
    SourcePVC       string
    Trigger         *TriggerConfig
    Mover           SourceMover  // exactly one variant — compile-time enforced
}
```

- Setting two movers is a compile error (single field).
- The unexported marker method seals the interface — external packages cannot satisfy it.
- Per-mover Configs are defined types over upstream Specs, so callers populate fields with the same names/types as upstream while the public surface still owns the type identity.

This is now the **kure standard** for one-of constraints. Documented in `docs/ARCHITECTURE.md` § "One-of Constraints (Sealed Interfaces)". `pkg/kubernetes/certmanager` predates this convention and uses the older multi-pointer + first-match-precedence pattern; refactoring it to this idiom is tracked as a follow-up before v1.0.

## Files

- `pkg/kubernetes/volsync/`: `doc.go`, `types.go`, `create.go`, `update.go`, `create_test.go`, `update_test.go`, `README.md`
- `internal/volsync/`: `doc.go`, `replicationsource.go`, `replicationdestination.go`, `replicationsource_test.go`
- `pkg/kubernetes/scheme.go` — registers `volsyncv1alpha1.AddToScheme`
- `docs/ARCHITECTURE.md` — new "One-of Constraints (Sealed Interfaces)" subsection
- `site/scripts/check-mounts.sh`, `site/scripts/inject-frontmatter.sh`, `site/hugo.toml` — mount the new README under `api-reference/volsync-builders`
- `go.mod`, `go.sum` — adds `github.com/backube/volsync@v0.15.0`

## Test plan

- [x] `make test` — all packages pass; per-mover happy paths for both directions; nil-cfg / nil-mover / mover-replacement coverage.
- [x] `make lint LINT_FLAGS="--new-from-rev=origin/main"` — 0 new issues.
- [x] `bash site/scripts/check-mounts.sh` — all 23 mounted files verified (new volsync README included).
- [x] Compile-time interface conformance asserted via `var _ SourceMover = (*SourceResticConfig)(nil)` etc. for every mover.
- [ ] CI green.

## What this does NOT solve

- `ReplicationGroupSource` / `ReplicationGroupDestination` — not in upstream v0.15.0.
- Stack/generator wiring — this is a builder package only; consumers (crane, direct kure users) wire it in themselves.
- crane#181 migration — separate PR in the crane repo.