### PR TITLE
feat(kubernetes): add public Namespace builder with PSA label support

### DIFF
--- a/pkg/kubernetes/README.md
+++ b/pkg/kubernetes/README.md
@@ -215,6 +215,36 @@ kubernetes.AddHTTPRouteRuleBackendRef(&rule, gwapiv1.HTTPBackendRef{
 err = kubernetes.AddHTTPRouteRule(route, rule)
 ```
 
+## Namespace Builder
+
+Create and configure Kubernetes Namespaces, including Pod Security Admission (PSA) label management.
+
+```go
+// Create a Namespace with default app label and annotation
+ns := kubernetes.CreateNamespace("my-app")
+
+// Add or replace labels and annotations
+kubernetes.AddNamespaceLabel(ns, "env", "prod")
+kubernetes.AddNamespaceAnnotation(ns, "owner", "platform-team")
+kubernetes.SetNamespaceLabels(ns, map[string]string{"app": "my-app", "env": "prod"})
+kubernetes.SetNamespaceAnnotations(ns, map[string]string{"owner": "platform-team"})
+
+// Manage finalizers
+kubernetes.AddNamespaceFinalizer(ns, corev1.FinalizerKubernetes)
+kubernetes.SetNamespaceFinalizers(ns, []corev1.FinalizerName{"custom-finalizer"})
+
+// Apply PSA admission labels (enforce, warn, audit modes)
+kubernetes.SetNamespacePSALabels(ns,
+    kubernetes.PSARestricted,  // enforce
+    kubernetes.PSARestricted,  // warn
+    kubernetes.PSARestricted,  // audit
+    "v1.28",                   // version (pass "" to omit version labels)
+)
+
+// Skip a mode by passing an empty string
+kubernetes.SetNamespacePSALabels(ns, kubernetes.PSARestricted, "", "", "latest")
+```
+
 ## PSA Security Context Helpers
 
 Helpers for Pod Security Admission (PSA) compliance at Restricted, Baseline, and Privileged levels.

--- a/pkg/kubernetes/namespace.go
+++ b/pkg/kubernetes/namespace.go
@@ -1,0 +1,91 @@
+package kubernetes
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateNamespace creates a new Namespace with TypeMeta, a default "app" label
+// and annotation, and an empty Spec.Finalizers slice.
+func CreateNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"app": name,
+			},
+			Annotations: map[string]string{
+				"app": name,
+			},
+		},
+		Spec: corev1.NamespaceSpec{
+			Finalizers: []corev1.FinalizerName{},
+		},
+	}
+}
+
+// AddNamespaceLabel adds a label to the Namespace, initializing the map if needed.
+func AddNamespaceLabel(ns *corev1.Namespace, key, value string) {
+	if ns.Labels == nil {
+		ns.Labels = make(map[string]string)
+	}
+	ns.Labels[key] = value
+}
+
+// AddNamespaceAnnotation adds an annotation to the Namespace, initializing the map if needed.
+func AddNamespaceAnnotation(ns *corev1.Namespace, key, value string) {
+	if ns.Annotations == nil {
+		ns.Annotations = make(map[string]string)
+	}
+	ns.Annotations[key] = value
+}
+
+// AddNamespaceFinalizer appends a finalizer to the Namespace spec.
+func AddNamespaceFinalizer(ns *corev1.Namespace, finalizer corev1.FinalizerName) {
+	ns.Spec.Finalizers = append(ns.Spec.Finalizers, finalizer)
+}
+
+// SetNamespaceLabels replaces all labels on the Namespace.
+func SetNamespaceLabels(ns *corev1.Namespace, labels map[string]string) {
+	ns.Labels = labels
+}
+
+// SetNamespaceAnnotations replaces all annotations on the Namespace.
+func SetNamespaceAnnotations(ns *corev1.Namespace, annotations map[string]string) {
+	ns.Annotations = annotations
+}
+
+// SetNamespaceFinalizers replaces all finalizers on the Namespace spec.
+func SetNamespaceFinalizers(ns *corev1.Namespace, finalizers []corev1.FinalizerName) {
+	ns.Spec.Finalizers = finalizers
+}
+
+// SetNamespacePSALabels sets Pod Security Admission labels on the namespace.
+// enforce, warn, audit are PSA levels: use PSALevel constants (PSARestricted,
+// PSABaseline, PSAPrivileged) or an empty string to skip that mode.
+// version is applied to all configured modes; pass "latest", a specific
+// Kubernetes version like "v1.28", or an empty string to omit version labels.
+func SetNamespacePSALabels(ns *corev1.Namespace, enforce, warn, audit PSALevel, version string) {
+	if enforce != "" {
+		AddNamespaceLabel(ns, "pod-security.kubernetes.io/enforce", string(enforce))
+		if version != "" {
+			AddNamespaceLabel(ns, "pod-security.kubernetes.io/enforce-version", version)
+		}
+	}
+	if warn != "" {
+		AddNamespaceLabel(ns, "pod-security.kubernetes.io/warn", string(warn))
+		if version != "" {
+			AddNamespaceLabel(ns, "pod-security.kubernetes.io/warn-version", version)
+		}
+	}
+	if audit != "" {
+		AddNamespaceLabel(ns, "pod-security.kubernetes.io/audit", string(audit))
+		if version != "" {
+			AddNamespaceLabel(ns, "pod-security.kubernetes.io/audit-version", version)
+		}
+	}
+}

--- a/pkg/kubernetes/namespace_test.go
+++ b/pkg/kubernetes/namespace_test.go
@@ -1,0 +1,194 @@
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestCreateNamespace(t *testing.T) {
+	ns := CreateNamespace("demo")
+	if ns == nil {
+		t.Fatal("expected non-nil Namespace")
+	}
+	if ns.Kind != "Namespace" {
+		t.Errorf("expected Kind=Namespace, got %q", ns.Kind)
+	}
+	if ns.APIVersion != "v1" {
+		t.Errorf("expected APIVersion=v1, got %q", ns.APIVersion)
+	}
+	if ns.Name != "demo" {
+		t.Errorf("expected Name=demo, got %q", ns.Name)
+	}
+	if ns.Labels["app"] != "demo" {
+		t.Errorf("expected default label app=demo, got %q", ns.Labels["app"])
+	}
+	if ns.Annotations["app"] != "demo" {
+		t.Errorf("expected default annotation app=demo, got %q", ns.Annotations["app"])
+	}
+	if len(ns.Spec.Finalizers) != 0 {
+		t.Errorf("expected empty Spec.Finalizers, got %v", ns.Spec.Finalizers)
+	}
+}
+
+func TestAddNamespaceLabel(t *testing.T) {
+	ns := CreateNamespace("demo")
+	AddNamespaceLabel(ns, "env", "prod")
+	if ns.Labels["env"] != "prod" {
+		t.Errorf("expected label env=prod, got %q", ns.Labels["env"])
+	}
+}
+
+func TestAddNamespaceLabel_NilMap(t *testing.T) {
+	ns := &corev1.Namespace{}
+	AddNamespaceLabel(ns, "env", "prod")
+	if ns.Labels["env"] != "prod" {
+		t.Errorf("expected label added on nil map, got %q", ns.Labels["env"])
+	}
+}
+
+func TestAddNamespaceAnnotation(t *testing.T) {
+	ns := CreateNamespace("demo")
+	AddNamespaceAnnotation(ns, "team", "dev")
+	if ns.Annotations["team"] != "dev" {
+		t.Errorf("expected annotation team=dev, got %q", ns.Annotations["team"])
+	}
+}
+
+func TestAddNamespaceAnnotation_NilMap(t *testing.T) {
+	ns := &corev1.Namespace{}
+	AddNamespaceAnnotation(ns, "team", "dev")
+	if ns.Annotations["team"] != "dev" {
+		t.Errorf("expected annotation added on nil map, got %q", ns.Annotations["team"])
+	}
+}
+
+func TestAddNamespaceFinalizer(t *testing.T) {
+	ns := CreateNamespace("demo")
+	AddNamespaceFinalizer(ns, corev1.FinalizerKubernetes)
+	if len(ns.Spec.Finalizers) != 1 || ns.Spec.Finalizers[0] != corev1.FinalizerKubernetes {
+		t.Errorf("expected finalizer %q, got %v", corev1.FinalizerKubernetes, ns.Spec.Finalizers)
+	}
+}
+
+func TestSetNamespaceLabels(t *testing.T) {
+	ns := CreateNamespace("demo")
+	newLabels := map[string]string{"a": "b"}
+	SetNamespaceLabels(ns, newLabels)
+	if !reflect.DeepEqual(ns.Labels, newLabels) {
+		t.Errorf("expected labels %v, got %v", newLabels, ns.Labels)
+	}
+}
+
+func TestSetNamespaceAnnotations(t *testing.T) {
+	ns := CreateNamespace("demo")
+	newAnn := map[string]string{"x": "y"}
+	SetNamespaceAnnotations(ns, newAnn)
+	if !reflect.DeepEqual(ns.Annotations, newAnn) {
+		t.Errorf("expected annotations %v, got %v", newAnn, ns.Annotations)
+	}
+}
+
+func TestSetNamespaceFinalizers(t *testing.T) {
+	ns := CreateNamespace("demo")
+	finals := []corev1.FinalizerName{"custom"}
+	SetNamespaceFinalizers(ns, finals)
+	if !reflect.DeepEqual(ns.Spec.Finalizers, finals) {
+		t.Errorf("expected finalizers %v, got %v", finals, ns.Spec.Finalizers)
+	}
+}
+
+func TestSetNamespacePSALabels_AllModes(t *testing.T) {
+	ns := CreateNamespace("demo")
+	SetNamespacePSALabels(ns, PSARestricted, PSARestricted, PSARestricted, "v1.28")
+
+	want := map[string]string{
+		"pod-security.kubernetes.io/enforce":         "restricted",
+		"pod-security.kubernetes.io/enforce-version": "v1.28",
+		"pod-security.kubernetes.io/warn":            "restricted",
+		"pod-security.kubernetes.io/warn-version":    "v1.28",
+		"pod-security.kubernetes.io/audit":           "restricted",
+		"pod-security.kubernetes.io/audit-version":   "v1.28",
+	}
+	for k, v := range want {
+		if ns.Labels[k] != v {
+			t.Errorf("expected label %s=%s, got %q", k, v, ns.Labels[k])
+		}
+	}
+}
+
+func TestSetNamespacePSALabels_NoVersion(t *testing.T) {
+	ns := CreateNamespace("demo")
+	SetNamespacePSALabels(ns, PSARestricted, PSABaseline, PSAPrivileged, "")
+
+	if ns.Labels["pod-security.kubernetes.io/enforce"] != "restricted" {
+		t.Errorf("expected enforce=restricted")
+	}
+	if ns.Labels["pod-security.kubernetes.io/warn"] != "baseline" {
+		t.Errorf("expected warn=baseline")
+	}
+	if ns.Labels["pod-security.kubernetes.io/audit"] != "privileged" {
+		t.Errorf("expected audit=privileged")
+	}
+	// No version labels should be set
+	for _, k := range []string{
+		"pod-security.kubernetes.io/enforce-version",
+		"pod-security.kubernetes.io/warn-version",
+		"pod-security.kubernetes.io/audit-version",
+	} {
+		if _, ok := ns.Labels[k]; ok {
+			t.Errorf("expected no version label %s when version is empty", k)
+		}
+	}
+}
+
+func TestSetNamespacePSALabels_SkipEmpty(t *testing.T) {
+	ns := CreateNamespace("demo")
+	// Only enforce is set; warn and audit are empty
+	SetNamespacePSALabels(ns, PSARestricted, "", "", "latest")
+
+	if ns.Labels["pod-security.kubernetes.io/enforce"] != "restricted" {
+		t.Errorf("expected enforce=restricted")
+	}
+	if ns.Labels["pod-security.kubernetes.io/enforce-version"] != "latest" {
+		t.Errorf("expected enforce-version=latest")
+	}
+	for _, k := range []string{
+		"pod-security.kubernetes.io/warn",
+		"pod-security.kubernetes.io/warn-version",
+		"pod-security.kubernetes.io/audit",
+		"pod-security.kubernetes.io/audit-version",
+	} {
+		if _, ok := ns.Labels[k]; ok {
+			t.Errorf("expected label %s to be absent when mode is empty", k)
+		}
+	}
+}
+
+func TestSetNamespacePSALabels_CranePattern(t *testing.T) {
+	// Mirrors the pattern used in crane's namespace.go: enforce+warn+audit all "restricted", no version
+	ns := CreateNamespace("myapp")
+	SetNamespacePSALabels(ns, PSARestricted, PSARestricted, PSARestricted, "")
+
+	wantLabels := map[string]string{
+		"pod-security.kubernetes.io/enforce": "restricted",
+		"pod-security.kubernetes.io/audit":   "restricted",
+		"pod-security.kubernetes.io/warn":    "restricted",
+	}
+	for k, v := range wantLabels {
+		if ns.Labels[k] != v {
+			t.Errorf("expected %s=%s, got %q", k, v, ns.Labels[k])
+		}
+	}
+	// No version labels
+	for _, k := range []string{
+		"pod-security.kubernetes.io/enforce-version",
+		"pod-security.kubernetes.io/warn-version",
+		"pod-security.kubernetes.io/audit-version",
+	} {
+		if _, ok := ns.Labels[k]; ok {
+			t.Errorf("unexpected version label %s", k)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Promotes internal Namespace builder to `pkg/kubernetes/namespace.go` with direct implementation
- Adds `SetNamespacePSALabels(ns, enforce, warn, audit PSALevel, version string)` using existing `PSALevel` type
- PSA labels set: `pod-security.kubernetes.io/{enforce,warn,audit}` and `pod-security.kubernetes.io/{enforce,warn,audit}-version`
- Empty string for any mode skips that label; empty version skips all version labels

## Consumer
crane `internal/transform/namespace.go:20-33` constructs Namespace via struct literal with hardcoded PSA labels.

## Test plan
- [ ] `mise run verify` passes
- [ ] TestCreateNamespace: TypeMeta, Name, default label/annotation, empty Finalizers
- [ ] TestSetNamespacePSALabels_AllModes: all 6 PSA labels set with version
- [ ] TestSetNamespacePSALabels_NoVersion: 3 labels, no version labels
- [ ] TestSetNamespacePSALabels_SkipEmpty: only enforce set when warn/audit empty
- [ ] TestSetNamespacePSALabels_CranePattern: mirrors crane's actual pattern

Closes #498