### PR TITLE
ci: skip apt-get in test job when build-essential already installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Install build tools
-      run: sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends build-essential
+      run: command -v gcc &>/dev/null || (sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends build-essential)
 
     - name: Read Go version from mise.toml
       id: go-version


### PR DESCRIPTION
## Summary

- The \`test\` job's "Install build tools" step ran \`apt-get update\` unconditionally, costing ~11 minutes per run even when \`build-essential\` is already present on the runner
- Add a \`command -v gcc\` guard, matching the pattern already used in all other jobs (\`command -v make || apt-get...\`)
- Our custom runner image (\`ghcr.io/ginsys/opsmaster/actions-runner\`) pre-installs \`build-essential\`, so the step will be a no-op on \`autops-kube\` runners

## Test plan

- [ ] Verify "Install build tools" step completes in seconds (not minutes) on the next CI run