### PR TITLE
feat(kubernetes): add CreateVolumeClaimTemplate helper for StatefulSet embedding

### DIFF
--- a/pkg/kubernetes/persistentvolumeclaim.go
+++ b/pkg/kubernetes/persistentvolumeclaim.go
@@ -76,3 +76,43 @@ func SetPVCDataSource(pvc *corev1.PersistentVolumeClaim, src *corev1.TypedLocalO
 func SetPVCDataSourceRef(pvc *corev1.PersistentVolumeClaim, src *corev1.TypedObjectReference) {
 	pvc.Spec.DataSourceRef = src
 }
+
+// VolumeClaimTemplateOptions holds fields needed to construct a PVC for
+// embedding in StatefulSet.Spec.VolumeClaimTemplates.
+type VolumeClaimTemplateOptions struct {
+	// StorageClassName is the name of the StorageClass. When empty, the cluster
+	// default StorageClass is used.
+	StorageClassName string
+	// AccessModes defines the desired access modes for the volume.
+	AccessModes []corev1.PersistentVolumeAccessMode
+	// StorageRequest is the minimum storage capacity requested.
+	StorageRequest resource.Quantity
+	// Labels are optional metadata labels applied to the PVC template.
+	Labels map[string]string
+}
+
+// CreateVolumeClaimTemplate returns a PersistentVolumeClaim suitable for
+// embedding in StatefulSet.Spec.VolumeClaimTemplates. Only ObjectMeta.Name and
+// Spec are set; TypeMeta and Namespace are intentionally omitted because
+// StatefulSet embeds PVCs by name only and the owning StatefulSet provides the
+// namespace.
+func CreateVolumeClaimTemplate(name string, opts VolumeClaimTemplateOptions) corev1.PersistentVolumeClaim {
+	pvc := corev1.PersistentVolumeClaim{}
+	pvc.Name = name
+	if opts.Labels != nil {
+		pvc.Labels = opts.Labels
+	}
+	pvc.Spec = corev1.PersistentVolumeClaimSpec{
+		AccessModes: opts.AccessModes,
+		Resources: corev1.VolumeResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceStorage: opts.StorageRequest,
+			},
+		},
+	}
+	if opts.StorageClassName != "" {
+		sc := opts.StorageClassName
+		pvc.Spec.StorageClassName = &sc
+	}
+	return pvc
+}

--- a/pkg/kubernetes/persistentvolumeclaim_test.go
+++ b/pkg/kubernetes/persistentvolumeclaim_test.go
@@ -86,3 +86,99 @@ func TestPersistentVolumeClaimFunctions(t *testing.T) {
 		t.Errorf("data source ref not set")
 	}
 }
+
+func TestCreateVolumeClaimTemplate(t *testing.T) {
+	t.Run("sets name", func(t *testing.T) {
+		pvc := CreateVolumeClaimTemplate("data", VolumeClaimTemplateOptions{
+			StorageRequest: resource.MustParse("5Gi"),
+		})
+		if pvc.Name != "data" {
+			t.Errorf("expected name %q got %q", "data", pvc.Name)
+		}
+	})
+
+	t.Run("TypeMeta is empty", func(t *testing.T) {
+		pvc := CreateVolumeClaimTemplate("data", VolumeClaimTemplateOptions{
+			StorageRequest: resource.MustParse("1Gi"),
+		})
+		if pvc.Kind != "" {
+			t.Errorf("expected empty Kind, got %q", pvc.Kind)
+		}
+		if pvc.APIVersion != "" {
+			t.Errorf("expected empty APIVersion, got %q", pvc.APIVersion)
+		}
+	})
+
+	t.Run("Namespace is empty", func(t *testing.T) {
+		pvc := CreateVolumeClaimTemplate("data", VolumeClaimTemplateOptions{
+			StorageRequest: resource.MustParse("1Gi"),
+		})
+		if pvc.Namespace != "" {
+			t.Errorf("expected empty Namespace, got %q", pvc.Namespace)
+		}
+	})
+
+	t.Run("sets storageClassName", func(t *testing.T) {
+		pvc := CreateVolumeClaimTemplate("data", VolumeClaimTemplateOptions{
+			StorageClassName: "fast",
+			StorageRequest:   resource.MustParse("10Gi"),
+		})
+		if pvc.Spec.StorageClassName == nil {
+			t.Fatal("expected non-nil StorageClassName")
+		}
+		if *pvc.Spec.StorageClassName != "fast" {
+			t.Errorf("expected StorageClassName %q got %q", "fast", *pvc.Spec.StorageClassName)
+		}
+	})
+
+	t.Run("empty storageClassName omitted", func(t *testing.T) {
+		pvc := CreateVolumeClaimTemplate("data", VolumeClaimTemplateOptions{
+			StorageRequest: resource.MustParse("1Gi"),
+		})
+		if pvc.Spec.StorageClassName != nil {
+			t.Errorf("expected nil StorageClassName, got %q", *pvc.Spec.StorageClassName)
+		}
+	})
+
+	t.Run("sets accessModes", func(t *testing.T) {
+		modes := []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+		pvc := CreateVolumeClaimTemplate("data", VolumeClaimTemplateOptions{
+			AccessModes:    modes,
+			StorageRequest: resource.MustParse("1Gi"),
+		})
+		if !reflect.DeepEqual(pvc.Spec.AccessModes, modes) {
+			t.Errorf("access modes mismatch: got %v want %v", pvc.Spec.AccessModes, modes)
+		}
+	})
+
+	t.Run("sets storage request", func(t *testing.T) {
+		qty := resource.MustParse("20Gi")
+		pvc := CreateVolumeClaimTemplate("data", VolumeClaimTemplateOptions{
+			StorageRequest: qty,
+		})
+		got := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+		if got.Cmp(qty) != 0 {
+			t.Errorf("storage request mismatch: got %v want %v", got, qty)
+		}
+	})
+
+	t.Run("sets labels when provided", func(t *testing.T) {
+		labels := map[string]string{"env": "prod", "tier": "db"}
+		pvc := CreateVolumeClaimTemplate("data", VolumeClaimTemplateOptions{
+			StorageRequest: resource.MustParse("1Gi"),
+			Labels:         labels,
+		})
+		if !reflect.DeepEqual(pvc.Labels, labels) {
+			t.Errorf("labels mismatch: got %v want %v", pvc.Labels, labels)
+		}
+	})
+
+	t.Run("nil labels not set", func(t *testing.T) {
+		pvc := CreateVolumeClaimTemplate("data", VolumeClaimTemplateOptions{
+			StorageRequest: resource.MustParse("1Gi"),
+		})
+		if pvc.Labels != nil {
+			t.Errorf("expected nil labels, got %v", pvc.Labels)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `VolumeClaimTemplateOptions` struct (StorageClassName, AccessModes, StorageRequest, Labels)
- Adds `CreateVolumeClaimTemplate(name string, opts VolumeClaimTemplateOptions) corev1.PersistentVolumeClaim`
- Added to existing `persistentvolumeclaim.go` (alongside the standalone PVC builder)
- TypeMeta and Namespace intentionally omitted — StatefulSet embeds PVCs by name only

## Consumer
crane `internal/transform/components/statefulset.go:288-311` builds VolumeClaimTemplates via raw struct literals.

## Test plan
- [ ] `mise run verify` passes (tidy + lint + test)
- [ ] `TestCreateVolumeClaimTemplate`: name, TypeMeta empty, Namespace empty, storageClassName, accessModes, storage request, labels

Closes #497