### PR TITLE
feat(stack/fluxcd): expose GenerateFluxInstance as public method

### DIFF
--- a/pkg/stack/fluxcd/bootstrap_generator.go
+++ b/pkg/stack/fluxcd/bootstrap_generator.go
@@ -246,6 +246,21 @@ func (bg *BootstrapGenerator) generateOCISource(config *stack.BootstrapConfig, r
 	return intfluxcd.CreateOCIRepository(sourceName, bg.DefaultNamespace, spec)
 }
 
+// GenerateFluxInstance returns only the FluxInstance CR configured for
+// the given bootstrap settings, without the full Flux Operator install bundle.
+// Returns (nil, nil) when config is nil.
+func (bg *BootstrapGenerator) GenerateFluxInstance(config *stack.BootstrapConfig, rootNode *stack.Node) (*fluxv1.FluxInstance, error) {
+	if config == nil {
+		return nil, nil
+	}
+	obj := bg.generateFluxInstance(config, rootNode)
+	fi, ok := obj.(*fluxv1.FluxInstance)
+	if !ok {
+		return nil, errors.Errorf("internal error: generateFluxInstance returned unexpected type %T", obj)
+	}
+	return fi, nil
+}
+
 // generateFluxInstance creates a FluxInstance for flux-operator mode.
 func (bg *BootstrapGenerator) generateFluxInstance(config *stack.BootstrapConfig, rootNode *stack.Node) client.Object {
 	spec := fluxv1.FluxInstanceSpec{

--- a/pkg/stack/fluxcd/bootstrap_generator.go
+++ b/pkg/stack/fluxcd/bootstrap_generator.go
@@ -248,7 +248,8 @@ func (bg *BootstrapGenerator) generateOCISource(config *stack.BootstrapConfig, r
 
 // GenerateFluxInstance returns only the FluxInstance CR configured for
 // the given bootstrap settings, without the full Flux Operator install bundle.
-// Returns (nil, nil) when config is nil.
+// Returns (nil, nil) when config is nil. Unlike GenerateBootstrap, this method
+// does not check config.Enabled — the caller is responsible for that gate.
 func (bg *BootstrapGenerator) GenerateFluxInstance(config *stack.BootstrapConfig, rootNode *stack.Node) (*fluxv1.FluxInstance, error) {
 	if config == nil {
 		return nil, nil

--- a/pkg/stack/fluxcd/bootstrap_generator_test.go
+++ b/pkg/stack/fluxcd/bootstrap_generator_test.go
@@ -380,6 +380,101 @@ func TestGotkGitRepositorySourceGeneration(t *testing.T) {
 	}
 }
 
+func TestGenerateFluxInstanceNilConfig(t *testing.T) {
+	bg := fluxstack.NewBootstrapGenerator()
+
+	fi, err := bg.GenerateFluxInstance(nil, nil)
+	if err != nil {
+		t.Errorf("GenerateFluxInstance(nil, nil) error = %v, want nil", err)
+	}
+	if fi != nil {
+		t.Errorf("GenerateFluxInstance(nil, nil) = %v, want nil", fi)
+	}
+}
+
+func TestGenerateFluxInstanceDistribution(t *testing.T) {
+	bg := fluxstack.NewBootstrapGenerator()
+
+	config := &stack.BootstrapConfig{
+		Enabled:     true,
+		FluxVersion: "v2.4.0",
+		Registry:    "registry.example.com",
+	}
+
+	fi, err := bg.GenerateFluxInstance(config, nil)
+	if err != nil {
+		t.Fatalf("GenerateFluxInstance() error = %v", err)
+	}
+	if fi == nil {
+		t.Fatal("expected non-nil FluxInstance")
+	}
+
+	if fi.Spec.Distribution.Version != "v2.4.0" {
+		t.Errorf("Distribution.Version = %q, want %q", fi.Spec.Distribution.Version, "v2.4.0")
+	}
+	if fi.Spec.Distribution.Registry != "registry.example.com" {
+		t.Errorf("Distribution.Registry = %q, want %q", fi.Spec.Distribution.Registry, "registry.example.com")
+	}
+}
+
+func TestGenerateFluxInstanceSyncFromSourceURL(t *testing.T) {
+	bg := fluxstack.NewBootstrapGenerator()
+
+	config := &stack.BootstrapConfig{
+		Enabled:    true,
+		SourceURL:  "https://github.com/example/fleet.git",
+		SourceRef:  "main",
+		SourceKind: "GitRepository",
+	}
+	rootNode := &stack.Node{Name: "production"}
+
+	fi, err := bg.GenerateFluxInstance(config, rootNode)
+	if err != nil {
+		t.Fatalf("GenerateFluxInstance() error = %v", err)
+	}
+	if fi == nil {
+		t.Fatal("expected non-nil FluxInstance")
+	}
+
+	if fi.Spec.Sync == nil {
+		t.Fatal("expected Sync to be set when SourceURL is non-empty")
+	}
+	if fi.Spec.Sync.Kind != "GitRepository" {
+		t.Errorf("Sync.Kind = %q, want %q", fi.Spec.Sync.Kind, "GitRepository")
+	}
+	if fi.Spec.Sync.URL != "https://github.com/example/fleet.git" {
+		t.Errorf("Sync.URL = %q, want %q", fi.Spec.Sync.URL, "https://github.com/example/fleet.git")
+	}
+	if fi.Spec.Sync.Ref != "main" {
+		t.Errorf("Sync.Ref = %q, want %q", fi.Spec.Sync.Ref, "main")
+	}
+	if fi.Spec.Sync.Path != "./production" {
+		t.Errorf("Sync.Path = %q, want %q", fi.Spec.Sync.Path, "./production")
+	}
+}
+
+func TestGenerateFluxInstanceNoSyncWhenNoSourceURL(t *testing.T) {
+	bg := fluxstack.NewBootstrapGenerator()
+
+	config := &stack.BootstrapConfig{
+		Enabled:     true,
+		FluxVersion: "v2.4.0",
+		// No SourceURL
+	}
+
+	fi, err := bg.GenerateFluxInstance(config, nil)
+	if err != nil {
+		t.Fatalf("GenerateFluxInstance() error = %v", err)
+	}
+	if fi == nil {
+		t.Fatal("expected non-nil FluxInstance")
+	}
+
+	if fi.Spec.Sync != nil {
+		t.Errorf("expected Sync to be nil when SourceURL is empty, got %+v", fi.Spec.Sync)
+	}
+}
+
 // TestFluxOperatorInstallObjects verifies the vendored install.yaml parses
 // into the expected resource inventory. If the manifest is bumped to a
 // newer flux-operator release the counts may shift and this test should


### PR DESCRIPTION
## Summary
- Adds `GenerateFluxInstance(cfg, node) (*fluxv1.FluxInstance, error)` to `BootstrapGenerator`
- Delegates to the existing private `generateFluxInstance` with a typed return
- `GenerateBootstrap` is unchanged — no breaking changes

## Test plan
- [x] `mise run verify` passes
- [x] Test: nil config returns (nil, nil)
- [x] Test: returned FluxInstance has correct Distribution.Version and Distribution.Registry
- [x] Test: Sync is set when SourceURL is non-empty
- [x] Test: Sync is nil when SourceURL is empty

Closes #494