### PR TITLE
feat(kubernetes/fluxcd): add Type field to HelmRepositoryConfig for OCI registries

### DIFF
--- a/pkg/kubernetes/fluxcd/README.md
+++ b/pkg/kubernetes/fluxcd/README.md
@@ -33,12 +33,19 @@ ociRepo := fluxcd.OCIRepository(&fluxcd.OCIRepositoryConfig{
     Interval:  "10m",
 })
 
-// Helm repository
+// Helm repository (HTTP/HTTPS)
 helmRepo := fluxcd.HelmRepository(&fluxcd.HelmRepositoryConfig{
     Name:      "bitnami",
     Namespace: "flux-system",
     URL:       "https://charts.bitnami.com/bitnami",
-    Interval:  "1h",
+})
+
+// Helm repository (OCI registry)
+ociRepo := fluxcd.HelmRepository(&fluxcd.HelmRepositoryConfig{
+    Name:      "ghcr",
+    Namespace: "flux-system",
+    URL:       "oci://ghcr.io/example/charts",
+    Type:      sourcev1.HelmRepositoryTypeOCI, // "oci"
 })
 
 // Bucket source

--- a/pkg/kubernetes/fluxcd/README.md
+++ b/pkg/kubernetes/fluxcd/README.md
@@ -41,7 +41,7 @@ helmRepo := fluxcd.HelmRepository(&fluxcd.HelmRepositoryConfig{
 })
 
 // Helm repository (OCI registry)
-ociRepo := fluxcd.HelmRepository(&fluxcd.HelmRepositoryConfig{
+ociHelmRepo := fluxcd.HelmRepository(&fluxcd.HelmRepositoryConfig{
     Name:      "ghcr",
     Namespace: "flux-system",
     URL:       "oci://ghcr.io/example/charts",

--- a/pkg/kubernetes/fluxcd/create.go
+++ b/pkg/kubernetes/fluxcd/create.go
@@ -38,6 +38,9 @@ func HelmRepository(cfg *HelmRepositoryConfig) *sourcev1.HelmRepository {
 	}
 	obj := intfluxcd.CreateHelmRepository(cfg.Name, cfg.Namespace, sourcev1.HelmRepositorySpec{})
 	intfluxcd.SetHelmRepositoryURL(obj, cfg.URL)
+	if cfg.Type != "" {
+		intfluxcd.SetHelmRepositoryType(obj, cfg.Type)
+	}
 	return obj
 }
 

--- a/pkg/kubernetes/fluxcd/create_test.go
+++ b/pkg/kubernetes/fluxcd/create_test.go
@@ -109,6 +109,47 @@ func TestHelmRepository_NilConfig(t *testing.T) {
 	}
 }
 
+func TestHelmRepository_NoType(t *testing.T) {
+	cfg := &HelmRepositoryConfig{
+		Name:      "bitnami",
+		Namespace: "flux-system",
+		URL:       "https://charts.bitnami.com/bitnami",
+	}
+
+	helmRepo := HelmRepository(cfg)
+
+	if helmRepo == nil {
+		t.Fatal("expected non-nil HelmRepository")
+	}
+
+	if helmRepo.Spec.Type != "" {
+		t.Errorf("expected empty Type, got %s", helmRepo.Spec.Type)
+	}
+}
+
+func TestHelmRepository_OCI(t *testing.T) {
+	cfg := &HelmRepositoryConfig{
+		Name:      "ghcr",
+		Namespace: "flux-system",
+		URL:       "oci://ghcr.io/example/charts",
+		Type:      sourcev1.HelmRepositoryTypeOCI,
+	}
+
+	helmRepo := HelmRepository(cfg)
+
+	if helmRepo == nil {
+		t.Fatal("expected non-nil HelmRepository")
+	}
+
+	if helmRepo.Spec.URL != "oci://ghcr.io/example/charts" {
+		t.Errorf("expected URL 'oci://ghcr.io/example/charts', got %s", helmRepo.Spec.URL)
+	}
+
+	if helmRepo.Spec.Type != sourcev1.HelmRepositoryTypeOCI {
+		t.Errorf("expected Type %q, got %q", sourcev1.HelmRepositoryTypeOCI, helmRepo.Spec.Type)
+	}
+}
+
 func TestBucket_Success(t *testing.T) {
 	cfg := &BucketConfig{
 		Name:       "s3-bucket",

--- a/pkg/kubernetes/fluxcd/types.go
+++ b/pkg/kubernetes/fluxcd/types.go
@@ -32,6 +32,7 @@ type HelmRepositoryConfig struct {
 	Name      string `yaml:"name"`
 	Namespace string `yaml:"namespace"`
 	URL       string `yaml:"url"`
+	Type      string `yaml:"type,omitempty"`
 }
 
 // BucketConfig contains the configuration for a Bucket source.


### PR DESCRIPTION
## Summary

- Adds a `Type string` field to `HelmRepositoryConfig` with `yaml:"type,omitempty"` tag
- Updates the `HelmRepository()` builder to call `SetHelmRepositoryType` when `Type` is non-empty
- Uses the existing `internal/fluxcd.SetHelmRepositoryType` setter (already present, takes `string`)

## Why

Flux source-controller requires `spec.type: oci` for HelmRepository resources that reference OCI chart registries (`oci://` URLs). Without this field, callers had to mutate the returned object directly after calling `HelmRepository()` — a kure boundary violation. This change brings OCI type configuration within the builder pattern.

Valid values are `sourcev1.HelmRepositoryTypeOCI` (`"oci"`) and `sourcev1.HelmRepositoryTypeDefault` (`"default"`). The field is omitted when empty, preserving backward compatibility for HTTP/HTTPS repositories.

## Crane consumer reference

Crane issue crane#175 uses a Flux Operator HelmRelease with an OCI chart registry and requires this field to configure the upstream HelmRepository correctly.

## Test plan

- [ ] `TestHelmRepository_NoType` — omitting `Type` leaves `spec.type` empty (default HTTP behaviour)
- [ ] `TestHelmRepository_OCI` — setting `Type: sourcev1.HelmRepositoryTypeOCI` produces `spec.type: oci`
- [ ] `TestHelmRepository_NilConfig` — nil config returns nil (existing, unchanged)
- [ ] `TestHelmRepository_Success` — existing HTTP repository test continues to pass
- [ ] `mise run verify` passes (tidy, lint, all tests)