### PR TITLE
feat(kubernetes): promote ConfigMap builder to public API

### DIFF
--- a/pkg/kubernetes/README.md
+++ b/pkg/kubernetes/README.md
@@ -266,6 +266,32 @@ pm := prometheus.CreatePodMonitor("my-app", "monitoring")
 rule := prometheus.CreatePrometheusRule("alerts", "monitoring")
 ```
 
+## ConfigMap Builders
+
+```go
+// Create a ConfigMap
+cm := kubernetes.CreateConfigMap("my-config", "default")
+
+// Add or replace string data
+kubernetes.AddConfigMapData(cm, "key", "value")
+kubernetes.AddConfigMapDataMap(cm, map[string]string{"a": "1", "b": "2"})
+kubernetes.SetConfigMapData(cm, map[string]string{"x": "y"})
+
+// Add or replace binary data
+kubernetes.AddConfigMapBinaryData(cm, "cert", certBytes)
+kubernetes.AddConfigMapBinaryDataMap(cm, map[string][]byte{"p12": p12Bytes})
+kubernetes.SetConfigMapBinaryData(cm, map[string][]byte{"tls.key": keyBytes})
+
+// Mark as immutable
+kubernetes.SetConfigMapImmutable(cm, true)
+
+// Update metadata
+kubernetes.AddConfigMapLabel(cm, "env", "prod")
+kubernetes.AddConfigMapAnnotation(cm, "owner", "platform")
+kubernetes.SetConfigMapLabels(cm, map[string]string{"app": "my-config"})
+kubernetes.SetConfigMapAnnotations(cm, map[string]string{"managed-by": "crane"})
+```
+
 ## Related Packages
 
 - [fluxcd](/api-reference/fluxcd-builders/) - FluxCD resource constructors

--- a/pkg/kubernetes/configmap.go
+++ b/pkg/kubernetes/configmap.go
@@ -1,3 +1,5 @@
+// Package kubernetes exposes ConfigMap builders that delegate to internal/kubernetes,
+// keeping the implementation in one place while providing the public API.
 package kubernetes
 
 import (

--- a/pkg/kubernetes/configmap.go
+++ b/pkg/kubernetes/configmap.go
@@ -1,0 +1,67 @@
+package kubernetes
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	intk8s "github.com/go-kure/kure/internal/kubernetes"
+)
+
+// CreateConfigMap returns a basic ConfigMap object with common metadata preset.
+func CreateConfigMap(name, namespace string) *corev1.ConfigMap {
+	return intk8s.CreateConfigMap(name, namespace)
+}
+
+// AddConfigMapData inserts a single key/value pair into the ConfigMap's Data field.
+func AddConfigMapData(cm *corev1.ConfigMap, key, value string) {
+	intk8s.AddConfigMapData(cm, key, value)
+}
+
+// AddConfigMapDataMap merges all entries from the provided map into the ConfigMap's Data field.
+func AddConfigMapDataMap(cm *corev1.ConfigMap, data map[string]string) {
+	intk8s.AddConfigMapDataMap(cm, data)
+}
+
+// AddConfigMapBinaryData inserts a single binary entry into the ConfigMap.
+func AddConfigMapBinaryData(cm *corev1.ConfigMap, key string, value []byte) {
+	intk8s.AddConfigMapBinaryData(cm, key, value)
+}
+
+// AddConfigMapBinaryDataMap merges all binary entries into the ConfigMap's BinaryData field.
+func AddConfigMapBinaryDataMap(cm *corev1.ConfigMap, data map[string][]byte) {
+	intk8s.AddConfigMapBinaryDataMap(cm, data)
+}
+
+// SetConfigMapData replaces the ConfigMap's Data map entirely.
+func SetConfigMapData(cm *corev1.ConfigMap, data map[string]string) {
+	intk8s.SetConfigMapData(cm, data)
+}
+
+// SetConfigMapBinaryData replaces the ConfigMap's BinaryData map entirely.
+func SetConfigMapBinaryData(cm *corev1.ConfigMap, data map[string][]byte) {
+	intk8s.SetConfigMapBinaryData(cm, data)
+}
+
+// SetConfigMapImmutable sets the immutable field for the ConfigMap.
+func SetConfigMapImmutable(cm *corev1.ConfigMap, immutable bool) {
+	intk8s.SetConfigMapImmutable(cm, immutable)
+}
+
+// AddConfigMapLabel adds a label to the ConfigMap.
+func AddConfigMapLabel(cm *corev1.ConfigMap, key, value string) {
+	intk8s.AddConfigMapLabel(cm, key, value)
+}
+
+// AddConfigMapAnnotation adds an annotation to the ConfigMap.
+func AddConfigMapAnnotation(cm *corev1.ConfigMap, key, value string) {
+	intk8s.AddConfigMapAnnotation(cm, key, value)
+}
+
+// SetConfigMapLabels replaces all labels on the ConfigMap.
+func SetConfigMapLabels(cm *corev1.ConfigMap, labels map[string]string) {
+	intk8s.SetConfigMapLabels(cm, labels)
+}
+
+// SetConfigMapAnnotations replaces all annotations on the ConfigMap.
+func SetConfigMapAnnotations(cm *corev1.ConfigMap, anns map[string]string) {
+	intk8s.SetConfigMapAnnotations(cm, anns)
+}

--- a/pkg/kubernetes/configmap_test.go
+++ b/pkg/kubernetes/configmap_test.go
@@ -1,0 +1,144 @@
+package kubernetes_test
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	kubernetes "github.com/go-kure/kure/pkg/kubernetes"
+)
+
+func TestCreateConfigMap(t *testing.T) {
+	cm := kubernetes.CreateConfigMap("cm", "ns")
+	if cm == nil {
+		t.Fatal("expected non-nil ConfigMap")
+	}
+	if cm.Name != "cm" || cm.Namespace != "ns" {
+		t.Fatalf("metadata mismatch: %s/%s", cm.Namespace, cm.Name)
+	}
+	if cm.Kind != "ConfigMap" {
+		t.Errorf("unexpected kind %q", cm.Kind)
+	}
+	if cm.APIVersion != corev1.SchemeGroupVersion.String() {
+		t.Errorf("unexpected apiVersion %q", cm.APIVersion)
+	}
+	if len(cm.Data) != 0 {
+		t.Errorf("expected empty data map")
+	}
+	if len(cm.BinaryData) != 0 {
+		t.Errorf("expected empty binary data map")
+	}
+}
+
+func TestAddConfigMapData(t *testing.T) {
+	cm := kubernetes.CreateConfigMap("cm", "ns")
+
+	kubernetes.AddConfigMapData(cm, "key", "val")
+	if cm.Data["key"] != "val" {
+		t.Errorf("AddConfigMapData: expected 'val', got %q", cm.Data["key"])
+	}
+}
+
+func TestAddConfigMapDataMap(t *testing.T) {
+	cm := kubernetes.CreateConfigMap("cm", "ns")
+
+	more := map[string]string{"a": "b", "c": "d"}
+	kubernetes.AddConfigMapDataMap(cm, more)
+	for k, v := range more {
+		if cm.Data[k] != v {
+			t.Errorf("AddConfigMapDataMap: missing key %s", k)
+		}
+	}
+}
+
+func TestSetConfigMapData(t *testing.T) {
+	cm := kubernetes.CreateConfigMap("cm", "ns")
+	kubernetes.AddConfigMapData(cm, "old", "value")
+
+	newData := map[string]string{"x": "y"}
+	kubernetes.SetConfigMapData(cm, newData)
+	if !reflect.DeepEqual(cm.Data, newData) {
+		t.Errorf("SetConfigMapData: got %+v", cm.Data)
+	}
+}
+
+func TestAddConfigMapBinaryData(t *testing.T) {
+	cm := kubernetes.CreateConfigMap("cm", "ns")
+
+	kubernetes.AddConfigMapBinaryData(cm, "bin", []byte{1, 2})
+	if !reflect.DeepEqual(cm.BinaryData["bin"], []byte{1, 2}) {
+		t.Errorf("AddConfigMapBinaryData: unexpected value")
+	}
+}
+
+func TestAddConfigMapBinaryDataMap(t *testing.T) {
+	cm := kubernetes.CreateConfigMap("cm", "ns")
+
+	more := map[string][]byte{"b1": {2, 3}, "b2": {4}}
+	kubernetes.AddConfigMapBinaryDataMap(cm, more)
+	for k, v := range more {
+		if !reflect.DeepEqual(cm.BinaryData[k], v) {
+			t.Errorf("AddConfigMapBinaryDataMap: missing key %s", k)
+		}
+	}
+}
+
+func TestSetConfigMapBinaryData(t *testing.T) {
+	cm := kubernetes.CreateConfigMap("cm", "ns")
+	kubernetes.AddConfigMapBinaryData(cm, "old", []byte{0})
+
+	newData := map[string][]byte{"x": {9}}
+	kubernetes.SetConfigMapBinaryData(cm, newData)
+	if !reflect.DeepEqual(cm.BinaryData, newData) {
+		t.Errorf("SetConfigMapBinaryData: got %+v", cm.BinaryData)
+	}
+}
+
+func TestSetConfigMapImmutable(t *testing.T) {
+	cm := kubernetes.CreateConfigMap("cm", "ns")
+
+	kubernetes.SetConfigMapImmutable(cm, true)
+	if cm.Immutable == nil || !*cm.Immutable {
+		t.Errorf("SetConfigMapImmutable: expected true")
+	}
+
+	kubernetes.SetConfigMapImmutable(cm, false)
+	if cm.Immutable == nil || *cm.Immutable {
+		t.Errorf("SetConfigMapImmutable: expected false")
+	}
+}
+
+func TestAddConfigMapLabel(t *testing.T) {
+	cm := kubernetes.CreateConfigMap("cm", "ns")
+	kubernetes.AddConfigMapLabel(cm, "env", "prod")
+	if cm.Labels["env"] != "prod" {
+		t.Errorf("AddConfigMapLabel: label not set")
+	}
+}
+
+func TestAddConfigMapAnnotation(t *testing.T) {
+	cm := kubernetes.CreateConfigMap("cm", "ns")
+	kubernetes.AddConfigMapAnnotation(cm, "owner", "team")
+	if cm.Annotations["owner"] != "team" {
+		t.Errorf("AddConfigMapAnnotation: annotation not set")
+	}
+}
+
+func TestSetConfigMapLabels(t *testing.T) {
+	cm := kubernetes.CreateConfigMap("cm", "ns")
+	labels := map[string]string{"x": "y"}
+	kubernetes.SetConfigMapLabels(cm, labels)
+	if !reflect.DeepEqual(cm.Labels, labels) {
+		t.Errorf("SetConfigMapLabels: got %+v", cm.Labels)
+	}
+}
+
+func TestSetConfigMapAnnotations(t *testing.T) {
+	cm := kubernetes.CreateConfigMap("cm", "ns")
+	anns := map[string]string{"c": "d"}
+	kubernetes.SetConfigMapAnnotations(cm, anns)
+	if !reflect.DeepEqual(cm.Annotations, anns) {
+		t.Errorf("SetConfigMapAnnotations: got %+v", cm.Annotations)
+	}
+}

--- a/pkg/kubernetes/configmap_test.go
+++ b/pkg/kubernetes/configmap_test.go
@@ -23,6 +23,12 @@ func TestCreateConfigMap(t *testing.T) {
 	if cm.APIVersion != corev1.SchemeGroupVersion.String() {
 		t.Errorf("unexpected apiVersion %q", cm.APIVersion)
 	}
+	if cm.Labels["app"] != "cm" {
+		t.Errorf("expected default label app=cm, got %q", cm.Labels["app"])
+	}
+	if cm.Annotations["app"] != "cm" {
+		t.Errorf("expected default annotation app=cm, got %q", cm.Annotations["app"])
+	}
 	if len(cm.Data) != 0 {
 		t.Errorf("expected empty data map")
 	}


### PR DESCRIPTION
## Summary
- Promotes `CreateConfigMap` and all associated setters/adders from `internal/kubernetes` to `pkg/kubernetes`
- Delegates public functions to the existing internal implementation (no code duplication)
- Enables crane to replace raw `unstructured.Unstructured` ConfigMap construction with typed builders

## Test plan
- [x] `make precommit` passes (tidy + lint + test)
- [x] Public API tests cover `CreateConfigMap`, `AddConfigMapData`, `AddConfigMapDataMap`, `AddConfigMapBinaryData`, `AddConfigMapBinaryDataMap`, `SetConfigMapData`, `SetConfigMapBinaryData`, `SetConfigMapImmutable`, `AddConfigMapLabel`, `AddConfigMapAnnotation`, `SetConfigMapLabels`, `SetConfigMapAnnotations`
- [x] Delegation verified (public functions call internal)
- [x] README updated with ConfigMap builder section

Closes #495