### PR TITLE
feat(kubernetes/externalsecrets): add SetRefreshInterval, SetTarget, AddDataFrom

### DIFF
--- a/internal/externalsecrets/update.go
+++ b/internal/externalsecrets/update.go
@@ -1,0 +1,21 @@
+package externalsecrets
+
+import (
+	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SetRefreshInterval sets the polling interval on an ExternalSecret.
+func SetRefreshInterval(obj *esv1.ExternalSecret, d metav1.Duration) {
+	obj.Spec.RefreshInterval = &d
+}
+
+// SetTarget sets the target secret configuration on an ExternalSecret.
+func SetTarget(obj *esv1.ExternalSecret, target esv1.ExternalSecretTarget) {
+	obj.Spec.Target = target
+}
+
+// AddDataFrom appends a dataFrom source to an ExternalSecret.
+func AddDataFrom(obj *esv1.ExternalSecret, source esv1.ExternalSecretDataFromRemoteRef) {
+	obj.Spec.DataFrom = append(obj.Spec.DataFrom, source)
+}

--- a/pkg/kubernetes/externalsecrets/update.go
+++ b/pkg/kubernetes/externalsecrets/update.go
@@ -2,6 +2,7 @@ package externalsecrets
 
 import (
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	intes "github.com/go-kure/kure/internal/externalsecrets"
 )
@@ -79,4 +80,19 @@ func SetClusterSecretStoreProvider(obj *esv1.ClusterSecretStore, provider *esv1.
 // SetClusterSecretStoreController delegates to the internal helper.
 func SetClusterSecretStoreController(obj *esv1.ClusterSecretStore, controller string) {
 	intes.SetClusterSecretStoreController(obj, controller)
+}
+
+// SetRefreshInterval sets the polling interval on an ExternalSecret.
+func SetRefreshInterval(obj *esv1.ExternalSecret, d metav1.Duration) {
+	intes.SetRefreshInterval(obj, d)
+}
+
+// SetTarget sets the target secret configuration on an ExternalSecret.
+func SetTarget(obj *esv1.ExternalSecret, target esv1.ExternalSecretTarget) {
+	intes.SetTarget(obj, target)
+}
+
+// AddDataFrom appends a dataFrom source to an ExternalSecret.
+func AddDataFrom(obj *esv1.ExternalSecret, source esv1.ExternalSecretDataFromRemoteRef) {
+	intes.AddDataFrom(obj, source)
 }

--- a/pkg/kubernetes/externalsecrets/update_test.go
+++ b/pkg/kubernetes/externalsecrets/update_test.go
@@ -2,8 +2,10 @@ package externalsecrets
 
 import (
 	"testing"
+	"time"
 
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestSetExternalSecretSpec(t *testing.T) {
@@ -244,5 +246,74 @@ func TestSetClusterSecretStoreController(t *testing.T) {
 
 	if css.Spec.Controller != "global" {
 		t.Errorf("expected Controller 'global', got %s", css.Spec.Controller)
+	}
+}
+
+func TestSetRefreshInterval(t *testing.T) {
+	es := ExternalSecret(&ExternalSecretConfig{
+		Name:      "test",
+		Namespace: "default",
+	})
+
+	d := metav1.Duration{Duration: 5 * time.Minute}
+	SetRefreshInterval(es, d)
+
+	if es.Spec.RefreshInterval == nil {
+		t.Fatal("expected non-nil RefreshInterval")
+	}
+	if es.Spec.RefreshInterval.Duration != 5*time.Minute {
+		t.Errorf("expected 5m, got %s", es.Spec.RefreshInterval.Duration)
+	}
+}
+
+func TestSetTarget(t *testing.T) {
+	es := ExternalSecret(&ExternalSecretConfig{
+		Name:      "test",
+		Namespace: "default",
+	})
+
+	target := esv1.ExternalSecretTarget{
+		Name:           "my-secret",
+		CreationPolicy: esv1.CreatePolicyOwner,
+	}
+	SetTarget(es, target)
+
+	if es.Spec.Target.Name != "my-secret" {
+		t.Errorf("expected Target.Name 'my-secret', got %s", es.Spec.Target.Name)
+	}
+	if es.Spec.Target.CreationPolicy != esv1.CreatePolicyOwner {
+		t.Errorf("expected CreationPolicy 'Owner', got %s", es.Spec.Target.CreationPolicy)
+	}
+}
+
+func TestAddDataFrom(t *testing.T) {
+	es := ExternalSecret(&ExternalSecretConfig{
+		Name:      "test",
+		Namespace: "default",
+	})
+
+	source := esv1.ExternalSecretDataFromRemoteRef{
+		Extract: &esv1.ExternalSecretDataRemoteRef{
+			Key: "secret/all",
+		},
+	}
+	AddDataFrom(es, source)
+
+	if len(es.Spec.DataFrom) != 1 {
+		t.Fatalf("expected 1 DataFrom entry, got %d", len(es.Spec.DataFrom))
+	}
+	if es.Spec.DataFrom[0].Extract == nil || es.Spec.DataFrom[0].Extract.Key != "secret/all" {
+		t.Errorf("unexpected DataFrom[0]: %+v", es.Spec.DataFrom[0])
+	}
+
+	// Verify append behaviour: second call adds another entry.
+	source2 := esv1.ExternalSecretDataFromRemoteRef{
+		Extract: &esv1.ExternalSecretDataRemoteRef{
+			Key: "secret/other",
+		},
+	}
+	AddDataFrom(es, source2)
+	if len(es.Spec.DataFrom) != 2 {
+		t.Fatalf("expected 2 DataFrom entries after second append, got %d", len(es.Spec.DataFrom))
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `SetRefreshInterval(obj, metav1.Duration)` to set `spec.refreshInterval` on an ExternalSecret
- Adds `SetTarget(obj, esv1.ExternalSecretTarget)` to set `spec.target` (name, creationPolicy, deletionPolicy)
- Adds `AddDataFrom(obj, esv1.ExternalSecretDataFromRemoteRef)` to append entries to `spec.dataFrom`

These enable crane (and other consumers) to build ExternalSecrets incrementally with typed setters instead of direct field mutations. The existing bulk `SetExternalSecretSpec` is retained for backwards compatibility.

Each public function in `pkg/kubernetes/externalsecrets/update.go` delegates to a matching internal helper in `internal/externalsecrets/update.go`, following the existing delegation pattern.

Closes #500

## Test plan

- [x] `mise run verify` (tidy + lint + tests) passes green — all 36 packages pass
- [x] `TestSetRefreshInterval` — verifies the duration pointer is set correctly
- [x] `TestSetTarget` — verifies Target.Name and CreationPolicy are set
- [x] `TestAddDataFrom` — verifies append behaviour with one and two entries