### PR TITLE
feat(layout): add LayoutRules.FlattenSingleTier opt-in flag

### DIFF
--- a/pkg/stack/fluxcd/layout_integrator.go
+++ b/pkg/stack/fluxcd/layout_integrator.go
@@ -27,20 +27,33 @@ func NewLayoutIntegrator(generator *ResourceGenerator) *LayoutIntegrator {
 }
 
 // IntegrateWithLayout adds Flux resources to an existing manifest layout.
+//
+// If the layout was post-processed by FlattenSingleTier (recorded as
+// flattenInfo on the absorbing layouts), this method consults nodeAliases
+// during integrated placement (see findLayoutNode) and rewrites Flux
+// Kustomization Spec.Path values via layout.ApplyFlattenPathRewrites before
+// returning, regardless of placement mode.
 func (li *LayoutIntegrator) IntegrateWithLayout(ml *layout.ManifestLayout, c *stack.Cluster, rules layout.LayoutRules) error {
 	if ml == nil || c == nil {
 		return nil
 	}
 
+	var err error
 	switch li.FluxPlacement {
 	case layout.FluxIntegrated:
-		return li.addIntegratedFluxToLayout(ml, c, rules)
+		err = li.addIntegratedFluxToLayout(ml, c, rules)
 	case layout.FluxSeparate:
-		return li.addSeparateFluxToLayout(ml, c, rules)
+		err = li.addSeparateFluxToLayout(ml, c, rules)
 	default:
 		return errors.NewValidationError("fluxPlacement", string(li.FluxPlacement), "LayoutIntegrator",
 			[]string{string(layout.FluxIntegrated), string(layout.FluxSeparate)})
 	}
+	if err != nil {
+		return err
+	}
+
+	layout.ApplyFlattenPathRewrites(ml)
+	return nil
 }
 
 // CreateLayoutWithResources creates a new layout that includes Flux resources.
@@ -221,9 +234,15 @@ func (li *LayoutIntegrator) addSeparateFluxToLayout(ml *layout.ManifestLayout, c
 // findLayoutNode finds the layout node corresponding to a stack node using path-based matching.
 // It computes the layout's full path and compares against the node's path to avoid
 // ambiguity when nodes at different hierarchy levels share the same name.
+// When path-based search misses (because FlattenSingleTier collapsed the
+// target's layout into an ancestor), it falls back to the flattenInfo alias
+// recorded on the absorbing layout.
 func (li *LayoutIntegrator) findLayoutNode(ml *layout.ManifestLayout, node *stack.Node) *layout.ManifestLayout {
 	targetPath := node.GetPath()
-	return li.findLayoutNodeByPath(ml, targetPath, "")
+	if found := li.findLayoutNodeByPath(ml, targetPath, ""); found != nil {
+		return found
+	}
+	return layout.FindByNodeAlias(ml, targetPath)
 }
 
 // findLayoutNodeByPath recursively searches the layout tree for a node whose

--- a/pkg/stack/fluxcd/layout_integrator_test.go
+++ b/pkg/stack/fluxcd/layout_integrator_test.go
@@ -700,3 +700,91 @@ func TestCreateLayoutWithResources_UmbrellaChildWithSource(t *testing.T) {
 		t.Error("expected umbrella child's GitRepository at parent bundle layout")
 	}
 }
+
+// TestIntegrateWithLayout_AppliesFlattenPathRewrites confirms that
+// IntegrateWithLayout invokes layout.ApplyFlattenPathRewrites before
+// returning, so callers using WalkCluster + IntegrateWithLayout directly
+// (without going through CreateLayoutWithResources) still get rewritten
+// Spec.Path values on Flux Kustomization CRs.
+func TestIntegrateWithLayout_AppliesFlattenPathRewrites(t *testing.T) {
+	generator := fluxstack.NewResourceGenerator()
+	integrator := fluxstack.NewLayoutIntegrator(generator)
+	integrator.SetFluxPlacement(layout.FluxSeparate)
+
+	cluster := &stack.Cluster{
+		Name: "arc-runners",
+		Node: &stack.Node{Name: "apps", Bundle: &stack.Bundle{Name: "bundle"}},
+	}
+
+	// Walk + collapse via the public API; this populates flattenInfo on
+	// the absorbing root.
+	walked, err := layout.WalkCluster(cluster, layout.LayoutRules{
+		ClusterName:         "arc-runners",
+		BundleGrouping:      layout.GroupFlat,
+		ApplicationGrouping: layout.GroupFlat,
+		FlattenSingleTier:   true,
+	})
+	if err != nil {
+		t.Fatalf("WalkCluster: %v", err)
+	}
+
+	// Pre-plant a Kustomization CR whose Spec.Path matches the recorded
+	// rewrite. After IntegrateWithLayout returns, the post-pass must have
+	// rewritten it.
+	preplanted := &kustv1.Kustomization{}
+	preplanted.Spec.Path = "arc-runners/apps"
+	walked.Resources = append(walked.Resources, preplanted)
+
+	if err := integrator.IntegrateWithLayout(walked, cluster, layout.LayoutRules{}); err != nil {
+		t.Fatalf("IntegrateWithLayout: %v", err)
+	}
+
+	if preplanted.Spec.Path != "arc-runners" {
+		t.Errorf("expected Spec.Path rewritten to 'arc-runners', got %q", preplanted.Spec.Path)
+	}
+}
+
+// TestIntegrateWithLayout_RepeatedCallSucceeds confirms that calling
+// IntegrateWithLayout twice on the same flattened layout works. The first
+// call must not destroy the alias state that integrated placement depends
+// on for resolving the collapsed node path on the second call.
+func TestIntegrateWithLayout_RepeatedCallSucceeds(t *testing.T) {
+	generator := fluxstack.NewResourceGenerator()
+	integrator := fluxstack.NewLayoutIntegrator(generator)
+	integrator.SetFluxPlacement(layout.FluxIntegrated)
+
+	cluster := &stack.Cluster{
+		Name: "arc-runners",
+		Node: &stack.Node{
+			Name: "apps",
+			Bundle: &stack.Bundle{
+				Name: "bundle",
+				SourceRef: &stack.SourceRef{
+					Kind:      "GitRepository",
+					Name:      "test-source",
+					Namespace: "flux-system",
+				},
+			},
+		},
+	}
+
+	walked, err := layout.WalkCluster(cluster, layout.LayoutRules{
+		ClusterName:         "arc-runners",
+		BundleGrouping:      layout.GroupFlat,
+		ApplicationGrouping: layout.GroupFlat,
+		FlattenSingleTier:   true,
+	})
+	if err != nil {
+		t.Fatalf("WalkCluster: %v", err)
+	}
+
+	if err := integrator.IntegrateWithLayout(walked, cluster, layout.LayoutRules{}); err != nil {
+		t.Fatalf("first IntegrateWithLayout: %v", err)
+	}
+
+	// Second call must still resolve the collapsed "apps" node via the
+	// alias fallback rather than failing with "layout node not found".
+	if err := integrator.IntegrateWithLayout(walked, cluster, layout.LayoutRules{}); err != nil {
+		t.Fatalf("second IntegrateWithLayout: %v (alias state was destroyed by the first pass)", err)
+	}
+}

--- a/pkg/stack/layout/README.md
+++ b/pkg/stack/layout/README.md
@@ -130,6 +130,27 @@ When `app.Config` implements it, the walker invokes `AugmentLayout` on the per-a
 
 Setting `LayoutRules.ClusterName` prepends the cluster name as a root directory, producing paths like `{clusterName}/{nodeName}/...` instead of `{nodeName}/...`. This is useful when a single repository manages multiple clusters.
 
+### Flatten Single Tier (opt-in)
+
+`LayoutRules.FlattenSingleTier` collapses one vestigial intermediate directory layer when the wrapping Node adds no semantic value. Typical case: a flat single-bundle app whose caller wraps the Bundle in an extra Node (e.g. crane's `apps` Node), producing `cluster-name/apps/manifests.yaml` where the `apps/` layer is redundant. Enabling the flag yields `cluster-name/manifests.yaml` directly.
+
+Conservative collapse preconditions — ALL must hold:
+
+- `LayoutRules.FlattenSingleTier` is `true`.
+- The parent layout is top-level (`Namespace` has no path separator).
+- Parent has exactly one `Children` entry.
+- Parent has no own `Resources`.
+- The single child is not an `UmbrellaChild`.
+- The single child has no `Children` of its own (terminal layer).
+
+Multi-tier apps with sub-Kustomizations are unaffected: the precondition that the child be terminal preserves them. Empty containers (`only-Children`) are also unaffected: the precondition requiring the parent to have no own resources doesn't apply to them.
+
+When the layout participates in Flux integration, the flatten helper records redirect tables (`nodeAliases` for `findLayoutNode` lookups, `pathRewrites` for `Spec.Path` rewriting). `IntegrateWithLayout` consults the aliases during integrated placement and calls `ApplyFlattenPathRewrites(root)` before returning, regardless of placement mode (FluxIntegrated or FluxSeparate). Direct callers using `WalkCluster` + `IntegrateWithLayout` (without going through `CreateLayoutWithResources`) get the rewrite for free.
+
+Scoped to `WalkCluster`. `WalkClusterByPackage` is unaffected — its synthetic unnamed wrappers express package boundaries that the flatten helper would otherwise erroneously collapse.
+
+Default: `false` — no behaviour change for existing callers.
+
 ## Layout Presets
 
 Three named presets provide pre-configured LayoutRules for common deployment patterns. Use `LayoutRulesForPreset()` to get rules, or `ConfigForPreset()` to get a matching Config.

--- a/pkg/stack/layout/flatten.go
+++ b/pkg/stack/layout/flatten.go
@@ -1,0 +1,228 @@
+package layout
+
+import (
+	"strings"
+
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+
+	"github.com/go-kure/kure/pkg/stack"
+)
+
+// flattenSingleTier collapses one vestigial intermediate layout layer when
+// safe, populating redirects on the absorbing layout for the Flux integrator
+// to consume. Returns root unchanged when preconditions fail.
+//
+// Preconditions for collapse — ALL must hold:
+//   - rules.FlattenSingleTier is true.
+//   - The parent layout's Namespace has no path separator (top-level layer).
+//   - The parent has exactly one Children entry.
+//   - The parent has no own Resources.
+//   - The single child is not an UmbrellaChild.
+//   - The single child has no Children of its own.
+//
+// On collapse:
+//   - parent.Resources = child.Resources, parent.Children = nil.
+//   - parent.ExtraFiles += child.ExtraFiles, parent.ConfigMapGenerators += child.ConfigMapGenerators.
+//   - Inherit child's Mode / FilePer / ApplicationFileMode / FileNaming if
+//     the parent has them as their unset sentinel value.
+//   - Populate parent.flattenInfo (nodeAliases + pathRewrites).
+func flattenSingleTier(root *ManifestLayout, c *stack.Cluster, rules LayoutRules) *ManifestLayout {
+	if root == nil || c == nil || !rules.FlattenSingleTier {
+		return root
+	}
+	if !canFlatten(root) {
+		return root
+	}
+
+	child := root.Children[0]
+
+	oldLayoutPath := child.FullRepoPath()
+	newLayoutPath := root.FullRepoPath()
+
+	// Resolve the node-path form for the alias. The collapsed child layout
+	// corresponds to a stack.Node only when the layout's Name matches a Node
+	// reachable from c.Node. We look up by name in the immediate Node tree;
+	// for the typical case (cluster-name mode collapsing the root node into
+	// the synthetic cluster root) the match is c.Node itself.
+	var oldNodePath string
+	if matched := findNodeByLayoutName(c.Node, child.Name); matched != nil {
+		oldNodePath = matched.GetPath()
+	}
+
+	// Mutate parent.
+	root.Resources = child.Resources
+	root.ExtraFiles = append(root.ExtraFiles, child.ExtraFiles...)
+	root.ConfigMapGenerators = append(root.ConfigMapGenerators, child.ConfigMapGenerators...)
+	root.Children = nil
+	if root.Mode == KustomizationUnset && child.Mode != KustomizationUnset {
+		root.Mode = child.Mode
+	}
+	if root.FilePer == FilePerUnset && child.FilePer != FilePerUnset {
+		root.FilePer = child.FilePer
+	}
+	if root.ApplicationFileMode == AppFileUnset && child.ApplicationFileMode != AppFileUnset {
+		root.ApplicationFileMode = child.ApplicationFileMode
+	}
+	if root.FileNaming == FileNamingUnset && child.FileNaming != FileNamingUnset {
+		root.FileNaming = child.FileNaming
+	}
+
+	// Populate redirects.
+	if root.flattenInfo == nil {
+		root.flattenInfo = &flattenInfo{
+			nodeAliases:  map[string]*ManifestLayout{},
+			pathRewrites: map[string]string{},
+		}
+	}
+	if oldNodePath != "" {
+		root.flattenInfo.nodeAliases[oldNodePath] = root
+	}
+	if oldLayoutPath != newLayoutPath {
+		root.flattenInfo.pathRewrites[oldLayoutPath] = newLayoutPath
+	}
+
+	return root
+}
+
+// canFlatten checks the collapse preconditions on a candidate parent layout.
+func canFlatten(parent *ManifestLayout) bool {
+	if parent == nil {
+		return false
+	}
+	// Parent must be top-level (single-segment or empty Namespace).
+	if strings.Contains(parent.Namespace, "/") {
+		return false
+	}
+	if len(parent.Children) != 1 {
+		return false
+	}
+	if len(parent.Resources) > 0 {
+		return false
+	}
+	child := parent.Children[0]
+	if child == nil {
+		return false
+	}
+	if child.UmbrellaChild {
+		return false
+	}
+	if len(child.Children) > 0 {
+		return false
+	}
+	return true
+}
+
+// findNodeByLayoutName traverses the stack.Node tree depth-first looking for
+// a Node whose Name matches the given layout-side name. Returns the first
+// match or nil.
+func findNodeByLayoutName(n *stack.Node, name string) *stack.Node {
+	if n == nil {
+		return nil
+	}
+	if n.Name == name {
+		return n
+	}
+	for _, child := range n.Children {
+		if found := findNodeByLayoutName(child, name); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// FindByNodeAlias walks the layout tree looking for a flattenInfo nodeAlias
+// matching nodePath. Returns the absorbing layout, or nil if no alias
+// matches. Used by the Flux integrator's findLayoutNode as a fallback when
+// regular path-based search fails.
+func FindByNodeAlias(ml *ManifestLayout, nodePath string) *ManifestLayout {
+	if ml == nil {
+		return nil
+	}
+	if redirect := ml.FlattenInfoNodeAlias(nodePath); redirect != nil {
+		return redirect
+	}
+	for _, child := range ml.Children {
+		if redirect := FindByNodeAlias(child, nodePath); redirect != nil {
+			return redirect
+		}
+	}
+	return nil
+}
+
+// ApplyFlattenPathRewrites walks the layout tree, gathers all path rewrites
+// recorded by flattenSingleTier collapses, and rewrites Spec.Path on every
+// Flux Kustomization CR found in the tree's Resources. Idempotent: if no
+// rewrites were recorded, returns immediately; on repeated invocations
+// already-rewritten paths no longer match the rewrite keys, so subsequent
+// passes are no-ops.
+//
+// flattenInfo is intentionally left in place after a rewrite pass so that
+// IntegrateWithLayout can be called multiple times on the same flattened
+// layout — the integrator's findLayoutNode fallback depends on the
+// nodeAliases remaining populated for the lifetime of the layout.
+//
+// Called by the Flux integrator's IntegrateWithLayout before returning.
+// Lives in the layout package because the flattenInfo field is unexported
+// here.
+func ApplyFlattenPathRewrites(root *ManifestLayout) {
+	rewrites := collectPathRewrites(root)
+	if len(rewrites) == 0 {
+		return
+	}
+	rewriteFluxPaths(root, rewrites)
+}
+
+func collectPathRewrites(ml *ManifestLayout) map[string]string {
+	if ml == nil {
+		return nil
+	}
+	var out map[string]string
+	if r := ml.FlattenInfoPathRewrites(); len(r) > 0 {
+		out = map[string]string{}
+		for k, v := range r {
+			out[k] = v
+		}
+	}
+	for _, child := range ml.Children {
+		childMap := collectPathRewrites(child)
+		if len(childMap) == 0 {
+			continue
+		}
+		if out == nil {
+			out = map[string]string{}
+		}
+		for k, v := range childMap {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func rewriteFluxPaths(ml *ManifestLayout, rewrites map[string]string) {
+	if ml == nil {
+		return
+	}
+	for _, obj := range ml.Resources {
+		k, ok := obj.(*kustomizev1.Kustomization)
+		if !ok {
+			continue
+		}
+		for old, neu := range rewrites {
+			// Once a rewrite fires for this resource, stop testing the
+			// remaining entries against the modified path. With Go's
+			// non-deterministic map iteration, continuing could double-
+			// rewrite if multiple rewrites' keys/values overlap.
+			if k.Spec.Path == old {
+				k.Spec.Path = neu
+				break
+			}
+			if strings.HasPrefix(k.Spec.Path, old+"/") {
+				k.Spec.Path = neu + strings.TrimPrefix(k.Spec.Path, old)
+				break
+			}
+		}
+	}
+	for _, child := range ml.Children {
+		rewriteFluxPaths(child, rewrites)
+	}
+}

--- a/pkg/stack/layout/flatten_test.go
+++ b/pkg/stack/layout/flatten_test.go
@@ -1,0 +1,337 @@
+package layout
+
+import (
+	"testing"
+
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/kure/pkg/stack"
+)
+
+// flattenFakeConfig is a minimal stack.ApplicationConfig for these tests.
+type flattenFakeConfig struct {
+	objs []*client.Object
+}
+
+func (f *flattenFakeConfig) Generate(*stack.Application) ([]*client.Object, error) {
+	return f.objs, nil
+}
+
+func newFlattenTestCluster(t *testing.T) *stack.Cluster {
+	t.Helper()
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("v1")
+	obj.SetKind("ConfigMap")
+	obj.SetName("cm")
+	obj.SetNamespace("default")
+	var o client.Object = obj
+
+	app := stack.NewApplication("only", "ns", &flattenFakeConfig{objs: []*client.Object{&o}})
+	bundle := &stack.Bundle{Name: "bundle", Applications: []*stack.Application{app}}
+	root := &stack.Node{Name: "apps", Bundle: bundle}
+	return &stack.Cluster{Name: "demo", Node: root}
+}
+
+func TestFlatten_DisabledIsNoOp(t *testing.T) {
+	cluster := newFlattenTestCluster(t)
+	rules := LayoutRules{
+		ClusterName:         "arc-runners",
+		BundleGrouping:      GroupFlat,
+		ApplicationGrouping: GroupFlat,
+	}
+	ml, err := WalkCluster(cluster, rules)
+	if err != nil {
+		t.Fatalf("WalkCluster: %v", err)
+	}
+	if len(ml.Children) == 0 {
+		t.Fatalf("expected children when flatten is disabled, got resources directly")
+	}
+	if len(ml.Resources) != 0 {
+		t.Errorf("synthetic root should not have resources when flatten is disabled, got %d", len(ml.Resources))
+	}
+	if ml.flattenInfo != nil {
+		t.Errorf("no flattenInfo expected when flag is off")
+	}
+}
+
+func TestFlatten_EnabledCollapsesSingleTier(t *testing.T) {
+	cluster := newFlattenTestCluster(t)
+	rules := LayoutRules{
+		ClusterName:         "arc-runners",
+		BundleGrouping:      GroupFlat,
+		ApplicationGrouping: GroupFlat,
+		FlattenSingleTier:   true,
+	}
+	ml, err := WalkCluster(cluster, rules)
+	if err != nil {
+		t.Fatalf("WalkCluster: %v", err)
+	}
+	if len(ml.Children) != 0 {
+		t.Errorf("expected no children after collapse, got %d", len(ml.Children))
+	}
+	if len(ml.Resources) != 1 {
+		t.Errorf("expected child resources lifted to root, got %d", len(ml.Resources))
+	}
+	if ml.flattenInfo == nil {
+		t.Fatal("expected flattenInfo populated after collapse")
+	}
+	if got := ml.FlattenInfoNodeAlias("apps"); got != ml {
+		t.Errorf("expected node alias for 'apps' to point at root, got %p", got)
+	}
+	rewrites := ml.FlattenInfoPathRewrites()
+	if rewrites["arc-runners/apps"] != "arc-runners" {
+		t.Errorf("expected path rewrite arc-runners/apps -> arc-runners, got %v", rewrites)
+	}
+}
+
+func TestFlatten_PropagatesExtraFilesAndCMGen(t *testing.T) {
+	cluster := newFlattenTestCluster(t)
+	rules := LayoutRules{
+		ClusterName:         "arc-runners",
+		BundleGrouping:      GroupFlat,
+		ApplicationGrouping: GroupFlat,
+		FlattenSingleTier:   true,
+	}
+	// Build the layout, then artificially attach extras to the child before
+	// flattening to mimic an augmenter that ran during walk.
+	cluster.Node.Bundle.Applications[0] = stack.NewApplication("only", "ns", &flattenFakeConfig{
+		objs: cluster.Node.Bundle.Applications[0].Config.(*flattenFakeConfig).objs,
+	})
+
+	// Manual layout for direct helper test (bypasses WalkCluster's own augmenter machinery).
+	parent := &ManifestLayout{
+		Name:      "",
+		Namespace: "arc-runners",
+		Children: []*ManifestLayout{{
+			Name:      "apps",
+			Namespace: "arc-runners/apps",
+			ExtraFiles: []ExtraFile{
+				{Name: "values.yaml", Content: []byte("a: b")},
+			},
+			ConfigMapGenerators: []ConfigMapGeneratorSpec{
+				{Name: "vals", Files: []string{"values.yaml"}},
+			},
+		}},
+	}
+	flattenSingleTier(parent, cluster, rules)
+	if len(parent.ExtraFiles) != 1 || parent.ExtraFiles[0].Name != "values.yaml" {
+		t.Errorf("ExtraFiles not propagated: %+v", parent.ExtraFiles)
+	}
+	if len(parent.ConfigMapGenerators) != 1 || parent.ConfigMapGenerators[0].Name != "vals" {
+		t.Errorf("ConfigMapGenerators not propagated: %+v", parent.ConfigMapGenerators)
+	}
+}
+
+func TestFlatten_NoCollapseWhenMultipleChildren(t *testing.T) {
+	cluster := &stack.Cluster{Name: "demo", Node: &stack.Node{Name: "apps"}}
+	rules := LayoutRules{FlattenSingleTier: true}
+
+	parent := &ManifestLayout{
+		Name:      "",
+		Namespace: "arc-runners",
+		Children: []*ManifestLayout{
+			{Name: "a", Namespace: "arc-runners/a"},
+			{Name: "b", Namespace: "arc-runners/b"},
+		},
+	}
+	flattenSingleTier(parent, cluster, rules)
+	if len(parent.Children) != 2 {
+		t.Errorf("expected no collapse with multiple children")
+	}
+	if parent.flattenInfo != nil {
+		t.Errorf("no flattenInfo expected when no collapse occurred")
+	}
+}
+
+func TestFlatten_NoCollapseWhenUmbrellaChild(t *testing.T) {
+	cluster := &stack.Cluster{Name: "demo", Node: &stack.Node{Name: "apps"}}
+	rules := LayoutRules{FlattenSingleTier: true}
+
+	parent := &ManifestLayout{
+		Name:      "",
+		Namespace: "arc-runners",
+		Children: []*ManifestLayout{
+			{Name: "apps", Namespace: "arc-runners/apps", UmbrellaChild: true},
+		},
+	}
+	flattenSingleTier(parent, cluster, rules)
+	if len(parent.Children) != 1 {
+		t.Errorf("expected no collapse with umbrella child")
+	}
+}
+
+func TestFlatten_NoCollapseWhenChildHasChildren(t *testing.T) {
+	cluster := &stack.Cluster{Name: "demo", Node: &stack.Node{Name: "apps"}}
+	rules := LayoutRules{FlattenSingleTier: true}
+
+	parent := &ManifestLayout{
+		Name:      "",
+		Namespace: "arc-runners",
+		Children: []*ManifestLayout{
+			{
+				Name:      "apps",
+				Namespace: "arc-runners/apps",
+				Children:  []*ManifestLayout{{Name: "deeper"}},
+			},
+		},
+	}
+	flattenSingleTier(parent, cluster, rules)
+	if len(parent.Children) != 1 {
+		t.Errorf("expected no collapse when child has its own children")
+	}
+}
+
+func TestFlatten_NoCollapseWhenParentHasResources(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetKind("ConfigMap")
+	cluster := &stack.Cluster{Name: "demo", Node: &stack.Node{Name: "apps"}}
+	rules := LayoutRules{FlattenSingleTier: true}
+
+	parent := &ManifestLayout{
+		Name:      "",
+		Namespace: "arc-runners",
+		Resources: []client.Object{obj},
+		Children:  []*ManifestLayout{{Name: "apps", Namespace: "arc-runners/apps"}},
+	}
+	flattenSingleTier(parent, cluster, rules)
+	if len(parent.Children) != 1 {
+		t.Errorf("expected no collapse when parent has its own Resources")
+	}
+}
+
+func TestFlatten_NoCollapseWhenParentNamespaceHasSeparator(t *testing.T) {
+	cluster := &stack.Cluster{Name: "demo", Node: &stack.Node{Name: "apps"}}
+	rules := LayoutRules{FlattenSingleTier: true}
+
+	parent := &ManifestLayout{
+		Name:      "intermediate",
+		Namespace: "arc-runners/intermediate",
+		Children:  []*ManifestLayout{{Name: "apps", Namespace: "arc-runners/intermediate/apps"}},
+	}
+	flattenSingleTier(parent, cluster, rules)
+	if len(parent.Children) != 1 {
+		t.Errorf("expected no collapse when parent is not top-level")
+	}
+}
+
+func TestFlatten_PackageWalkIsNoOp(t *testing.T) {
+	cluster := newFlattenTestCluster(t)
+	rules := LayoutRules{
+		BundleGrouping:      GroupFlat,
+		ApplicationGrouping: GroupFlat,
+		FlattenSingleTier:   true,
+	}
+	packages, err := WalkClusterByPackage(cluster, rules)
+	if err != nil {
+		t.Fatalf("WalkClusterByPackage: %v", err)
+	}
+	for _, ml := range packages {
+		if ml.flattenInfo != nil {
+			t.Errorf("WalkClusterByPackage should not invoke flattenSingleTier; got flattenInfo on a package layout")
+		}
+	}
+}
+
+func TestApplyFlattenPathRewrites(t *testing.T) {
+	kust := &kustomizev1.Kustomization{}
+	kust.Spec.Path = "arc-runners/apps"
+
+	deepKust := &kustomizev1.Kustomization{}
+	deepKust.Spec.Path = "arc-runners/apps/sub"
+
+	unrelated := &kustomizev1.Kustomization{}
+	unrelated.Spec.Path = "other/path"
+
+	root := &ManifestLayout{
+		Name:      "",
+		Namespace: "arc-runners",
+		Resources: []client.Object{kust, unrelated},
+		flattenInfo: &flattenInfo{
+			pathRewrites: map[string]string{"arc-runners/apps": "arc-runners"},
+		},
+		Children: []*ManifestLayout{
+			{
+				Name:      "flux-system",
+				Namespace: "arc-runners/flux-system",
+				Resources: []client.Object{deepKust},
+			},
+		},
+	}
+
+	ApplyFlattenPathRewrites(root)
+
+	if kust.Spec.Path != "arc-runners" {
+		t.Errorf("exact-match rewrite failed: got %q, want %q", kust.Spec.Path, "arc-runners")
+	}
+	if deepKust.Spec.Path != "arc-runners/sub" {
+		t.Errorf("prefix-match rewrite failed: got %q, want %q", deepKust.Spec.Path, "arc-runners/sub")
+	}
+	if unrelated.Spec.Path != "other/path" {
+		t.Errorf("unrelated path should not be rewritten: got %q", unrelated.Spec.Path)
+	}
+	if root.flattenInfo == nil {
+		t.Errorf("flattenInfo should remain populated after rewrite so subsequent integrator passes can resolve aliases")
+	}
+}
+
+func TestApplyFlattenPathRewrites_NoOpWhenEmpty(t *testing.T) {
+	root := &ManifestLayout{Name: "x", Namespace: "ns"}
+	ApplyFlattenPathRewrites(root) // must not panic
+}
+
+func TestApplyFlattenPathRewrites_IsIdempotent(t *testing.T) {
+	// After a rewrite pass leaves flattenInfo intact, a second pass on the
+	// same layout must be a no-op (the already-rewritten Spec.Path no
+	// longer matches the rewrite key).
+	kust := &kustomizev1.Kustomization{}
+	kust.Spec.Path = "arc-runners/apps"
+	root := &ManifestLayout{
+		Name:      "",
+		Namespace: "arc-runners",
+		Resources: []client.Object{kust},
+		flattenInfo: &flattenInfo{
+			pathRewrites: map[string]string{"arc-runners/apps": "arc-runners"},
+		},
+	}
+
+	ApplyFlattenPathRewrites(root)
+	if kust.Spec.Path != "arc-runners" {
+		t.Fatalf("first pass: got %q, want %q", kust.Spec.Path, "arc-runners")
+	}
+
+	// Second pass: must not double-rewrite or panic.
+	ApplyFlattenPathRewrites(root)
+	if kust.Spec.Path != "arc-runners" {
+		t.Errorf("second pass should be idempotent: got %q, want %q", kust.Spec.Path, "arc-runners")
+	}
+	if root.flattenInfo == nil {
+		t.Errorf("flattenInfo must remain populated for repeated integration calls")
+	}
+}
+
+func TestFindByNodeAlias(t *testing.T) {
+	leaf := &ManifestLayout{Name: "leaf"}
+	root := &ManifestLayout{
+		Name: "",
+		Children: []*ManifestLayout{
+			{
+				Name: "branch",
+				Children: []*ManifestLayout{
+					leaf,
+				},
+			},
+		},
+	}
+	leaf.flattenInfo = &flattenInfo{
+		nodeAliases: map[string]*ManifestLayout{"deep/path": leaf},
+	}
+
+	if got := FindByNodeAlias(root, "deep/path"); got != leaf {
+		t.Errorf("expected alias to resolve to leaf, got %p", got)
+	}
+	if got := FindByNodeAlias(root, "missing"); got != nil {
+		t.Errorf("expected nil for missing alias, got %p", got)
+	}
+}

--- a/pkg/stack/layout/manifest.go
+++ b/pkg/stack/layout/manifest.go
@@ -42,6 +42,47 @@ type ManifestLayout struct {
 	// child's Flux Kustomization CR at the parent layout node rather than in
 	// the child's own directory.
 	UmbrellaChild bool
+	// flattenInfo carries the redirects produced by FlattenSingleTier when
+	// this layout absorbed a collapsed child. Set only on the absorbing
+	// layout; never serialised. Consulted by the Flux integrator's
+	// findLayoutNode fallback and by ApplyFlattenPathRewrites; remains
+	// populated after rewrite so that IntegrateWithLayout can be invoked
+	// multiple times on the same flattened layout without losing the alias
+	// state needed by integrated placement.
+	flattenInfo *flattenInfo
+}
+
+// flattenInfo records the redirects produced by a FlattenSingleTier collapse.
+// Two distinct keying schemes are needed because the integrator looks up
+// layouts by node paths while Flux Kustomization Spec.Path values are
+// layout-tree paths (cluster-name-prefixed); a single map cannot serve both.
+type flattenInfo struct {
+	// nodeAliases maps node.GetPath() of the collapsed child node to the
+	// absorbing layout. Used by findLayoutNode (FluxIntegrated mode only).
+	nodeAliases map[string]*ManifestLayout
+	// pathRewrites maps pre-collapse layout repo path → post-collapse layout
+	// repo path. Used to rewrite Spec.Path strings on Flux Kustomization
+	// CRs (both modes). Handles exact-match and prefix-match (path/...).
+	pathRewrites map[string]string
+}
+
+// FlattenInfoNodeAlias returns the absorbing layout for the given node path
+// recorded on this layout's flattenInfo, or nil if no alias matches. Exposed
+// for the Flux integrator's findLayoutNode fallback.
+func (ml *ManifestLayout) FlattenInfoNodeAlias(nodePath string) *ManifestLayout {
+	if ml == nil || ml.flattenInfo == nil {
+		return nil
+	}
+	return ml.flattenInfo.nodeAliases[nodePath]
+}
+
+// FlattenInfoPathRewrites returns the path-rewrite map recorded on this
+// layout's flattenInfo, or nil. Exposed for ApplyFlattenPathRewrites.
+func (ml *ManifestLayout) FlattenInfoPathRewrites() map[string]string {
+	if ml == nil || ml.flattenInfo == nil {
+		return nil
+	}
+	return ml.flattenInfo.pathRewrites
 }
 
 // ExtraFile is an arbitrary file written into a ManifestLayout's directory

--- a/pkg/stack/layout/types.go
+++ b/pkg/stack/layout/types.go
@@ -115,6 +115,27 @@ type LayoutRules struct {
 	// FileNaming controls the file naming pattern for manifest files.
 	// Defaults to FileNamingDefault ({namespace}-{kind}-{name}.yaml).
 	FileNaming FileNamingMode
+
+	// FlattenSingleTier collapses a vestigial intermediate directory layer
+	// produced by the walker when it adds no semantic value: a parent layout
+	// with exactly one named child whose own children are empty and which is
+	// not an UmbrellaChild, where the parent itself is a top-level layout
+	// (Namespace has no path separator) with no own Resources.
+	//
+	// Typical case: flat single-bundle apps where the caller wraps the bundle
+	// in an extra Node (e.g. crane's "apps" Node). Multi-tier apps with sub-
+	// Kustomizations are unaffected — the collapse rules require the
+	// intermediate to be terminal.
+	//
+	// Only effective for WalkCluster (not WalkClusterByPackage, which uses
+	// synthetic unnamed wrappers to express package boundaries).
+	//
+	// When the layout participates in Flux integration, the flatten helper
+	// records pathRewrites/nodeAliases on the absorbing layout.
+	// IntegrateWithLayout consults aliases via findLayoutNode and calls
+	// ApplyFlattenPathRewrites before returning, so generated Flux
+	// Kustomization CRs resolve to the post-collapse directory.
+	FlattenSingleTier bool
 }
 
 // DefaultLayoutRules returns a LayoutRules instance populated with the

--- a/pkg/stack/layout/walker.go
+++ b/pkg/stack/layout/walker.go
@@ -52,7 +52,11 @@ func WalkCluster(c *stack.Cluster, rules LayoutRules) (*ManifestLayout, error) {
 
 	// For cluster-aware layout, we need to restructure the hierarchy
 	if rules.ClusterName != "" {
-		return walkClusterWithClusterName(c, rules, nodeOnly, filePer)
+		ml, err := walkClusterWithClusterName(c, rules, nodeOnly, filePer)
+		if err != nil {
+			return nil, err
+		}
+		return flattenSingleTier(ml, c, rules), nil
 	}
 
 	// Traditional layout without cluster name
@@ -61,7 +65,7 @@ func WalkCluster(c *stack.Cluster, rules LayoutRules) (*ManifestLayout, error) {
 		return nil, err
 	}
 
-	return ml, nil
+	return flattenSingleTier(ml, c, rules), nil
 }
 
 // walkClusterWithClusterName creates a cluster-aware layout where the cluster

--- a/pkg/stack/layout/write.go
+++ b/pkg/stack/layout/write.go
@@ -103,12 +103,20 @@ func WriteManifest(basePath string, cfg Config, ml *ManifestLayout) error {
 		return err
 	}
 
-	// Don't generate root kustomization.yaml at cluster level (when namespace is just the cluster name)
-	isClusterRoot := strings.Count(ml.Namespace, string(filepath.Separator)) == 0 && ml.Name == ""
+	// Skip the kustomization.yaml at the synthetic cluster root only when it
+	// has no resources of its own. The synthetic root is the cluster-name
+	// container created by walkClusterWithClusterName: Name="",
+	// single-segment Namespace. With FlattenSingleTier the root may absorb a
+	// collapsed child's Resources, in which case it does need a
+	// kustomization.yaml.
+	skipClusterRoot := ml.Namespace != "" &&
+		strings.Count(ml.Namespace, string(filepath.Separator)) == 0 &&
+		ml.Name == "" &&
+		len(fileGroups) == 0
 
-	// Generate kustomization.yaml if there are resources or children, but not at cluster root
-	// Every directory with manifests should have a kustomization.yaml for proper GitOps workflow
-	if !isClusterRoot && (len(fileGroups) > 0 || len(ml.Children) > 0) {
+	// Generate kustomization.yaml if there are resources or children, except at the empty cluster root.
+	// Every directory with manifests should have a kustomization.yaml for proper GitOps workflow.
+	if !skipClusterRoot && (len(fileGroups) > 0 || len(ml.Children) > 0) {
 		kustomPath := filepath.Join(fullPath, "kustomization.yaml")
 		kf, err := os.Create(kustomPath)
 		if err != nil {

--- a/pkg/stack/layout/write_test.go
+++ b/pkg/stack/layout/write_test.go
@@ -345,10 +345,43 @@ func TestWriteManifest_WithChildren(t *testing.T) {
 	}
 }
 
-func TestWriteManifest_ClusterRootNoKustomization(t *testing.T) {
+func TestWriteManifest_ClusterRootEmptyContainerNoKustomization(t *testing.T) {
+	// Cluster root acting as a structural container: no own resources, only
+	// child layouts. No kustomization.yaml at this level — children own their
+	// own kustomization.yaml. Preserves the original walkClusterWithClusterName
+	// behaviour.
+	ml := &ManifestLayout{
+		Name:      "",
+		Namespace: "mycluster",
+		Children: []*ManifestLayout{
+			{
+				Name:      "child",
+				Namespace: "mycluster/child",
+				Resources: []client.Object{testObject("v1", "Namespace", "default", "")},
+			},
+		},
+	}
+
+	cfg := DefaultLayoutConfig()
+	dir := t.TempDir()
+
+	if err := WriteManifest(dir, cfg, ml); err != nil {
+		t.Fatalf("WriteManifest failed: %v", err)
+	}
+
+	kustomFile := filepath.Join(dir, "clusters", "mycluster", "kustomization.yaml")
+	if _, err := os.Stat(kustomFile); !os.IsNotExist(err) {
+		t.Errorf("kustomization.yaml should NOT be generated at empty cluster root (%s)", kustomFile)
+	}
+}
+
+func TestWriteManifest_ClusterRootWithResourcesEmitsKustomization(t *testing.T) {
+	// Cluster root carrying its own resources (e.g. after FlattenSingleTier
+	// collapsed a child up): the directory has manifests, so it must have a
+	// kustomization.yaml referencing them. Regression guard for the writer
+	// relaxation.
 	obj := testObject("v1", "Namespace", "default", "")
 
-	// Cluster root: Namespace without separator, Name empty.
 	ml := &ManifestLayout{
 		Name:      "",
 		Namespace: "mycluster",
@@ -362,16 +395,18 @@ func TestWriteManifest_ClusterRootNoKustomization(t *testing.T) {
 		t.Fatalf("WriteManifest failed: %v", err)
 	}
 
-	// Resource file should still be written.
 	resourceFile := filepath.Join(dir, "clusters", "mycluster", "cluster-namespace-default.yaml")
 	if _, err := os.Stat(resourceFile); err != nil {
 		t.Fatalf("expected resource file at %s: %v", resourceFile, err)
 	}
 
-	// Kustomization should NOT be generated at cluster root.
 	kustomFile := filepath.Join(dir, "clusters", "mycluster", "kustomization.yaml")
-	if _, err := os.Stat(kustomFile); !os.IsNotExist(err) {
-		t.Errorf("kustomization.yaml should NOT be generated at cluster root (%s)", kustomFile)
+	data, err := os.ReadFile(kustomFile)
+	if err != nil {
+		t.Fatalf("expected kustomization.yaml at cluster root with resources: %v", err)
+	}
+	if !strings.Contains(string(data), "cluster-namespace-default.yaml") {
+		t.Errorf("kustomization.yaml should reference the resource file, got:\n%s", data)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `LayoutRules.FlattenSingleTier`, an opt-in flag that collapses one vestigial intermediate directory layer when the wrapping Node adds no semantic value. Default `false` — no behaviour change for existing callers.

The reported case (#472): crane's `internal/transform/transformer.go:260` builds `Node{Name: "apps", Bundle: bundle}` for every flat app, producing `cluster-name/apps/manifests.yaml` where the `apps/` layer is redundant. With the flag enabled the output becomes `cluster-name/manifests.yaml` directly.

Closes #472.

## Conservative collapse preconditions

ALL must hold:

- `LayoutRules.FlattenSingleTier` is `true`.
- Parent layout is top-level (`Namespace` has no path separator).
- Parent has exactly one `Children` entry.
- Parent has no own `Resources`.
- The single child is not an `UmbrellaChild`.
- The single child has no `Children` (terminal layer).

Multi-tier apps with sub-Kustomizations stay intact (intermediate is not terminal). Empty cluster-name containers stay intact (parent has no own resources, but has children, so the "no own resources" only matters in combination with the other rules).

## Three supporting pieces

1. **Writer relaxation** (`WriteManifest`): the `isClusterRoot` guard now emits a `kustomization.yaml` when the synthetic cluster root carries its own resources (post-collapse). The empty-container case (synthetic root with only Children, no own Resources) keeps its current no-kust behaviour.
2. **Flux integrator alias lookup**: `findLayoutNode` consults `flattenInfo.nodeAliases` recorded by the helper, so FluxIntegrated placement still resolves the collapsed-target node to the absorbing layout.
3. **`Spec.Path` rewriting**: `IntegrateWithLayout` calls `layout.ApplyFlattenPathRewrites(root)` before returning. Walks the tree, rewrites `Spec.Path` on any `*kustomizev1.Kustomization` matching a recorded rewrite (exact-match or `path/...` prefix). Lives inside the integrator (not the wrapper) so direct callers using `WalkCluster` + `IntegrateWithLayout` get the rewrite too.

## Scope

Out of scope (documented in `pkg/stack/layout/README.md` and as plan notes):

- Recursive single-child collapse at deeper levels.
- `WalkClusterByPackage` — its synthetic unnamed wrappers preserve package boundaries.
- Mixed-resource roots (parent has own resources AND a single child) — would need to merge resource lists.
- Auto-flatten as default — opt-in only.

## Test plan

- [x] `make test` — all packages pass; new tests cover all collapse-precondition branches, the writer relaxation (both branches), redirect-population assertions (both maps), and integrator path rewriting via direct `WalkCluster` + `IntegrateWithLayout` callers.
- [x] `make lint LINT_FLAGS="--new-from-rev=origin/main"` — 0 new issues.
- [x] Existing `TestWriteManifest_ClusterRootNoKustomization` was renamed and split: the empty-container case keeps the original assertion (no kust); a new `*_WithResourcesEmitsKustomization` covers the relaxed behaviour.
- [ ] CI green.

## Files

| File | Change |
|---|---|
| `pkg/stack/layout/types.go` | new `LayoutRules.FlattenSingleTier` field |
| `pkg/stack/layout/manifest.go` | unexported `flattenInfo` type and field on `ManifestLayout`; `FlattenInfoNodeAlias` / `FlattenInfoPathRewrites` accessors |
| `pkg/stack/layout/write.go` | relaxed `skipClusterRoot` rule |
| `pkg/stack/layout/flatten.go` (new) | `flattenSingleTier`, `FindByNodeAlias`, `ApplyFlattenPathRewrites` |
| `pkg/stack/layout/walker.go` | invoke `flattenSingleTier` at the end of both `WalkCluster` paths |
| `pkg/stack/fluxcd/layout_integrator.go` | `findLayoutNode` falls back to alias lookup; `IntegrateWithLayout` calls `ApplyFlattenPathRewrites` before returning |
| `pkg/stack/layout/flatten_test.go` (new) | 10 tests covering all preconditions + redirect maps + path rewriting + node-alias lookup |
| `pkg/stack/layout/write_test.go` | empty-container regression + with-resources regression for the writer relaxation |
| `pkg/stack/fluxcd/layout_integrator_test.go` | direct `WalkCluster` + `IntegrateWithLayout` path-rewrite test |
| `pkg/stack/layout/README.md` | new "Flatten Single Tier" subsection |