### PR TITLE
chore(certmanager): refactor builders to sealed-interface idiom

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -507,7 +507,7 @@ Kure encodes these as a **sealed-interface sum type** so violations are a compil
 
 This is the kure idiom for one-of: setting two variants is a compile error (single field), and missing variants are caught at construction (nil case in the type switch).
 
-`pkg/kubernetes/volsync` is the reference implementation. `pkg/kubernetes/certmanager` predates this convention and uses the older multi-pointer + first-match-precedence pattern; refactoring it to the sealed-interface idiom is tracked as a follow-up before v1.0.
+`pkg/kubernetes/volsync` and `pkg/kubernetes/certmanager` both follow this idiom. cert-manager carries three layers: `IssuerVariant` (ACME / CA on `IssuerConfig.Variant` and `ClusterIssuerConfig.Variant`), `ACMESolver` (HTTP-01 / DNS-01 on `ACMESolverConfig.Solver`), and `DNS01Provider` (Cloudflare / Route 53 / Google CloudDNS on `DNS01SolverConfig.Provider`).
 
 ---
 

--- a/pkg/kubernetes/certmanager/README.md
+++ b/pkg/kubernetes/certmanager/README.md
@@ -26,16 +26,42 @@ cert := certmanager.Certificate(&certmanager.CertificateConfig{
 
 ### Issuer
 
+`IssuerConfig.Variant` is a [sealed-interface sum type](/concepts/architecture/#one-of-constraints-sealed-interfaces): exactly one of `*ACMEConfig` or `*CAConfig` is permitted, enforced at compile time.
+
 ```go
 issuer := certmanager.Issuer(&certmanager.IssuerConfig{
     Name:      "letsencrypt",
     Namespace: "default",
-    ACME: &certmanager.ACMEConfig{
+    Variant: &certmanager.ACMEConfig{
         Server: "https://acme-v02.api.letsencrypt.org/directory",
         Email:  "admin@example.com",
         Solvers: []certmanager.ACMESolverConfig{
-            {HTTP01: &certmanager.HTTP01SolverConfig{IngressClass: "nginx"}},
+            {Solver: &certmanager.HTTP01SolverConfig{IngressClass: "nginx"}},
         },
+    },
+})
+```
+
+`ACMESolverConfig.Solver` is also a sealed sum (`*HTTP01SolverConfig` or `*DNS01SolverConfig`). DNS-01 providers are likewise sealed:
+
+```go
+issuer = certmanager.Issuer(&certmanager.IssuerConfig{
+    Name:      "letsencrypt-dns",
+    Namespace: "default",
+    Variant: &certmanager.ACMEConfig{
+        Server: "https://acme-v02.api.letsencrypt.org/directory",
+        Email:  "admin@example.com",
+        Solvers: []certmanager.ACMESolverConfig{{
+            Solver: &certmanager.DNS01SolverConfig{
+                Provider: &certmanager.CloudflareProviderConfig{
+                    Email:    "admin@example.com",
+                    APIToken: &cmmeta.SecretKeySelector{
+                        LocalObjectReference: cmmeta.LocalObjectReference{Name: "cf-api-token"},
+                        Key:                  "api-token",
+                    },
+                },
+            },
+        }},
     },
 })
 ```
@@ -44,8 +70,8 @@ issuer := certmanager.Issuer(&certmanager.IssuerConfig{
 
 ```go
 clusterIssuer := certmanager.ClusterIssuer(&certmanager.ClusterIssuerConfig{
-    Name: "letsencrypt-prod",
-    CA:   &certmanager.CAConfig{SecretName: "ca-key-pair"},
+    Name:    "letsencrypt-prod",
+    Variant: &certmanager.CAConfig{SecretName: "ca-key-pair"},
 })
 ```
 

--- a/pkg/kubernetes/certmanager/create.go
+++ b/pkg/kubernetes/certmanager/create.go
@@ -34,12 +34,11 @@ func Issuer(cfg *IssuerConfig) *certv1.Issuer {
 		return nil
 	}
 	obj := intcm.CreateIssuer(cfg.Name, cfg.Namespace, certv1.IssuerSpec{})
-	if cfg.ACME != nil {
-		acme := buildACMEIssuer(cfg.ACME)
-		intcm.SetIssuerACME(obj, acme)
-	} else if cfg.CA != nil {
-		intcm.SetIssuerCA(obj, &certv1.CAIssuer{SecretName: cfg.CA.SecretName})
-	}
+	applyIssuerVariant(cfg.Variant, func(v *cmacme.ACMEIssuer) {
+		intcm.SetIssuerACME(obj, v)
+	}, func(v *certv1.CAIssuer) {
+		intcm.SetIssuerCA(obj, v)
+	})
 	return obj
 }
 
@@ -49,13 +48,30 @@ func ClusterIssuer(cfg *ClusterIssuerConfig) *certv1.ClusterIssuer {
 		return nil
 	}
 	obj := intcm.CreateClusterIssuer(cfg.Name, certv1.IssuerSpec{})
-	if cfg.ACME != nil {
-		acme := buildACMEIssuer(cfg.ACME)
-		intcm.SetClusterIssuerACME(obj, acme)
-	} else if cfg.CA != nil {
-		intcm.SetClusterIssuerCA(obj, &certv1.CAIssuer{SecretName: cfg.CA.SecretName})
-	}
+	applyIssuerVariant(cfg.Variant, func(v *cmacme.ACMEIssuer) {
+		intcm.SetClusterIssuerACME(obj, v)
+	}, func(v *certv1.CAIssuer) {
+		intcm.SetClusterIssuerCA(obj, v)
+	})
 	return obj
+}
+
+// applyIssuerVariant dispatches on the IssuerVariant sum and invokes the
+// matching setter. Each case guards against typed-nil pointers stored in the
+// interface (a `var v *ACMEConfig` would match the case but `*v` would panic);
+// typed-nil is treated as "no variant set" — same effective behaviour as a
+// nil interface.
+func applyIssuerVariant(v IssuerVariant, setACME func(*cmacme.ACMEIssuer), setCA func(*certv1.CAIssuer)) {
+	switch x := v.(type) {
+	case *ACMEConfig:
+		if x != nil {
+			setACME(buildACMEIssuer(x))
+		}
+	case *CAConfig:
+		if x != nil {
+			setCA(&certv1.CAIssuer{SecretName: x.SecretName})
+		}
+	}
 }
 
 // buildACMEIssuer converts an ACMEConfig to an ACMEIssuer, including solvers.
@@ -71,29 +87,42 @@ func buildACMEIssuer(cfg *ACMEConfig) *cmacme.ACMEIssuer {
 }
 
 // buildACMESolver converts an ACMESolverConfig to an ACMEChallengeSolver.
+// The Solver field is a sealed sum (HTTP01SolverConfig or DNS01SolverConfig);
+// each case guards against typed-nil.
 func buildACMESolver(cfg *ACMESolverConfig) cmacme.ACMEChallengeSolver {
-	if cfg.HTTP01 != nil {
-		return intcm.CreateACMEHTTP01Solver(cfg.HTTP01.ServiceType, cfg.HTTP01.IngressClass)
+	if cfg == nil {
+		return cmacme.ACMEChallengeSolver{}
 	}
-	if cfg.DNS01 != nil {
-		return buildDNS01Solver(cfg.DNS01)
+	switch s := cfg.Solver.(type) {
+	case *HTTP01SolverConfig:
+		if s != nil {
+			return intcm.CreateACMEHTTP01Solver(s.ServiceType, s.IngressClass)
+		}
+	case *DNS01SolverConfig:
+		if s != nil {
+			return buildDNS01Solver(s)
+		}
 	}
 	return cmacme.ACMEChallengeSolver{}
 }
 
 // buildDNS01Solver converts a DNS01SolverConfig to an ACMEChallengeSolver.
+// Provider is a sealed sum (Cloudflare/Route53/Google); each case guards
+// against typed-nil.
 func buildDNS01Solver(cfg *DNS01SolverConfig) cmacme.ACMEChallengeSolver {
-	switch cfg.Provider {
-	case "cloudflare":
-		if cfg.APIToken != nil {
-			return intcm.CreateACMEDNS01SolverCloudflare(cfg.Email, *cfg.APIToken)
+	switch p := cfg.Provider.(type) {
+	case *CloudflareProviderConfig:
+		if p != nil && p.APIToken != nil {
+			return intcm.CreateACMEDNS01SolverCloudflare(p.Email, *p.APIToken)
 		}
-	case "route53":
-		if cfg.SecretAccessKey != nil {
-			return intcm.CreateACMEDNS01SolverRoute53(cfg.Region, *cfg.SecretAccessKey)
+	case *Route53ProviderConfig:
+		if p != nil && p.SecretAccessKey != nil {
+			return intcm.CreateACMEDNS01SolverRoute53(p.Region, *p.SecretAccessKey)
 		}
-	case "clouddns":
-		return intcm.CreateACMEDNS01SolverGoogle(cfg.Project, cfg.ServiceAccount)
+	case *GoogleProviderConfig:
+		if p != nil {
+			return intcm.CreateACMEDNS01SolverGoogle(p.Project, p.ServiceAccount)
+		}
 	}
 	return cmacme.ACMEChallengeSolver{}
 }

--- a/pkg/kubernetes/certmanager/create_test.go
+++ b/pkg/kubernetes/certmanager/create_test.go
@@ -54,11 +54,11 @@ func TestIssuer_ACME(t *testing.T) {
 	cfg := &IssuerConfig{
 		Name:      "letsencrypt",
 		Namespace: "cert-manager",
-		ACME: &ACMEConfig{
+		Variant: &ACMEConfig{
 			Server: "https://acme-v02.api.letsencrypt.org/directory",
 			Email:  "admin@example.com",
 			Solvers: []ACMESolverConfig{
-				{HTTP01: &HTTP01SolverConfig{IngressClass: "nginx"}},
+				{Solver: &HTTP01SolverConfig{IngressClass: "nginx"}},
 			},
 		},
 	}
@@ -89,7 +89,7 @@ func TestIssuer_CA(t *testing.T) {
 	cfg := &IssuerConfig{
 		Name:      "ca-issuer",
 		Namespace: "default",
-		CA:        &CAConfig{SecretName: "ca-key-pair"},
+		Variant:   &CAConfig{SecretName: "ca-key-pair"},
 	}
 
 	issuer := Issuer(cfg)
@@ -112,10 +112,40 @@ func TestIssuer_NilConfig(t *testing.T) {
 	}
 }
 
+func TestIssuer_NilVariantLeavesSpecEmpty(t *testing.T) {
+	cfg := &IssuerConfig{Name: "no-variant", Namespace: "default"}
+	issuer := Issuer(cfg)
+	if issuer == nil {
+		t.Fatal("expected non-nil Issuer")
+	}
+	if issuer.Spec.IssuerConfig.ACME != nil || issuer.Spec.IssuerConfig.CA != nil {
+		t.Errorf("expected empty IssuerConfig, got: %+v", issuer.Spec.IssuerConfig)
+	}
+}
+
+func TestIssuer_TypedNilVariantDoesNotPanic(t *testing.T) {
+	var nilACME *ACMEConfig
+	cfg := &IssuerConfig{Name: "n", Namespace: "ns", Variant: nilACME}
+	issuer := Issuer(cfg)
+	if issuer == nil {
+		t.Fatal("nil result")
+	}
+	if issuer.Spec.IssuerConfig.ACME != nil {
+		t.Errorf("typed-nil ACME should leave spec empty, got: %+v", issuer.Spec.IssuerConfig)
+	}
+
+	var nilCA *CAConfig
+	cfg = &IssuerConfig{Name: "n", Namespace: "ns", Variant: nilCA}
+	issuer = Issuer(cfg)
+	if issuer.Spec.IssuerConfig.CA != nil {
+		t.Errorf("typed-nil CA should leave spec empty, got: %+v", issuer.Spec.IssuerConfig)
+	}
+}
+
 func TestClusterIssuer_CA(t *testing.T) {
 	cfg := &ClusterIssuerConfig{
-		Name: "ca-cluster-issuer",
-		CA:   &CAConfig{SecretName: "ca-key-pair"},
+		Name:    "ca-cluster-issuer",
+		Variant: &CAConfig{SecretName: "ca-key-pair"},
 	}
 
 	ci := ClusterIssuer(cfg)
@@ -137,7 +167,7 @@ func TestClusterIssuer_CA(t *testing.T) {
 func TestClusterIssuer_ACME(t *testing.T) {
 	cfg := &ClusterIssuerConfig{
 		Name: "letsencrypt-prod",
-		ACME: &ACMEConfig{
+		Variant: &ACMEConfig{
 			Server: "https://acme-v02.api.letsencrypt.org/directory",
 			Email:  "admin@example.com",
 		},
@@ -163,12 +193,24 @@ func TestClusterIssuer_NilConfig(t *testing.T) {
 	}
 }
 
+func TestClusterIssuer_TypedNilVariantDoesNotPanic(t *testing.T) {
+	var nilACME *ACMEConfig
+	cfg := &ClusterIssuerConfig{Name: "n", Variant: nilACME}
+	ci := ClusterIssuer(cfg)
+	if ci == nil {
+		t.Fatal("nil result")
+	}
+	if ci.Spec.IssuerConfig.ACME != nil {
+		t.Errorf("typed-nil ACME should leave spec empty, got: %+v", ci.Spec.IssuerConfig)
+	}
+}
+
 func TestBuildACMEIssuer_SkipsEmptySolver(t *testing.T) {
 	cfg := &ACMEConfig{
 		Server: "https://acme-v02.api.letsencrypt.org/directory",
 		Email:  "admin@example.com",
 		Solvers: []ACMESolverConfig{
-			{}, // no HTTP01 or DNS01 — should be skipped
+			{}, // no Solver — should be skipped
 		},
 	}
 
@@ -179,62 +221,16 @@ func TestBuildACMEIssuer_SkipsEmptySolver(t *testing.T) {
 	}
 }
 
-func TestIssuer_ACMEPrecedenceOverCA(t *testing.T) {
-	cfg := &IssuerConfig{
-		Name:      "both",
-		Namespace: "default",
-		ACME: &ACMEConfig{
-			Server: "https://acme-v02.api.letsencrypt.org/directory",
-			Email:  "admin@example.com",
-		},
-		CA: &CAConfig{SecretName: "ca-key-pair"},
-	}
-
-	issuer := Issuer(cfg)
-
-	if issuer == nil {
-		t.Fatal("expected non-nil Issuer")
-	}
-	if issuer.Spec.IssuerConfig.ACME == nil {
-		t.Fatal("expected ACME to be set when both ACME and CA are configured")
-	}
-	if issuer.Spec.IssuerConfig.CA != nil {
-		t.Error("expected CA to be nil when ACME is configured (ACME takes precedence)")
-	}
-}
-
-func TestClusterIssuer_ACMEPrecedenceOverCA(t *testing.T) {
-	cfg := &ClusterIssuerConfig{
-		Name: "both",
-		ACME: &ACMEConfig{
-			Server: "https://acme-v02.api.letsencrypt.org/directory",
-			Email:  "admin@example.com",
-		},
-		CA: &CAConfig{SecretName: "ca-key-pair"},
-	}
-
-	ci := ClusterIssuer(cfg)
-
-	if ci == nil {
-		t.Fatal("expected non-nil ClusterIssuer")
-	}
-	if ci.Spec.IssuerConfig.ACME == nil {
-		t.Fatal("expected ACME to be set when both ACME and CA are configured")
-	}
-	if ci.Spec.IssuerConfig.CA != nil {
-		t.Error("expected CA to be nil when ACME is configured (ACME takes precedence)")
-	}
-}
-
 func TestBuildDNS01Solver_Cloudflare(t *testing.T) {
 	token := cmmeta.SecretKeySelector{
 		LocalObjectReference: cmmeta.LocalObjectReference{Name: "cloudflare-token"},
 		Key:                  "api-token",
 	}
 	cfg := &DNS01SolverConfig{
-		Provider: "cloudflare",
-		Email:    "admin@example.com",
-		APIToken: &token,
+		Provider: &CloudflareProviderConfig{
+			Email:    "admin@example.com",
+			APIToken: &token,
+		},
 	}
 
 	solver := buildDNS01Solver(cfg)
@@ -256,9 +252,10 @@ func TestBuildDNS01Solver_Route53(t *testing.T) {
 		Key:                  "secret-access-key",
 	}
 	cfg := &DNS01SolverConfig{
-		Provider:        "route53",
-		Region:          "us-east-1",
-		SecretAccessKey: &key,
+		Provider: &Route53ProviderConfig{
+			Region:          "us-east-1",
+			SecretAccessKey: &key,
+		},
 	}
 
 	solver := buildDNS01Solver(cfg)
@@ -276,8 +273,7 @@ func TestBuildDNS01Solver_Route53(t *testing.T) {
 
 func TestBuildDNS01Solver_CloudDNS(t *testing.T) {
 	cfg := &DNS01SolverConfig{
-		Provider: "clouddns",
-		Project:  "my-project",
+		Provider: &GoogleProviderConfig{Project: "my-project"},
 	}
 
 	solver := buildDNS01Solver(cfg)
@@ -293,14 +289,60 @@ func TestBuildDNS01Solver_CloudDNS(t *testing.T) {
 	}
 }
 
-func TestBuildDNS01Solver_UnknownProvider(t *testing.T) {
-	cfg := &DNS01SolverConfig{
-		Provider: "unknown",
-	}
-
+func TestBuildDNS01Solver_NilProvider(t *testing.T) {
+	cfg := &DNS01SolverConfig{}
 	solver := buildDNS01Solver(cfg)
-
 	if solver.DNS01 != nil || solver.HTTP01 != nil {
-		t.Error("expected empty solver for unknown provider")
+		t.Error("expected empty solver when no provider is set")
 	}
 }
+
+func TestBuildDNS01Solver_TypedNilProviderDoesNotPanic(t *testing.T) {
+	var nilCloudflare *CloudflareProviderConfig
+	cfg := &DNS01SolverConfig{Provider: nilCloudflare}
+	solver := buildDNS01Solver(cfg)
+	if solver.DNS01 != nil {
+		t.Error("typed-nil Cloudflare should leave solver empty")
+	}
+
+	var nilRoute53 *Route53ProviderConfig
+	cfg = &DNS01SolverConfig{Provider: nilRoute53}
+	solver = buildDNS01Solver(cfg)
+	if solver.DNS01 != nil {
+		t.Error("typed-nil Route53 should leave solver empty")
+	}
+
+	var nilGoogle *GoogleProviderConfig
+	cfg = &DNS01SolverConfig{Provider: nilGoogle}
+	solver = buildDNS01Solver(cfg)
+	if solver.DNS01 != nil {
+		t.Error("typed-nil Google should leave solver empty")
+	}
+}
+
+func TestBuildACMESolver_TypedNilSolverDoesNotPanic(t *testing.T) {
+	var nilHTTP *HTTP01SolverConfig
+	cfg := &ACMESolverConfig{Solver: nilHTTP}
+	s := buildACMESolver(cfg)
+	if s.HTTP01 != nil || s.DNS01 != nil {
+		t.Error("typed-nil HTTP01 should leave solver empty")
+	}
+
+	var nilDNS *DNS01SolverConfig
+	cfg = &ACMESolverConfig{Solver: nilDNS}
+	s = buildACMESolver(cfg)
+	if s.HTTP01 != nil || s.DNS01 != nil {
+		t.Error("typed-nil DNS01 should leave solver empty")
+	}
+}
+
+// Compile-time interface conformance checks.
+var (
+	_ IssuerVariant = (*ACMEConfig)(nil)
+	_ IssuerVariant = (*CAConfig)(nil)
+	_ ACMESolver    = (*HTTP01SolverConfig)(nil)
+	_ ACMESolver    = (*DNS01SolverConfig)(nil)
+	_ DNS01Provider = (*CloudflareProviderConfig)(nil)
+	_ DNS01Provider = (*Route53ProviderConfig)(nil)
+	_ DNS01Provider = (*GoogleProviderConfig)(nil)
+)

--- a/pkg/kubernetes/certmanager/doc.go
+++ b/pkg/kubernetes/certmanager/doc.go
@@ -14,6 +14,13 @@
 // Resources covered include `Certificate`, `Issuer`, and `ClusterIssuer`, with
 // ACME and CA issuer configurations.
 //
+// ## One-of constraints
+//
+// `IssuerConfig.Variant`, `ClusterIssuerConfig.Variant`, `ACMESolverConfig.Solver`,
+// and `DNS01SolverConfig.Provider` are sealed-interface sum types — exactly one
+// implementation may be set, enforced at compile time. See
+// `docs/ARCHITECTURE.md` § "One-of Constraints (Sealed Interfaces)".
+//
 // ## Constructors
 //
 // Constructors accept a configuration struct and return the corresponding

--- a/pkg/kubernetes/certmanager/types.go
+++ b/pkg/kubernetes/certmanager/types.go
@@ -9,62 +9,110 @@ import (
 
 // CertificateConfig describes a cert-manager Certificate resource.
 type CertificateConfig struct {
-	Name        string                 `yaml:"name"`
-	Namespace   string                 `yaml:"namespace"`
-	SecretName  string                 `yaml:"secretName"`
-	IssuerRef   cmmeta.IssuerReference `yaml:"issuerRef"`
-	DNSNames    []string               `yaml:"dnsNames,omitempty"`
-	Duration    *metav1.Duration       `yaml:"duration,omitempty"`
-	RenewBefore *metav1.Duration       `yaml:"renewBefore,omitempty"`
+	Name        string
+	Namespace   string
+	SecretName  string
+	IssuerRef   cmmeta.IssuerReference
+	DNSNames    []string
+	Duration    *metav1.Duration
+	RenewBefore *metav1.Duration
 }
 
-// IssuerConfig describes a cert-manager Issuer resource.
+// IssuerVariant is a sealed interface implemented by exactly the per-variant
+// config types valid for an Issuer or ClusterIssuer (ACMEConfig, CAConfig).
+// The marker method is unexported so external packages cannot satisfy it.
+type IssuerVariant interface {
+	isIssuerVariant()
+}
+
+// IssuerConfig describes a cert-manager Issuer resource. Variant must hold
+// exactly one of the implementing types; setting two variants is a compile
+// error (single field).
 type IssuerConfig struct {
-	Name      string      `yaml:"name"`
-	Namespace string      `yaml:"namespace"`
-	ACME      *ACMEConfig `yaml:"acme,omitempty"`
-	CA        *CAConfig   `yaml:"ca,omitempty"`
+	Name      string
+	Namespace string
+	Variant   IssuerVariant
 }
 
-// ClusterIssuerConfig describes a cert-manager ClusterIssuer resource.
+// ClusterIssuerConfig describes a cert-manager ClusterIssuer resource. Variant
+// must hold exactly one of the implementing types.
 type ClusterIssuerConfig struct {
-	Name string      `yaml:"name"`
-	ACME *ACMEConfig `yaml:"acme,omitempty"`
-	CA   *CAConfig   `yaml:"ca,omitempty"`
+	Name    string
+	Variant IssuerVariant
 }
 
 // ACMEConfig describes the ACME issuer settings.
 type ACMEConfig struct {
-	Server     string                   `yaml:"server"`
-	Email      string                   `yaml:"email"`
-	PrivateKey cmmeta.SecretKeySelector `yaml:"privateKey"`
-	Solvers    []ACMESolverConfig       `yaml:"solvers,omitempty"`
+	Server     string
+	Email      string
+	PrivateKey cmmeta.SecretKeySelector
+	Solvers    []ACMESolverConfig
 }
 
-// ACMESolverConfig describes a single ACME challenge solver.
+func (*ACMEConfig) isIssuerVariant() {}
+
+// CAConfig describes a CA issuer configuration.
+type CAConfig struct {
+	SecretName string
+}
+
+func (*CAConfig) isIssuerVariant() {}
+
+// ACMESolver is a sealed interface implemented by exactly the per-challenge
+// solver config types valid for an ACME challenge (HTTP01SolverConfig,
+// DNS01SolverConfig).
+type ACMESolver interface {
+	isACMESolver()
+}
+
+// ACMESolverConfig describes a single ACME challenge solver. Solver must hold
+// exactly one of the implementing types.
 type ACMESolverConfig struct {
-	HTTP01 *HTTP01SolverConfig `yaml:"http01,omitempty"`
-	DNS01  *DNS01SolverConfig  `yaml:"dns01,omitempty"`
+	Solver ACMESolver
 }
 
 // HTTP01SolverConfig describes an HTTP-01 challenge solver.
 type HTTP01SolverConfig struct {
-	ServiceType  corev1.ServiceType `yaml:"serviceType,omitempty"`
-	IngressClass string             `yaml:"ingressClass,omitempty"`
+	ServiceType  corev1.ServiceType
+	IngressClass string
 }
 
-// DNS01SolverConfig describes a DNS-01 challenge solver.
+func (*HTTP01SolverConfig) isACMESolver() {}
+
+// DNS01SolverConfig describes a DNS-01 challenge solver. Provider must hold
+// exactly one provider implementation.
 type DNS01SolverConfig struct {
-	Provider        string                    `yaml:"provider"`
-	Email           string                    `yaml:"email,omitempty"`
-	Region          string                    `yaml:"region,omitempty"`
-	Project         string                    `yaml:"project,omitempty"`
-	ServiceAccount  *cmmeta.SecretKeySelector `yaml:"serviceAccount,omitempty"`
-	APIToken        *cmmeta.SecretKeySelector `yaml:"apiToken,omitempty"`
-	SecretAccessKey *cmmeta.SecretKeySelector `yaml:"secretAccessKey,omitempty"`
+	Provider DNS01Provider
 }
 
-// CAConfig describes a CA issuer configuration.
-type CAConfig struct {
-	SecretName string `yaml:"secretName"`
+func (*DNS01SolverConfig) isACMESolver() {}
+
+// DNS01Provider is a sealed interface implemented by per-provider DNS-01
+// solver configs (Cloudflare, Route53, Google CloudDNS).
+type DNS01Provider interface {
+	isDNS01Provider()
 }
+
+// CloudflareProviderConfig configures a Cloudflare DNS-01 solver.
+type CloudflareProviderConfig struct {
+	Email    string
+	APIToken *cmmeta.SecretKeySelector
+}
+
+func (*CloudflareProviderConfig) isDNS01Provider() {}
+
+// Route53ProviderConfig configures an AWS Route 53 DNS-01 solver.
+type Route53ProviderConfig struct {
+	Region          string
+	SecretAccessKey *cmmeta.SecretKeySelector
+}
+
+func (*Route53ProviderConfig) isDNS01Provider() {}
+
+// GoogleProviderConfig configures a Google Cloud DNS DNS-01 solver.
+type GoogleProviderConfig struct {
+	Project        string
+	ServiceAccount *cmmeta.SecretKeySelector
+}
+
+func (*GoogleProviderConfig) isDNS01Provider() {}


### PR DESCRIPTION
## Summary

Adopts the sealed-interface sum-type idiom (established by #481, documented in [`docs/ARCHITECTURE.md` § One-of Constraints](https://github.com/go-kure/kure/blob/main/docs/ARCHITECTURE.md#one-of-constraints-sealed-interfaces)) across `pkg/kubernetes/certmanager`. Three layers of one-of are refactored:

| Layer | Sealed interface | Implementations |
|---|---|---|
| Issuer / ClusterIssuer | `IssuerVariant` | `*ACMEConfig`, `*CAConfig` |
| ACME challenge solver | `ACMESolver` | `*HTTP01SolverConfig`, `*DNS01SolverConfig` |
| DNS-01 provider | `DNS01Provider` | `*CloudflareProviderConfig`, `*Route53ProviderConfig`, `*GoogleProviderConfig` |

Setting two variants on a config is now a compile error (single field). All four dispatchers (`Issuer` / `ClusterIssuer` constructors, `buildACMESolver`, `buildDNS01Solver`) use the typed-nil guard pattern from volsync — a `var v *ACMEConfig; cfg.Variant = v` pattern no longer panics.

The DNS-01 layer is the largest churn: previously a string-tagged union (`Provider` field + sibling provider-specific fields like `APIToken`/`SecretAccessKey`/`Project`) → now per-provider configs implementing `DNS01Provider`.

Closes #482.

## Breaking changes (public API)

- `IssuerConfig.ACME` / `IssuerConfig.CA` removed → use `IssuerConfig.Variant`.
- `ClusterIssuerConfig.ACME` / `ClusterIssuerConfig.CA` removed → use `ClusterIssuerConfig.Variant`.
- `ACMESolverConfig.HTTP01` / `ACMESolverConfig.DNS01` removed → use `ACMESolverConfig.Solver`.
- `DNS01SolverConfig` reshaped — `Provider` is now `DNS01Provider`, with `Email`/`Region`/`Project`/`ServiceAccount`/`APIToken`/`SecretAccessKey` moved into per-provider configs.

kure is v0.2.0-alpha (pre-1.0) → in-policy. Consumer migration tracked in [crane#186](https://gitlab.com/autops/wharf/crane/-/work_items/186) (the OAM certificate trait, currently `unstructured.Unstructured`-based, will adopt the post-refactor API directly).

## Test plan

- [x] `make test` — all packages pass; new typed-nil safety tests for IssuerVariant, ACMESolver, and all three DNS01Provider implementations.
- [x] `make lint LINT_FLAGS="--new-from-rev=origin/main"` — 0 new issues.
- [x] Compile-time interface conformance asserted via `var _ IssuerVariant = (*ACMEConfig)(nil)` etc. for every implementation.
- [ ] CI green.

## Doc updates

- `docs/ARCHITECTURE.md` § One-of Constraints — the migration note is struck; cert-manager is now listed alongside volsync as a reference implementation.
- `pkg/kubernetes/certmanager/README.md` — examples updated to the new shape (Variant / Solver / Provider).
- `pkg/kubernetes/certmanager/doc.go` — adds the one-of constraint section.

## Related

- #481 — established the idiom (volsync builders).
- crane#186 — consumer migration; depends on this PR.