### PR TITLE
feat(cnpg): add domain config types for Cluster, Database, ObjectStore

### DIFF
--- a/pkg/kubernetes/cnpg/create.go
+++ b/pkg/kubernetes/cnpg/create.go
@@ -1,34 +1,274 @@
 package cnpg
 
 import (
+	"encoding/json"
+	"fmt"
+
+	barmanApi "github.com/cloudnative-pg/barman-cloud/pkg/api"
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	machineryapi "github.com/cloudnative-pg/machinery/pkg/api"
 	barmanv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	intcnpg "github.com/go-kure/kure/internal/cnpg"
 )
 
-// Cluster converts the config to a CNPG Cluster object.
-func Cluster(cfg *ClusterConfig) *cnpgv1.Cluster {
-	if cfg == nil {
-		return nil
-	}
-	return intcnpg.CreateCluster(cfg.Name, cfg.Namespace, cfg.Spec)
-}
-
-// Database converts the config to a CNPG Database object.
-func Database(cfg *DatabaseConfig) *cnpgv1.Database {
-	if cfg == nil {
-		return nil
-	}
-	return intcnpg.CreateDatabase(cfg.Name, cfg.Namespace, cfg.Spec)
-}
-
-// ObjectStore converts the config to a Barman Cloud ObjectStore object.
+// ObjectStore converts ObjectStoreOptions to a Barman Cloud ObjectStore object.
 func ObjectStore(cfg *ObjectStoreConfig) *barmanv1.ObjectStore {
 	if cfg == nil {
 		return nil
 	}
-	return intcnpg.CreateObjectStore(cfg.Name, cfg.Namespace, cfg.Spec)
+	opts := cfg.Options
+	if opts == nil {
+		opts = &ObjectStoreOptions{}
+	}
+	bos := barmanApi.BarmanObjectStoreConfiguration{
+		DestinationPath: opts.DestinationPath,
+		EndpointURL:     opts.EndpointURL,
+		ServerName:      opts.ServerName,
+	}
+	if opts.SecretName != "" {
+		akKey := opts.AccessKeyIDKey
+		if akKey == "" {
+			akKey = "ACCESS_KEY_ID"
+		}
+		sakKey := opts.SecretAccessKeyKey
+		if sakKey == "" {
+			sakKey = "SECRET_ACCESS_KEY"
+		}
+		bos.AWS = &barmanApi.S3Credentials{
+			AccessKeyIDReference: &machineryapi.SecretKeySelector{
+				LocalObjectReference: machineryapi.LocalObjectReference{Name: opts.SecretName},
+				Key:                  akKey,
+			},
+			SecretAccessKeyReference: &machineryapi.SecretKeySelector{
+				LocalObjectReference: machineryapi.LocalObjectReference{Name: opts.SecretName},
+				Key:                  sakKey,
+			},
+		}
+	}
+	spec := barmanv1.ObjectStoreSpec{
+		Configuration:   bos,
+		RetentionPolicy: opts.RetentionPolicy,
+	}
+	return intcnpg.CreateObjectStore(cfg.Name, cfg.Namespace, spec)
+}
+
+// Database converts DatabaseOptions to a CNPG Database object.
+func Database(cfg *DatabaseConfig) *cnpgv1.Database {
+	if cfg == nil {
+		return nil
+	}
+	opts := cfg.Options
+	if opts == nil {
+		opts = &DatabaseOptions{}
+	}
+	spec := cnpgv1.DatabaseSpec{
+		ClusterRef: corev1.LocalObjectReference{Name: opts.ClusterName},
+		Name:       opts.DBName,
+		Owner:      opts.Owner,
+	}
+	if opts.Ensure == "absent" {
+		spec.Ensure = cnpgv1.EnsureAbsent
+	}
+	if opts.ReclaimPolicy == "delete" {
+		spec.ReclaimPolicy = cnpgv1.DatabaseReclaimDelete
+	}
+	for _, ext := range opts.Extensions {
+		e := cnpgv1.ExtensionSpec{}
+		e.Name = ext.Name
+		if ext.Ensure == "absent" {
+			e.Ensure = cnpgv1.EnsureAbsent
+		} else {
+			e.Ensure = cnpgv1.EnsurePresent
+		}
+		spec.Extensions = append(spec.Extensions, e)
+	}
+	return intcnpg.CreateDatabase(cfg.Name, cfg.Namespace, spec)
+}
+
+// Cluster converts ClusterOptions to a CNPG Cluster object.
+// It returns an error only if ExternalClusters contains an invalid BarmanObjectStore map.
+func Cluster(cfg *ClusterConfig) (*cnpgv1.Cluster, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	opts := cfg.Options
+	if opts == nil {
+		opts = &ClusterOptions{}
+	}
+
+	imageName := opts.ImageName
+	enablePDB := opts.Instances > 1
+	spec := cnpgv1.ClusterSpec{
+		Instances:             int(opts.Instances),
+		ImageName:             imageName,
+		EnablePDB:             &enablePDB,
+		PrimaryUpdateStrategy: cnpgv1.PrimaryUpdateStrategyUnsupervised,
+		StorageConfiguration:  cnpgv1.StorageConfiguration{Size: opts.StorageSize},
+	}
+
+	if len(opts.InheritedLabels) > 0 || len(opts.InheritedAnnotations) > 0 {
+		spec.InheritedMetadata = &cnpgv1.EmbeddedObjectMetadata{
+			Labels:      opts.InheritedLabels,
+			Annotations: opts.InheritedAnnotations,
+		}
+	}
+
+	if opts.Resources != nil {
+		rr, err := buildResourceRequirements(opts.Resources)
+		if err != nil {
+			return nil, err
+		}
+		spec.Resources = rr
+	}
+
+	if opts.Backup != nil && (opts.Backup.DestinationPath != "" || opts.Backup.RetentionPolicy != "") {
+		bos := &barmanApi.BarmanObjectStoreConfiguration{
+			DestinationPath: opts.Backup.DestinationPath,
+			EndpointURL:     opts.Backup.EndpointURL,
+		}
+		if c := opts.Backup.S3Credentials; c != nil && c.SecretName != "" {
+			akKey := c.AccessKeyIDKey
+			if akKey == "" {
+				akKey = "ACCESS_KEY_ID"
+			}
+			sakKey := c.SecretAccessKeyKey
+			if sakKey == "" {
+				sakKey = "SECRET_ACCESS_KEY"
+			}
+			bos.AWS = &barmanApi.S3Credentials{
+				AccessKeyIDReference: &machineryapi.SecretKeySelector{
+					LocalObjectReference: machineryapi.LocalObjectReference{Name: c.SecretName},
+					Key:                  akKey,
+				},
+				SecretAccessKeyReference: &machineryapi.SecretKeySelector{
+					LocalObjectReference: machineryapi.LocalObjectReference{Name: c.SecretName},
+					Key:                  sakKey,
+				},
+			}
+		}
+		spec.Backup = &cnpgv1.BackupConfiguration{
+			RetentionPolicy:   opts.Backup.RetentionPolicy,
+			BarmanObjectStore: bos,
+		}
+	}
+
+	if opts.Monitoring != nil && opts.Monitoring.EnablePodMonitor {
+		mon := &cnpgv1.MonitoringConfiguration{EnablePodMonitor: true}
+		for _, cq := range opts.Monitoring.CustomQueriesConfigMap {
+			mon.CustomQueriesConfigMap = append(mon.CustomQueriesConfigMap, cnpgv1.ConfigMapKeySelector{
+				LocalObjectReference: machineryapi.LocalObjectReference{Name: cq.Name},
+				Key:                  cq.Key,
+			})
+		}
+		spec.Monitoring = mon
+	}
+
+	if opts.Bootstrap != nil {
+		if opts.Bootstrap.RecoverySource != "" {
+			spec.Bootstrap = &cnpgv1.BootstrapConfiguration{
+				Recovery: &cnpgv1.BootstrapRecovery{Source: opts.Bootstrap.RecoverySource},
+			}
+		} else if opts.Bootstrap.PgBasebackupSource != "" {
+			spec.Bootstrap = &cnpgv1.BootstrapConfiguration{
+				PgBaseBackup: &cnpgv1.BootstrapPgBaseBackup{Source: opts.Bootstrap.PgBasebackupSource},
+			}
+		}
+	}
+
+	if len(opts.ExternalClusters) > 0 {
+		extClusters := make([]cnpgv1.ExternalCluster, 0, len(opts.ExternalClusters))
+		for _, ec := range opts.ExternalClusters {
+			extCluster := cnpgv1.ExternalCluster{
+				Name:                 ec.Name,
+				ConnectionParameters: ec.ConnectionParameters,
+			}
+			if ec.BarmanObjectStore != nil {
+				data, err := json.Marshal(ec.BarmanObjectStore)
+				if err != nil {
+					return nil, fmt.Errorf("external cluster %q: marshal barman object store: %w", ec.Name, err)
+				}
+				var bos barmanApi.BarmanObjectStoreConfiguration
+				if err := json.Unmarshal(data, &bos); err != nil {
+					return nil, fmt.Errorf("external cluster %q: unmarshal barman object store: %w", ec.Name, err)
+				}
+				extCluster.BarmanObjectStore = &bos
+			}
+			extClusters = append(extClusters, extCluster)
+		}
+		spec.ExternalClusters = extClusters
+	}
+
+	pgConfig := cnpgv1.PostgresConfiguration{}
+	if len(opts.PostgresParams) > 0 {
+		pgConfig.Parameters = opts.PostgresParams
+	}
+	if opts.Synchronous != nil && opts.Synchronous.Method != "" {
+		sync := &cnpgv1.SynchronousReplicaConfiguration{
+			Method: cnpgv1.SynchronousReplicaConfigurationMethod(opts.Synchronous.Method),
+			Number: int(opts.Synchronous.Number),
+		}
+		if opts.Synchronous.DataDurability != "" {
+			sync.DataDurability = cnpgv1.DataDurabilityLevel(opts.Synchronous.DataDurability)
+		}
+		pgConfig.Synchronous = sync
+	}
+	if pgConfig.Parameters != nil || pgConfig.Synchronous != nil {
+		spec.PostgresConfiguration = pgConfig
+	}
+
+	if opts.ObjectStoreName != "" {
+		isWALArchiver := true
+		spec.Plugins = []cnpgv1.PluginConfiguration{
+			{
+				Name:          "barman-cloud.barmancloud.cnpg.io",
+				IsWALArchiver: &isWALArchiver,
+				Parameters:    map[string]string{"objectStoreName": opts.ObjectStoreName},
+			},
+		}
+	}
+
+	if opts.Affinity != nil {
+		enablePAA := opts.Affinity.EnablePodAntiAffinity
+		spec.Affinity = cnpgv1.AffinityConfiguration{
+			EnablePodAntiAffinity: &enablePAA,
+			TopologyKey:           opts.Affinity.TopologyKey,
+			PodAntiAffinityType:   opts.Affinity.PodAntiAffinityType,
+			NodeSelector:          opts.Affinity.NodeSelector,
+		}
+	}
+
+	if len(opts.ManagedRoles) > 0 {
+		roles := make([]cnpgv1.RoleConfiguration, 0, len(opts.ManagedRoles))
+		for _, role := range opts.ManagedRoles {
+			rc := cnpgv1.RoleConfiguration{
+				Name:        role.Name,
+				Comment:     role.Comment,
+				Login:       role.Login,
+				Superuser:   role.Superuser,
+				CreateDB:    role.CreateDB,
+				CreateRole:  role.CreateRole,
+				Replication: role.Replication,
+				Inherit:     role.Inherit,
+				InRoles:     role.InRoles,
+			}
+			if role.ConnectionLimit != nil {
+				rc.ConnectionLimit = *role.ConnectionLimit
+			}
+			if role.Ensure == "absent" {
+				rc.Ensure = cnpgv1.EnsureAbsent
+			}
+			if role.PasswordSecret != "" {
+				rc.PasswordSecret = &cnpgv1.LocalObjectReference{Name: role.PasswordSecret}
+			}
+			roles = append(roles, rc)
+		}
+		spec.Managed = &cnpgv1.ManagedConfiguration{Roles: roles}
+	}
+
+	return intcnpg.CreateCluster(cfg.Name, cfg.Namespace, spec), nil
 }
 
 // ScheduledBackup converts the config to a CNPG ScheduledBackup object.
@@ -37,4 +277,43 @@ func ScheduledBackup(cfg *ScheduledBackupConfig) *cnpgv1.ScheduledBackup {
 		return nil
 	}
 	return intcnpg.CreateScheduledBackup(cfg.Name, cfg.Namespace, cfg.Spec)
+}
+
+func buildResourceRequirements(r *ResourceOptions) (corev1.ResourceRequirements, error) {
+	rr := corev1.ResourceRequirements{}
+	if r.RequestsCPU != "" || r.RequestsMemory != "" {
+		rr.Requests = corev1.ResourceList{}
+		if r.RequestsCPU != "" {
+			q, err := resource.ParseQuantity(r.RequestsCPU)
+			if err != nil {
+				return rr, fmt.Errorf("invalid cpu request %q: %w", r.RequestsCPU, err)
+			}
+			rr.Requests[corev1.ResourceCPU] = q
+		}
+		if r.RequestsMemory != "" {
+			q, err := resource.ParseQuantity(r.RequestsMemory)
+			if err != nil {
+				return rr, fmt.Errorf("invalid memory request %q: %w", r.RequestsMemory, err)
+			}
+			rr.Requests[corev1.ResourceMemory] = q
+		}
+	}
+	if r.LimitsCPU != "" || r.LimitsMemory != "" {
+		rr.Limits = corev1.ResourceList{}
+		if r.LimitsCPU != "" {
+			q, err := resource.ParseQuantity(r.LimitsCPU)
+			if err != nil {
+				return rr, fmt.Errorf("invalid cpu limit %q: %w", r.LimitsCPU, err)
+			}
+			rr.Limits[corev1.ResourceCPU] = q
+		}
+		if r.LimitsMemory != "" {
+			q, err := resource.ParseQuantity(r.LimitsMemory)
+			if err != nil {
+				return rr, fmt.Errorf("invalid memory limit %q: %w", r.LimitsMemory, err)
+			}
+			rr.Limits[corev1.ResourceMemory] = q
+		}
+	}
+	return rr, nil
 }

--- a/pkg/kubernetes/cnpg/create.go
+++ b/pkg/kubernetes/cnpg/create.go
@@ -2,7 +2,6 @@ package cnpg
 
 import (
 	"encoding/json"
-	"fmt"
 
 	barmanApi "github.com/cloudnative-pg/barman-cloud/pkg/api"
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -12,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	intcnpg "github.com/go-kure/kure/internal/cnpg"
+	"github.com/go-kure/kure/pkg/errors"
 )
 
 // ObjectStore converts ObjectStoreOptions to a Barman Cloud ObjectStore object.
@@ -188,11 +188,11 @@ func Cluster(cfg *ClusterConfig) (*cnpgv1.Cluster, error) {
 			if ec.BarmanObjectStore != nil {
 				data, err := json.Marshal(ec.BarmanObjectStore)
 				if err != nil {
-					return nil, fmt.Errorf("external cluster %q: marshal barman object store: %w", ec.Name, err)
+					return nil, errors.Wrapf(err, "external cluster %q: marshal barman object store", ec.Name)
 				}
 				var bos barmanApi.BarmanObjectStoreConfiguration
 				if err := json.Unmarshal(data, &bos); err != nil {
-					return nil, fmt.Errorf("external cluster %q: unmarshal barman object store: %w", ec.Name, err)
+					return nil, errors.Wrapf(err, "external cluster %q: unmarshal barman object store", ec.Name)
 				}
 				extCluster.BarmanObjectStore = &bos
 			}
@@ -286,14 +286,14 @@ func buildResourceRequirements(r *ResourceOptions) (corev1.ResourceRequirements,
 		if r.RequestsCPU != "" {
 			q, err := resource.ParseQuantity(r.RequestsCPU)
 			if err != nil {
-				return rr, fmt.Errorf("invalid cpu request %q: %w", r.RequestsCPU, err)
+				return rr, errors.Wrapf(err, "invalid cpu request %q", r.RequestsCPU)
 			}
 			rr.Requests[corev1.ResourceCPU] = q
 		}
 		if r.RequestsMemory != "" {
 			q, err := resource.ParseQuantity(r.RequestsMemory)
 			if err != nil {
-				return rr, fmt.Errorf("invalid memory request %q: %w", r.RequestsMemory, err)
+				return rr, errors.Wrapf(err, "invalid memory request %q", r.RequestsMemory)
 			}
 			rr.Requests[corev1.ResourceMemory] = q
 		}
@@ -303,14 +303,14 @@ func buildResourceRequirements(r *ResourceOptions) (corev1.ResourceRequirements,
 		if r.LimitsCPU != "" {
 			q, err := resource.ParseQuantity(r.LimitsCPU)
 			if err != nil {
-				return rr, fmt.Errorf("invalid cpu limit %q: %w", r.LimitsCPU, err)
+				return rr, errors.Wrapf(err, "invalid cpu limit %q", r.LimitsCPU)
 			}
 			rr.Limits[corev1.ResourceCPU] = q
 		}
 		if r.LimitsMemory != "" {
 			q, err := resource.ParseQuantity(r.LimitsMemory)
 			if err != nil {
-				return rr, fmt.Errorf("invalid memory limit %q: %w", r.LimitsMemory, err)
+				return rr, errors.Wrapf(err, "invalid memory limit %q", r.LimitsMemory)
 			}
 			rr.Limits[corev1.ResourceMemory] = q
 		}

--- a/pkg/kubernetes/cnpg/create_test.go
+++ b/pkg/kubernetes/cnpg/create_test.go
@@ -4,18 +4,21 @@ import (
 	"testing"
 
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
-	barmanv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
 )
 
 func TestCluster_Success(t *testing.T) {
-	cfg := &ClusterConfig{
+	obj, err := Cluster(&ClusterConfig{
 		Name:      "pg-main",
 		Namespace: "databases",
-		Spec:      cnpgv1.ClusterSpec{Instances: 3},
+		Options: &ClusterOptions{
+			Instances:   3,
+			ImageName:   "ghcr.io/cloudnative-pg/postgresql:16",
+			StorageSize: "10Gi",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-
-	obj := Cluster(cfg)
-
 	if obj == nil {
 		t.Fatal("expected non-nil Cluster")
 	}
@@ -28,68 +31,181 @@ func TestCluster_Success(t *testing.T) {
 	if obj.Spec.Instances != 3 {
 		t.Errorf("expected Instances 3, got %d", obj.Spec.Instances)
 	}
+	if obj.Spec.StorageConfiguration.Size != "10Gi" {
+		t.Errorf("expected StorageSize '10Gi', got %s", obj.Spec.StorageConfiguration.Size)
+	}
+}
+
+func TestCluster_EnablePDB(t *testing.T) {
+	single, err := Cluster(&ClusterConfig{
+		Name: "pg", Namespace: "ns",
+		Options: &ClusterOptions{Instances: 1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *single.Spec.EnablePDB {
+		t.Error("single-instance cluster should have EnablePDB=false")
+	}
+
+	multi, err := Cluster(&ClusterConfig{
+		Name: "pg", Namespace: "ns",
+		Options: &ClusterOptions{Instances: 3},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !*multi.Spec.EnablePDB {
+		t.Error("multi-instance cluster should have EnablePDB=true")
+	}
+}
+
+func TestCluster_ManagedRoles(t *testing.T) {
+	obj, err := Cluster(&ClusterConfig{
+		Name: "pg", Namespace: "ns",
+		Options: &ClusterOptions{
+			Instances: 1,
+			ManagedRoles: []ManagedRoleOptions{
+				{Name: "app_user", Login: true, PasswordSecret: "app-creds", Comment: "Application user"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if obj.Spec.Managed == nil || len(obj.Spec.Managed.Roles) != 1 {
+		t.Fatal("expected 1 managed role")
+	}
+	role := obj.Spec.Managed.Roles[0]
+	if role.Name != "app_user" || !role.Login || role.Comment != "Application user" {
+		t.Errorf("unexpected role: %+v", role)
+	}
+	if role.PasswordSecret == nil || role.PasswordSecret.Name != "app-creds" {
+		t.Errorf("expected PasswordSecret 'app-creds', got %v", role.PasswordSecret)
+	}
+}
+
+func TestCluster_ObjectStorePlugin(t *testing.T) {
+	obj, err := Cluster(&ClusterConfig{
+		Name: "pg", Namespace: "ns",
+		Options: &ClusterOptions{
+			Instances:       1,
+			ObjectStoreName: "pg-backup",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(obj.Spec.Plugins) != 1 {
+		t.Fatalf("expected 1 plugin, got %d", len(obj.Spec.Plugins))
+	}
+	if obj.Spec.Plugins[0].Parameters["objectStoreName"] != "pg-backup" {
+		t.Errorf("unexpected plugin params: %v", obj.Spec.Plugins[0].Parameters)
+	}
 }
 
 func TestCluster_NilConfig(t *testing.T) {
-	obj := Cluster(nil)
+	obj, err := Cluster(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if obj != nil {
 		t.Error("expected nil result for nil config")
 	}
 }
 
 func TestDatabase_Success(t *testing.T) {
-	cfg := &DatabaseConfig{
-		Name:      "app-db",
+	obj := Database(&DatabaseConfig{
+		Name:      "pg-appdb",
 		Namespace: "databases",
-		Spec:      cnpgv1.DatabaseSpec{Name: "appdb"},
-	}
-
-	obj := Database(cfg)
-
+		Options: &DatabaseOptions{
+			ClusterName: "pg",
+			DBName:      "appdb",
+			Owner:       "app_user",
+		},
+	})
 	if obj == nil {
 		t.Fatal("expected non-nil Database")
 	}
-	if obj.Name != "app-db" {
-		t.Errorf("expected Name 'app-db', got %s", obj.Name)
-	}
-	if obj.Namespace != "databases" {
-		t.Errorf("expected Namespace 'databases', got %s", obj.Namespace)
+	if obj.Name != "pg-appdb" {
+		t.Errorf("expected Name 'pg-appdb', got %s", obj.Name)
 	}
 	if obj.Spec.Name != "appdb" {
 		t.Errorf("expected Spec.Name 'appdb', got %s", obj.Spec.Name)
 	}
+	if obj.Spec.Owner != "app_user" {
+		t.Errorf("expected Owner 'app_user', got %s", obj.Spec.Owner)
+	}
+}
+
+func TestDatabase_Extensions(t *testing.T) {
+	obj := Database(&DatabaseConfig{
+		Name: "pg-db", Namespace: "ns",
+		Options: &DatabaseOptions{
+			ClusterName: "pg",
+			DBName:      "db",
+			Extensions: []ExtensionOptions{
+				{Name: "pg_stat_statements", Ensure: ""},
+				{Name: "pgvector", Ensure: "absent"},
+			},
+		},
+	})
+	if len(obj.Spec.Extensions) != 2 {
+		t.Fatalf("expected 2 extensions, got %d", len(obj.Spec.Extensions))
+	}
+	if obj.Spec.Extensions[0].Ensure != cnpgv1.EnsurePresent {
+		t.Errorf("expected first extension ensure=present, got %s", obj.Spec.Extensions[0].Ensure)
+	}
+	if obj.Spec.Extensions[1].Ensure != cnpgv1.EnsureAbsent {
+		t.Errorf("expected second extension ensure=absent, got %s", obj.Spec.Extensions[1].Ensure)
+	}
 }
 
 func TestDatabase_NilConfig(t *testing.T) {
-	obj := Database(nil)
-	if obj != nil {
+	if Database(nil) != nil {
 		t.Error("expected nil result for nil config")
 	}
 }
 
 func TestObjectStore_Success(t *testing.T) {
-	cfg := &ObjectStoreConfig{
+	obj := ObjectStore(&ObjectStoreConfig{
 		Name:      "backup-store",
 		Namespace: "databases",
-		Spec:      barmanv1.ObjectStoreSpec{},
-	}
-
-	obj := ObjectStore(cfg)
-
+		Options: &ObjectStoreOptions{
+			DestinationPath: "s3://my-bucket/pg/",
+			RetentionPolicy: "30d",
+			SecretName:      "backup-creds",
+		},
+	})
 	if obj == nil {
 		t.Fatal("expected non-nil ObjectStore")
 	}
 	if obj.Name != "backup-store" {
 		t.Errorf("expected Name 'backup-store', got %s", obj.Name)
 	}
-	if obj.Namespace != "databases" {
-		t.Errorf("expected Namespace 'databases', got %s", obj.Namespace)
+	if obj.Spec.Configuration.DestinationPath != "s3://my-bucket/pg/" {
+		t.Errorf("unexpected DestinationPath: %s", obj.Spec.Configuration.DestinationPath)
+	}
+	if obj.Spec.Configuration.AWS == nil {
+		t.Fatal("expected S3 credentials to be set")
+	}
+	if obj.Spec.Configuration.AWS.AccessKeyIDReference.Key != "ACCESS_KEY_ID" {
+		t.Errorf("unexpected access key ID key: %s", obj.Spec.Configuration.AWS.AccessKeyIDReference.Key)
+	}
+}
+
+func TestObjectStore_NoCredentials(t *testing.T) {
+	obj := ObjectStore(&ObjectStoreConfig{
+		Name: "store", Namespace: "ns",
+		Options: &ObjectStoreOptions{DestinationPath: "s3://bucket/path/"},
+	})
+	if obj.Spec.Configuration.AWS != nil {
+		t.Error("expected no S3 credentials when SecretName is empty")
 	}
 }
 
 func TestObjectStore_NilConfig(t *testing.T) {
-	obj := ObjectStore(nil)
-	if obj != nil {
+	if ObjectStore(nil) != nil {
 		t.Error("expected nil result for nil config")
 	}
 }
@@ -109,17 +225,13 @@ func TestScheduledBackup_Success(t *testing.T) {
 	if obj.Name != "daily-backup" {
 		t.Errorf("expected Name 'daily-backup', got %s", obj.Name)
 	}
-	if obj.Namespace != "databases" {
-		t.Errorf("expected Namespace 'databases', got %s", obj.Namespace)
-	}
 	if obj.Spec.Schedule != "0 2 * * *" {
 		t.Errorf("expected Schedule '0 2 * * *', got %s", obj.Spec.Schedule)
 	}
 }
 
 func TestScheduledBackup_NilConfig(t *testing.T) {
-	obj := ScheduledBackup(nil)
-	if obj != nil {
+	if ScheduledBackup(nil) != nil {
 		t.Error("expected nil result for nil config")
 	}
 }

--- a/pkg/kubernetes/cnpg/types.go
+++ b/pkg/kubernetes/cnpg/types.go
@@ -2,31 +2,181 @@ package cnpg
 
 import (
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
-	barmanv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
 )
 
-// ClusterConfig describes a CNPG Cluster resource.
-type ClusterConfig struct {
-	Name      string             `yaml:"name"`
-	Namespace string             `yaml:"namespace"`
-	Spec      cnpgv1.ClusterSpec `yaml:"spec"`
-}
-
-// DatabaseConfig describes a CNPG Database resource.
-type DatabaseConfig struct {
-	Name      string              `yaml:"name"`
-	Namespace string              `yaml:"namespace"`
-	Spec      cnpgv1.DatabaseSpec `yaml:"spec"`
+// ObjectStoreOptions is the domain-friendly input for ObjectStore construction.
+// It covers the S3 credential and destination path fields without exposing
+// barman-cloud or machinery API types to callers.
+type ObjectStoreOptions struct {
+	DestinationPath string
+	EndpointURL     string
+	ServerName      string
+	// SecretName is the K8s secret containing S3 credentials. Empty means no S3 creds.
+	SecretName string
+	// AccessKeyIDKey is the key within SecretName for the access key ID (default "ACCESS_KEY_ID").
+	AccessKeyIDKey string
+	// SecretAccessKeyKey is the key within SecretName for the secret (default "SECRET_ACCESS_KEY").
+	SecretAccessKeyKey string
+	RetentionPolicy    string
 }
 
 // ObjectStoreConfig describes a Barman Cloud ObjectStore resource.
 type ObjectStoreConfig struct {
-	Name      string                   `yaml:"name"`
-	Namespace string                   `yaml:"namespace"`
-	Spec      barmanv1.ObjectStoreSpec `yaml:"spec"`
+	Name      string
+	Namespace string
+	Options   *ObjectStoreOptions
+}
+
+// ExtensionOptions is the domain-friendly input for a single CNPG Database extension.
+type ExtensionOptions struct {
+	Name string
+	// Ensure is "absent" or "" (present).
+	Ensure string
+}
+
+// DatabaseOptions is the domain-friendly input for Database construction.
+type DatabaseOptions struct {
+	ClusterName string
+	DBName      string
+	Owner       string
+	// ReclaimPolicy is "delete" or "" (retain).
+	ReclaimPolicy string
+	// Ensure is "absent" or "" (present).
+	Ensure     string
+	Extensions []ExtensionOptions
+}
+
+// DatabaseConfig describes a CNPG Database resource.
+type DatabaseConfig struct {
+	Name      string
+	Namespace string
+	Options   *DatabaseOptions
+}
+
+// S3CredentialOptions specifies an S3 secret reference for backup.
+type S3CredentialOptions struct {
+	SecretName         string
+	AccessKeyIDKey     string // default "ACCESS_KEY_ID"
+	SecretAccessKeyKey string // default "SECRET_ACCESS_KEY"
+}
+
+// BackupOptions configures the inline barmanObjectStore backup on a Cluster.
+type BackupOptions struct {
+	DestinationPath string
+	EndpointURL     string
+	RetentionPolicy string
+	S3Credentials   *S3CredentialOptions
+}
+
+// ResourceOptions holds CPU/memory requests and limits as quantity strings (e.g. "500m", "1Gi").
+type ResourceOptions struct {
+	RequestsCPU    string
+	RequestsMemory string
+	LimitsCPU      string
+	LimitsMemory   string
+}
+
+// ConfigMapKeyRefOptions references a key in a ConfigMap.
+type ConfigMapKeyRefOptions struct {
+	Name string
+	Key  string
+}
+
+// MonitoringOptions configures the CNPG Cluster monitoring section.
+type MonitoringOptions struct {
+	EnablePodMonitor       bool
+	CustomQueriesConfigMap []ConfigMapKeyRefOptions
+}
+
+// BootstrapOptions configures the CNPG Cluster bootstrap section.
+// At most one of RecoverySource or PgBasebackupSource may be set.
+type BootstrapOptions struct {
+	RecoverySource     string
+	PgBasebackupSource string
+}
+
+// SynchronousOptions configures synchronous replication on a Cluster.
+type SynchronousOptions struct {
+	Method          string // e.g. "any" or "first"
+	Number          int32
+	DataDurability  string // "required" or "preferred"
+	MaxStandbyDelay int32
+}
+
+// AffinityOptions configures pod and node affinity/anti-affinity on a Cluster.
+type AffinityOptions struct {
+	EnablePodAntiAffinity bool
+	TopologyKey           string
+	PodAntiAffinityType   string
+	NodeSelector          map[string]string
+}
+
+// ManagedRoleOptions configures a single entry in spec.managed.roles[].
+type ManagedRoleOptions struct {
+	Name     string
+	Comment  string
+	Login    bool
+	Superuser bool
+	CreateDB  bool
+	CreateRole bool
+	Replication bool
+	// Inherit nil means omit (CNPG defaults to true).
+	Inherit         *bool
+	// ConnectionLimit nil means omit (CNPG defaults to -1).
+	ConnectionLimit *int64
+	PasswordSecret  string
+	InRoles         []string
+	// Ensure is "absent" or "" (present).
+	Ensure string
+}
+
+// ExternalClusterOptions defines an external cluster for bootstrap or replica sources.
+// BarmanObjectStore is passed as a map and translated via JSON round-trip to avoid
+// exposing barman-cloud types to callers.
+type ExternalClusterOptions struct {
+	Name                 string
+	ConnectionParameters map[string]string
+	BarmanObjectStore    map[string]any
+}
+
+// ClusterOptions is the domain-friendly input for Cluster construction.
+// It covers all fields used by crane's postgresql component handler without
+// exposing cnpgv1, barmanApi, or machinery API types to callers.
+type ClusterOptions struct {
+	Instances   int32
+	ImageName   string
+	StorageSize string // e.g. "10Gi"; stored as string, matches cnpgv1.StorageConfiguration.Size
+
+	InheritedLabels      map[string]string
+	InheritedAnnotations map[string]string
+
+	Resources *ResourceOptions
+	Backup    *BackupOptions
+	Monitoring *MonitoringOptions
+	Bootstrap  *BootstrapOptions
+
+	ExternalClusters []ExternalClusterOptions
+
+	PostgresParams map[string]string
+	Synchronous    *SynchronousOptions
+
+	// ObjectStoreName non-empty adds the barman-cloud WAL archiver plugin entry.
+	ObjectStoreName string
+
+	Affinity     *AffinityOptions
+	ManagedRoles []ManagedRoleOptions
+}
+
+// ClusterConfig describes a CNPG Cluster resource.
+type ClusterConfig struct {
+	Name      string
+	Namespace string
+	Options   *ClusterOptions
 }
 
 // ScheduledBackupConfig describes a CNPG ScheduledBackup resource.
+// It retains the raw spec type since crane does not use it; promoting it to
+// domain types is deferred until there is a concrete caller.
 type ScheduledBackupConfig struct {
 	Name      string                     `yaml:"name"`
 	Namespace string                     `yaml:"namespace"`

--- a/pkg/kubernetes/cnpg/types.go
+++ b/pkg/kubernetes/cnpg/types.go
@@ -113,15 +113,15 @@ type AffinityOptions struct {
 
 // ManagedRoleOptions configures a single entry in spec.managed.roles[].
 type ManagedRoleOptions struct {
-	Name     string
-	Comment  string
-	Login    bool
-	Superuser bool
-	CreateDB  bool
-	CreateRole bool
+	Name        string
+	Comment     string
+	Login       bool
+	Superuser   bool
+	CreateDB    bool
+	CreateRole  bool
 	Replication bool
 	// Inherit nil means omit (CNPG defaults to true).
-	Inherit         *bool
+	Inherit *bool
 	// ConnectionLimit nil means omit (CNPG defaults to -1).
 	ConnectionLimit *int64
 	PasswordSecret  string
@@ -150,8 +150,8 @@ type ClusterOptions struct {
 	InheritedLabels      map[string]string
 	InheritedAnnotations map[string]string
 
-	Resources *ResourceOptions
-	Backup    *BackupOptions
+	Resources  *ResourceOptions
+	Backup     *BackupOptions
 	Monitoring *MonitoringOptions
 	Bootstrap  *BootstrapOptions
 

--- a/pkg/kubernetes/cnpg/update_test.go
+++ b/pkg/kubernetes/cnpg/update_test.go
@@ -7,11 +7,19 @@ import (
 
 	barmanapi "github.com/cloudnative-pg/barman-cloud/pkg/api"
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
-	barmanv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
 )
 
+func mustCluster(t *testing.T, cfg *ClusterConfig) *cnpgv1.Cluster {
+	t.Helper()
+	obj, err := Cluster(cfg)
+	if err != nil {
+		t.Fatalf("Cluster: unexpected error: %v", err)
+	}
+	return obj
+}
+
 func TestAddClusterLabel(t *testing.T) {
-	obj := Cluster(&ClusterConfig{Name: "pg", Namespace: "db", Spec: cnpgv1.ClusterSpec{}})
+	obj := mustCluster(t, &ClusterConfig{Name: "pg", Namespace: "db", Options: &ClusterOptions{}})
 	AddClusterLabel(obj, "env", "prod")
 	if obj.Labels["env"] != "prod" {
 		t.Error("expected label 'env' to be 'prod'")
@@ -19,7 +27,7 @@ func TestAddClusterLabel(t *testing.T) {
 }
 
 func TestAddClusterAnnotation(t *testing.T) {
-	obj := Cluster(&ClusterConfig{Name: "pg", Namespace: "db", Spec: cnpgv1.ClusterSpec{}})
+	obj := mustCluster(t, &ClusterConfig{Name: "pg", Namespace: "db", Options: &ClusterOptions{}})
 	AddClusterAnnotation(obj, "note", "value")
 	if obj.Annotations["note"] != "value" {
 		t.Error("expected annotation 'note' to be 'value'")
@@ -27,7 +35,7 @@ func TestAddClusterAnnotation(t *testing.T) {
 }
 
 func TestAddClusterManagedRole(t *testing.T) {
-	obj := Cluster(&ClusterConfig{Name: "pg", Namespace: "db", Spec: cnpgv1.ClusterSpec{}})
+	obj := mustCluster(t, &ClusterConfig{Name: "pg", Namespace: "db", Options: &ClusterOptions{}})
 	role := cnpgv1.RoleConfiguration{Name: "app"}
 	AddClusterManagedRole(obj, role)
 	if len(obj.Spec.Managed.Roles) != 1 {
@@ -39,7 +47,7 @@ func TestAddClusterManagedRole(t *testing.T) {
 }
 
 func TestAddDatabaseLabel(t *testing.T) {
-	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Spec: cnpgv1.DatabaseSpec{}})
+	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Options: &DatabaseOptions{}})
 	AddDatabaseLabel(obj, "env", "prod")
 	if obj.Labels["env"] != "prod" {
 		t.Error("expected label 'env' to be 'prod'")
@@ -47,7 +55,7 @@ func TestAddDatabaseLabel(t *testing.T) {
 }
 
 func TestAddDatabaseAnnotation(t *testing.T) {
-	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Spec: cnpgv1.DatabaseSpec{}})
+	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Options: &DatabaseOptions{}})
 	AddDatabaseAnnotation(obj, "note", "value")
 	if obj.Annotations["note"] != "value" {
 		t.Error("expected annotation 'note' to be 'value'")
@@ -55,7 +63,7 @@ func TestAddDatabaseAnnotation(t *testing.T) {
 }
 
 func TestAddDatabaseExtension(t *testing.T) {
-	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Spec: cnpgv1.DatabaseSpec{}})
+	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Options: &DatabaseOptions{}})
 	ext := cnpgv1.ExtensionSpec{DatabaseObjectSpec: cnpgv1.DatabaseObjectSpec{Name: "pgcrypto"}}
 	AddDatabaseExtension(obj, ext)
 	if len(obj.Spec.Extensions) != 1 {
@@ -67,7 +75,7 @@ func TestAddDatabaseExtension(t *testing.T) {
 }
 
 func TestSetDatabaseClusterRef(t *testing.T) {
-	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Spec: cnpgv1.DatabaseSpec{}})
+	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Options: &DatabaseOptions{}})
 	SetDatabaseClusterRef(obj, "pg-main")
 	if obj.Spec.ClusterRef.Name != "pg-main" {
 		t.Errorf("expected cluster ref 'pg-main', got %s", obj.Spec.ClusterRef.Name)
@@ -75,7 +83,7 @@ func TestSetDatabaseClusterRef(t *testing.T) {
 }
 
 func TestSetDatabaseOwner(t *testing.T) {
-	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Spec: cnpgv1.DatabaseSpec{}})
+	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Options: &DatabaseOptions{}})
 	SetDatabaseOwner(obj, "appuser")
 	if obj.Spec.Owner != "appuser" {
 		t.Errorf("expected owner 'appuser', got %s", obj.Spec.Owner)
@@ -83,7 +91,7 @@ func TestSetDatabaseOwner(t *testing.T) {
 }
 
 func TestSetDatabaseReclaimPolicy(t *testing.T) {
-	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Spec: cnpgv1.DatabaseSpec{}})
+	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Options: &DatabaseOptions{}})
 	SetDatabaseReclaimPolicy(obj, cnpgv1.DatabaseReclaimDelete)
 	if obj.Spec.ReclaimPolicy != cnpgv1.DatabaseReclaimDelete {
 		t.Errorf("expected reclaim policy Delete, got %s", obj.Spec.ReclaimPolicy)
@@ -91,7 +99,7 @@ func TestSetDatabaseReclaimPolicy(t *testing.T) {
 }
 
 func TestSetDatabaseEnsure(t *testing.T) {
-	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Spec: cnpgv1.DatabaseSpec{}})
+	obj := Database(&DatabaseConfig{Name: "db", Namespace: "ns", Options: &DatabaseOptions{}})
 	SetDatabaseEnsure(obj, cnpgv1.EnsurePresent)
 	if obj.Spec.Ensure != cnpgv1.EnsurePresent {
 		t.Errorf("expected ensure Present, got %s", obj.Spec.Ensure)
@@ -99,7 +107,7 @@ func TestSetDatabaseEnsure(t *testing.T) {
 }
 
 func TestAddObjectStoreLabel(t *testing.T) {
-	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Spec: barmanv1.ObjectStoreSpec{}})
+	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Options: &ObjectStoreOptions{}})
 	AddObjectStoreLabel(obj, "env", "prod")
 	if obj.Labels["env"] != "prod" {
 		t.Error("expected label 'env' to be 'prod'")
@@ -107,7 +115,7 @@ func TestAddObjectStoreLabel(t *testing.T) {
 }
 
 func TestAddObjectStoreAnnotation(t *testing.T) {
-	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Spec: barmanv1.ObjectStoreSpec{}})
+	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Options: &ObjectStoreOptions{}})
 	AddObjectStoreAnnotation(obj, "note", "value")
 	if obj.Annotations["note"] != "value" {
 		t.Error("expected annotation 'note' to be 'value'")
@@ -115,7 +123,7 @@ func TestAddObjectStoreAnnotation(t *testing.T) {
 }
 
 func TestAddObjectStoreEnvVar(t *testing.T) {
-	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Spec: barmanv1.ObjectStoreSpec{}})
+	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Options: &ObjectStoreOptions{}})
 	env := corev1.EnvVar{Name: "AWS_REGION", Value: "us-east-1"}
 	AddObjectStoreEnvVar(obj, env)
 	if len(obj.Spec.InstanceSidecarConfiguration.Env) != 1 {
@@ -127,7 +135,7 @@ func TestAddObjectStoreEnvVar(t *testing.T) {
 }
 
 func TestSetObjectStoreDestinationPath(t *testing.T) {
-	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Spec: barmanv1.ObjectStoreSpec{}})
+	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Options: &ObjectStoreOptions{}})
 	SetObjectStoreDestinationPath(obj, "s3://my-bucket/backups")
 	if obj.Spec.Configuration.DestinationPath != "s3://my-bucket/backups" {
 		t.Errorf("expected DestinationPath 's3://my-bucket/backups', got %s", obj.Spec.Configuration.DestinationPath)
@@ -135,7 +143,7 @@ func TestSetObjectStoreDestinationPath(t *testing.T) {
 }
 
 func TestSetObjectStoreEndpointURL(t *testing.T) {
-	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Spec: barmanv1.ObjectStoreSpec{}})
+	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Options: &ObjectStoreOptions{}})
 	SetObjectStoreEndpointURL(obj, "https://s3.example.com")
 	if obj.Spec.Configuration.EndpointURL != "https://s3.example.com" {
 		t.Errorf("expected EndpointURL 'https://s3.example.com', got %s", obj.Spec.Configuration.EndpointURL)
@@ -143,7 +151,7 @@ func TestSetObjectStoreEndpointURL(t *testing.T) {
 }
 
 func TestSetObjectStoreS3Credentials(t *testing.T) {
-	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Spec: barmanv1.ObjectStoreSpec{}})
+	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Options: &ObjectStoreOptions{}})
 	creds := &barmanapi.S3Credentials{}
 	SetObjectStoreS3Credentials(obj, creds)
 	if obj.Spec.Configuration.AWS == nil {
@@ -152,7 +160,7 @@ func TestSetObjectStoreS3Credentials(t *testing.T) {
 }
 
 func TestSetObjectStoreRetentionPolicy(t *testing.T) {
-	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Spec: barmanv1.ObjectStoreSpec{}})
+	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Options: &ObjectStoreOptions{}})
 	SetObjectStoreRetentionPolicy(obj, "30d")
 	if obj.Spec.RetentionPolicy != "30d" {
 		t.Errorf("expected RetentionPolicy '30d', got %s", obj.Spec.RetentionPolicy)
@@ -160,7 +168,7 @@ func TestSetObjectStoreRetentionPolicy(t *testing.T) {
 }
 
 func TestSetObjectStoreWalConfig(t *testing.T) {
-	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Spec: barmanv1.ObjectStoreSpec{}})
+	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Options: &ObjectStoreOptions{}})
 	wal := &barmanapi.WalBackupConfiguration{Compression: barmanapi.CompressionTypeGzip}
 	SetObjectStoreWalConfig(obj, wal)
 	if obj.Spec.Configuration.Wal == nil {
@@ -172,7 +180,7 @@ func TestSetObjectStoreWalConfig(t *testing.T) {
 }
 
 func TestSetObjectStoreDataConfig(t *testing.T) {
-	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Spec: barmanv1.ObjectStoreSpec{}})
+	obj := ObjectStore(&ObjectStoreConfig{Name: "store", Namespace: "ns", Options: &ObjectStoreOptions{}})
 	data := &barmanapi.DataBackupConfiguration{Compression: barmanapi.CompressionTypeGzip}
 	SetObjectStoreDataConfig(obj, data)
 	if obj.Spec.Configuration.Data == nil {


### PR DESCRIPTION
Closes #491

## Summary

- Replaces raw `cnpgv1.ClusterSpec`/`DatabaseSpec`/`barmanv1.ObjectStoreSpec` pass-throughs in `ClusterConfig`/`DatabaseConfig`/`ObjectStoreConfig` with crane-friendly domain types
- Adds `ClusterOptions`, `DatabaseOptions`, `ObjectStoreOptions` and sub-types
- Moves spec construction logic into the builder functions (follows volsync pattern)
- `ScheduledBackupConfig` retains raw `Spec` — no caller-driven use case yet

## Result

Callers import only `pkg/kubernetes/cnpg`; upstream CNPG packages become indirect.

## Test plan

- [x] All existing `pkg/kubernetes/cnpg` tests updated and passing
- [x] New tests added for common scenarios
- [x] crane's `postgresql.go` compiles and all golden file tests pass against this branch