### PR TITLE
feat(kubernetes/cnpg): add Pooler builder

### DIFF
--- a/internal/cnpg/pooler.go
+++ b/internal/cnpg/pooler.go
@@ -1,0 +1,52 @@
+package cnpg
+
+import (
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreatePooler returns a CNPG Pooler with TypeMeta and ObjectMeta preset.
+func CreatePooler(name, namespace string, spec cnpgv1.PoolerSpec) *cnpgv1.Pooler {
+	return &cnpgv1.Pooler{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pooler",
+			APIVersion: cnpgv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: spec,
+	}
+}
+
+// SetPoolerInstances sets the number of replicas on the Pooler spec.
+func SetPoolerInstances(obj *cnpgv1.Pooler, instances int32) {
+	obj.Spec.Instances = &instances
+}
+
+// SetPoolerClusterRef sets the cluster reference on the Pooler spec.
+func SetPoolerClusterRef(obj *cnpgv1.Pooler, clusterName string) {
+	obj.Spec.Cluster = cnpgv1.LocalObjectReference{Name: clusterName}
+}
+
+// SetPoolerPgBouncerSpec sets the PgBouncer configuration on the Pooler spec.
+func SetPoolerPgBouncerSpec(obj *cnpgv1.Pooler, spec cnpgv1.PgBouncerSpec) {
+	obj.Spec.PgBouncer = &spec
+}
+
+// AddPoolerLabel adds or updates a label on the Pooler metadata.
+func AddPoolerLabel(obj *cnpgv1.Pooler, key, value string) {
+	if obj.Labels == nil {
+		obj.Labels = make(map[string]string)
+	}
+	obj.Labels[key] = value
+}
+
+// AddPoolerAnnotation adds or updates an annotation on the Pooler metadata.
+func AddPoolerAnnotation(obj *cnpgv1.Pooler, key, value string) {
+	if obj.Annotations == nil {
+		obj.Annotations = make(map[string]string)
+	}
+	obj.Annotations[key] = value
+}

--- a/internal/cnpg/pooler_test.go
+++ b/internal/cnpg/pooler_test.go
@@ -1,0 +1,108 @@
+package cnpg
+
+import (
+	"testing"
+
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+)
+
+func TestCreatePooler(t *testing.T) {
+	instances := int32(2)
+	spec := cnpgv1.PoolerSpec{
+		Cluster:   cnpgv1.LocalObjectReference{Name: "pg-main"},
+		Type:      cnpgv1.PoolerTypeRW,
+		Instances: &instances,
+		PgBouncer: &cnpgv1.PgBouncerSpec{},
+	}
+	obj := CreatePooler("my-pooler", "db-ns", spec)
+
+	if obj == nil {
+		t.Fatal("expected non-nil Pooler")
+	}
+	if obj.Name != "my-pooler" {
+		t.Errorf("unexpected name %q", obj.Name)
+	}
+	if obj.Namespace != "db-ns" {
+		t.Errorf("unexpected namespace %q", obj.Namespace)
+	}
+	if obj.Kind != "Pooler" {
+		t.Errorf("unexpected kind %q", obj.Kind)
+	}
+	if obj.APIVersion != "postgresql.cnpg.io/v1" {
+		t.Errorf("unexpected apiVersion %q", obj.APIVersion)
+	}
+	if obj.Spec.Cluster.Name != "pg-main" {
+		t.Errorf("unexpected cluster ref %q", obj.Spec.Cluster.Name)
+	}
+}
+
+func TestSetPoolerInstances(t *testing.T) {
+	obj := CreatePooler("test", "ns", cnpgv1.PoolerSpec{})
+	SetPoolerInstances(obj, 3)
+	if obj.Spec.Instances == nil {
+		t.Fatal("expected non-nil Instances")
+	}
+	if *obj.Spec.Instances != 3 {
+		t.Errorf("unexpected instances %d", *obj.Spec.Instances)
+	}
+}
+
+func TestSetPoolerClusterRef(t *testing.T) {
+	obj := CreatePooler("test", "ns", cnpgv1.PoolerSpec{})
+	SetPoolerClusterRef(obj, "pg-cluster")
+	if obj.Spec.Cluster.Name != "pg-cluster" {
+		t.Errorf("unexpected cluster ref %q", obj.Spec.Cluster.Name)
+	}
+}
+
+func TestSetPoolerPgBouncerSpec(t *testing.T) {
+	obj := CreatePooler("test", "ns", cnpgv1.PoolerSpec{})
+	spec := cnpgv1.PgBouncerSpec{
+		PoolMode: cnpgv1.PgBouncerPoolModeTransaction,
+	}
+	SetPoolerPgBouncerSpec(obj, spec)
+	if obj.Spec.PgBouncer == nil {
+		t.Fatal("expected non-nil PgBouncer")
+	}
+	if obj.Spec.PgBouncer.PoolMode != cnpgv1.PgBouncerPoolModeTransaction {
+		t.Errorf("unexpected pool mode %q", obj.Spec.PgBouncer.PoolMode)
+	}
+}
+
+func TestAddPoolerLabel(t *testing.T) {
+	obj := CreatePooler("test", "ns", cnpgv1.PoolerSpec{})
+	AddPoolerLabel(obj, "app", "pgbouncer")
+	if obj.Labels["app"] != "pgbouncer" {
+		t.Errorf("label not set")
+	}
+}
+
+func TestAddPoolerAnnotation(t *testing.T) {
+	obj := CreatePooler("test", "ns", cnpgv1.PoolerSpec{})
+	AddPoolerAnnotation(obj, "team", "dba")
+	if obj.Annotations["team"] != "dba" {
+		t.Errorf("annotation not set")
+	}
+}
+
+func TestAddPoolerLabel_InitializesMap(t *testing.T) {
+	obj := CreatePooler("test", "ns", cnpgv1.PoolerSpec{})
+	if obj.Labels != nil {
+		t.Fatal("expected nil Labels before adding label")
+	}
+	AddPoolerLabel(obj, "key", "val")
+	if obj.Labels == nil {
+		t.Fatal("expected non-nil Labels after adding label")
+	}
+}
+
+func TestAddPoolerAnnotation_InitializesMap(t *testing.T) {
+	obj := CreatePooler("test", "ns", cnpgv1.PoolerSpec{})
+	if obj.Annotations != nil {
+		t.Fatal("expected nil Annotations before adding annotation")
+	}
+	AddPoolerAnnotation(obj, "key", "val")
+	if obj.Annotations == nil {
+		t.Fatal("expected non-nil Annotations after adding annotation")
+	}
+}

--- a/pkg/kubernetes/cnpg/pooler.go
+++ b/pkg/kubernetes/cnpg/pooler.go
@@ -23,7 +23,12 @@ func Pooler(cfg *PoolerConfig) *cnpgv1.Pooler {
 
 	pgBouncer := &cnpgv1.PgBouncerSpec{}
 	if opts.PgBouncer != nil {
-		pgBouncer = opts.PgBouncer
+		if opts.PgBouncer.PoolMode != "" {
+			pgBouncer.PoolMode = cnpgv1.PgBouncerPoolMode(opts.PgBouncer.PoolMode)
+		}
+		if len(opts.PgBouncer.Parameters) > 0 {
+			pgBouncer.Parameters = opts.PgBouncer.Parameters
+		}
 	}
 
 	spec := cnpgv1.PoolerSpec{

--- a/pkg/kubernetes/cnpg/pooler.go
+++ b/pkg/kubernetes/cnpg/pooler.go
@@ -1,0 +1,40 @@
+package cnpg
+
+import (
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+
+	intcnpg "github.com/go-kure/kure/internal/cnpg"
+)
+
+// Pooler converts PoolerConfig to a CNPG Pooler object.
+func Pooler(cfg *PoolerConfig) *cnpgv1.Pooler {
+	if cfg == nil {
+		return nil
+	}
+	opts := cfg.Options
+	if opts == nil {
+		opts = &PoolerOptions{}
+	}
+
+	poolerType := cnpgv1.PoolerTypeRW
+	if opts.Type == "ro" {
+		poolerType = cnpgv1.PoolerTypeRO
+	}
+
+	pgBouncer := &cnpgv1.PgBouncerSpec{}
+	if opts.PgBouncer != nil {
+		pgBouncer = opts.PgBouncer
+	}
+
+	spec := cnpgv1.PoolerSpec{
+		Cluster:   cnpgv1.LocalObjectReference{Name: opts.ClusterName},
+		Type:      poolerType,
+		PgBouncer: pgBouncer,
+	}
+	if opts.Instances > 0 {
+		instances := opts.Instances
+		spec.Instances = &instances
+	}
+
+	return intcnpg.CreatePooler(cfg.Name, cfg.Namespace, spec)
+}

--- a/pkg/kubernetes/cnpg/pooler_test.go
+++ b/pkg/kubernetes/cnpg/pooler_test.go
@@ -1,0 +1,138 @@
+package cnpg
+
+import (
+	"testing"
+
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+)
+
+func TestPooler_Success(t *testing.T) {
+	obj := Pooler(&PoolerConfig{
+		Name:      "pg-pooler",
+		Namespace: "databases",
+		Options: &PoolerOptions{
+			ClusterName: "pg-main",
+			Instances:   2,
+			Type:        "rw",
+		},
+	})
+	if obj == nil {
+		t.Fatal("expected non-nil Pooler")
+	}
+	if obj.Name != "pg-pooler" {
+		t.Errorf("expected Name 'pg-pooler', got %s", obj.Name)
+	}
+	if obj.Namespace != "databases" {
+		t.Errorf("expected Namespace 'databases', got %s", obj.Namespace)
+	}
+	if obj.Spec.Cluster.Name != "pg-main" {
+		t.Errorf("expected Cluster 'pg-main', got %s", obj.Spec.Cluster.Name)
+	}
+	if obj.Spec.Type != cnpgv1.PoolerTypeRW {
+		t.Errorf("expected Type 'rw', got %s", obj.Spec.Type)
+	}
+	if obj.Spec.Instances == nil || *obj.Spec.Instances != 2 {
+		t.Errorf("expected Instances 2, got %v", obj.Spec.Instances)
+	}
+	if obj.Spec.PgBouncer == nil {
+		t.Error("expected non-nil PgBouncer")
+	}
+}
+
+func TestPooler_TypeRO(t *testing.T) {
+	obj := Pooler(&PoolerConfig{
+		Name:      "pg-pooler-ro",
+		Namespace: "databases",
+		Options: &PoolerOptions{
+			ClusterName: "pg-main",
+			Type:        "ro",
+		},
+	})
+	if obj == nil {
+		t.Fatal("expected non-nil Pooler")
+	}
+	if obj.Spec.Type != cnpgv1.PoolerTypeRO {
+		t.Errorf("expected Type 'ro', got %s", obj.Spec.Type)
+	}
+}
+
+func TestPooler_DefaultTypeRW(t *testing.T) {
+	obj := Pooler(&PoolerConfig{
+		Name:      "pg-pooler",
+		Namespace: "ns",
+		Options: &PoolerOptions{
+			ClusterName: "pg-main",
+		},
+	})
+	if obj.Spec.Type != cnpgv1.PoolerTypeRW {
+		t.Errorf("expected default Type 'rw', got %s", obj.Spec.Type)
+	}
+}
+
+func TestPooler_WithPgBouncerSpec(t *testing.T) {
+	pgBouncer := &cnpgv1.PgBouncerSpec{
+		PoolMode: cnpgv1.PgBouncerPoolModeTransaction,
+	}
+	obj := Pooler(&PoolerConfig{
+		Name:      "pg-pooler",
+		Namespace: "ns",
+		Options: &PoolerOptions{
+			ClusterName: "pg-main",
+			PgBouncer:   pgBouncer,
+		},
+	})
+	if obj.Spec.PgBouncer == nil {
+		t.Fatal("expected non-nil PgBouncer")
+	}
+	if obj.Spec.PgBouncer.PoolMode != cnpgv1.PgBouncerPoolModeTransaction {
+		t.Errorf("expected PoolMode transaction, got %s", obj.Spec.PgBouncer.PoolMode)
+	}
+}
+
+func TestPooler_ZeroInstances(t *testing.T) {
+	obj := Pooler(&PoolerConfig{
+		Name:      "pg-pooler",
+		Namespace: "ns",
+		Options: &PoolerOptions{
+			ClusterName: "pg-main",
+			Instances:   0,
+		},
+	})
+	if obj.Spec.Instances != nil {
+		t.Errorf("expected nil Instances for zero value, got %v", obj.Spec.Instances)
+	}
+}
+
+func TestPooler_NilOptions(t *testing.T) {
+	obj := Pooler(&PoolerConfig{
+		Name:      "pg-pooler",
+		Namespace: "ns",
+		Options:   nil,
+	})
+	if obj == nil {
+		t.Fatal("expected non-nil Pooler")
+	}
+	if obj.Spec.Type != cnpgv1.PoolerTypeRW {
+		t.Errorf("expected default Type 'rw', got %s", obj.Spec.Type)
+	}
+}
+
+func TestPooler_NilConfig(t *testing.T) {
+	if Pooler(nil) != nil {
+		t.Error("expected nil result for nil config")
+	}
+}
+
+func TestPooler_TypeMeta(t *testing.T) {
+	obj := Pooler(&PoolerConfig{
+		Name:      "pg-pooler",
+		Namespace: "ns",
+		Options:   &PoolerOptions{ClusterName: "pg"},
+	})
+	if obj.Kind != "Pooler" {
+		t.Errorf("expected Kind 'Pooler', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "postgresql.cnpg.io/v1" {
+		t.Errorf("expected APIVersion 'postgresql.cnpg.io/v1', got %s", obj.APIVersion)
+	}
+}

--- a/pkg/kubernetes/cnpg/pooler_test.go
+++ b/pkg/kubernetes/cnpg/pooler_test.go
@@ -69,16 +69,16 @@ func TestPooler_DefaultTypeRW(t *testing.T) {
 	}
 }
 
-func TestPooler_WithPgBouncerSpec(t *testing.T) {
-	pgBouncer := &cnpgv1.PgBouncerSpec{
-		PoolMode: cnpgv1.PgBouncerPoolModeTransaction,
-	}
+func TestPooler_WithPgBouncerOptions(t *testing.T) {
 	obj := Pooler(&PoolerConfig{
 		Name:      "pg-pooler",
 		Namespace: "ns",
 		Options: &PoolerOptions{
 			ClusterName: "pg-main",
-			PgBouncer:   pgBouncer,
+			PgBouncer: &PgBouncerOptions{
+				PoolMode:   "transaction",
+				Parameters: map[string]string{"max_client_conn": "100"},
+			},
 		},
 	})
 	if obj.Spec.PgBouncer == nil {
@@ -86,6 +86,9 @@ func TestPooler_WithPgBouncerSpec(t *testing.T) {
 	}
 	if obj.Spec.PgBouncer.PoolMode != cnpgv1.PgBouncerPoolModeTransaction {
 		t.Errorf("expected PoolMode transaction, got %s", obj.Spec.PgBouncer.PoolMode)
+	}
+	if obj.Spec.PgBouncer.Parameters["max_client_conn"] != "100" {
+		t.Errorf("expected parameter max_client_conn=100, got %v", obj.Spec.PgBouncer.Parameters)
 	}
 }
 

--- a/pkg/kubernetes/cnpg/types.go
+++ b/pkg/kubernetes/cnpg/types.go
@@ -182,3 +182,21 @@ type ScheduledBackupConfig struct {
 	Namespace string                     `yaml:"namespace"`
 	Spec      cnpgv1.ScheduledBackupSpec `yaml:"spec"`
 }
+
+// PoolerOptions is the domain-friendly input for Pooler construction.
+type PoolerOptions struct {
+	ClusterName string
+	Instances   int32
+	// Type is the pooler type: "rw" (read-write) or "ro" (read-only).
+	// Defaults to "rw" if empty.
+	Type string
+	// PgBouncer holds pgBouncer-specific configuration.
+	PgBouncer *cnpgv1.PgBouncerSpec
+}
+
+// PoolerConfig describes a CNPG Pooler resource.
+type PoolerConfig struct {
+	Name      string
+	Namespace string
+	Options   *PoolerOptions
+}

--- a/pkg/kubernetes/cnpg/types.go
+++ b/pkg/kubernetes/cnpg/types.go
@@ -183,15 +183,28 @@ type ScheduledBackupConfig struct {
 	Spec      cnpgv1.ScheduledBackupSpec `yaml:"spec"`
 }
 
+// PgBouncerOptions is the domain-friendly configuration for the PgBouncer
+// connection pooler. It covers the fields used by crane without exposing the
+// cnpgv1.PgBouncerSpec type to callers.
+type PgBouncerOptions struct {
+	// PoolMode is the connection pooling mode: "session" or "transaction".
+	// When empty, CNPG defaults to "session".
+	PoolMode string
+	// Parameters are extra PgBouncer configuration key-value pairs.
+	Parameters map[string]string
+}
+
 // PoolerOptions is the domain-friendly input for Pooler construction.
 type PoolerOptions struct {
 	ClusterName string
-	Instances   int32
-	// Type is the pooler type: "rw" (read-write) or "ro" (read-only).
-	// Defaults to "rw" if empty.
+	// Instances is the number of Pooler replicas. Zero means omit the field
+	// and let CNPG default to 1.
+	Instances int32
+	// Type is the pooler type: "rw" (read-write, default) or "ro" (read-only).
+	// Defaults to "rw" if empty or unrecognised.
 	Type string
 	// PgBouncer holds pgBouncer-specific configuration.
-	PgBouncer *cnpgv1.PgBouncerSpec
+	PgBouncer *PgBouncerOptions
 }
 
 // PoolerConfig describes a CNPG Pooler resource.

--- a/pkg/kubernetes/scheme.go
+++ b/pkg/kubernetes/scheme.go
@@ -7,6 +7,7 @@ import (
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	fluxv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
@@ -75,6 +76,7 @@ func registerAllSchemes() error {
 		gwapiv1.Install,
 		monitoringv1.AddToScheme,
 		volsyncv1alpha1.AddToScheme,
+		cnpgv1.AddToScheme,
 	}
 
 	// Register each scheme, returning the first error


### PR DESCRIPTION
## Summary

- Adds `internal/cnpg/pooler.go`: low-level `CreatePooler`, `SetPoolerInstances`, `SetPoolerClusterRef`, `SetPoolerPgBouncerSpec`, `AddPoolerLabel`, `AddPoolerAnnotation` functions taking raw `cnpgv1` types
- Adds `PoolerOptions` and `PoolerConfig` to `pkg/kubernetes/cnpg/types.go`: domain-friendly input structs (ClusterName, Instances, Type `"rw"`/`"ro"`, PgBouncer)
- Adds `pkg/kubernetes/cnpg/pooler.go`: public `Pooler(cfg *PoolerConfig) *cnpgv1.Pooler` builder following the same three-layer pattern as `Cluster`/`Database`
- Registers `cnpgv1.AddToScheme` in `pkg/kubernetes/scheme.go` (was missing)

## Consumer reference

Crane's `postgresql.go:757-792` creates a CNPG Pooler as raw `*unstructured.Unstructured`. This builder enables replacing that with a typed call: `cnpg.Pooler(&cnpg.PoolerConfig{...})`.

## Type names used (cloudnative-pg v1.29.0)

- `cnpgv1.Pooler`, `cnpgv1.PoolerSpec`, `cnpgv1.PoolerType`
- `cnpgv1.PoolerTypeRW`, `cnpgv1.PoolerTypeRO`
- `cnpgv1.PgBouncerSpec`, `cnpgv1.PgBouncerPoolMode`
- `cnpgv1.LocalObjectReference` (for `PoolerSpec.Cluster`, distinct from `corev1.LocalObjectReference`)
- `PoolerSpec.Instances` is `*int32` (pointer)

## Test plan

- [ ] `make precommit` passes (tidy, lint, all tests green)
- [ ] `internal/cnpg/pooler_test.go`: CreatePooler, SetPoolerInstances, SetPoolerClusterRef, SetPoolerPgBouncerSpec, AddPoolerLabel, AddPoolerAnnotation
- [ ] `pkg/kubernetes/cnpg/pooler_test.go`: nil config, nil options, default type rw, type ro, custom PgBouncer, zero instances, TypeMeta fields