### PR TITLE
feat(kubernetes/fluxcd): extend HelmReleaseConfig with chartRef, valuesFrom, and remediation

### DIFF
--- a/pkg/kubernetes/fluxcd/README.md
+++ b/pkg/kubernetes/fluxcd/README.md
@@ -73,18 +73,38 @@ ks := fluxcd.Kustomization(&fluxcd.KustomizationConfig{
     },
 })
 
-// HelmRelease (reconciles a Helm chart)
+// HelmRelease — chart template mode (chart + version + source reference)
 hr := fluxcd.HelmRelease(&fluxcd.HelmReleaseConfig{
-    Name:       "redis",
-    Namespace:  "default",
-    Chart:      "redis",
-    Version:    "17.0.0",
-    RepoName:   "bitnami",
-    RepoNamespace: "flux-system",
-    Values: map[string]interface{}{
-        "auth": map[string]interface{}{
-            "enabled": false,
-        },
+    Name:        "redis",
+    Namespace:   "apps",
+    Chart:       "redis",
+    Version:     "17.0.0",
+    SourceRef:   helmv2.CrossNamespaceObjectReference{Kind: "HelmRepository", Name: "bitnami"},
+    Interval:    "10m",
+    ReleaseName: "redis",
+    TargetNamespace:       "databases",
+    DriftDetectionMode:    "enabled",
+    InstallCRDs:           "CreateReplace",
+    InstallRetries:        ptr(3),
+    UpgradeCRDs:           "Skip",
+    UpgradeCleanupOnFail:  true,
+    UpgradeRetries:        ptr(3),
+    RollbackCleanupOnFail: true,
+    ValuesFrom: []fluxcd.ValuesFromConfig{
+        {Kind: "ConfigMap", Name: "redis-values"},
+        {Kind: "Secret", Name: "redis-secret", Optional: true},
+    },
+})
+
+// HelmRelease — chartRef mode (references an existing OCIRepository or HelmChart)
+hr = fluxcd.HelmRelease(&fluxcd.HelmReleaseConfig{
+    Name:      "my-app",
+    Namespace: "apps",
+    Interval:  "10m",
+    ChartRef: &fluxcd.ChartRefConfig{
+        Kind:      "OCIRepository",
+        Name:      "my-oci-source",
+        Namespace: "flux-system",
     },
 })
 ```

--- a/pkg/kubernetes/fluxcd/README.md
+++ b/pkg/kubernetes/fluxcd/README.md
@@ -74,6 +74,8 @@ ks := fluxcd.Kustomization(&fluxcd.KustomizationConfig{
 })
 
 // HelmRelease — chart template mode (chart + version + source reference)
+installRetries := 3
+upgradeRetries := 3
 hr := fluxcd.HelmRelease(&fluxcd.HelmReleaseConfig{
     Name:        "redis",
     Namespace:   "apps",
@@ -85,10 +87,10 @@ hr := fluxcd.HelmRelease(&fluxcd.HelmReleaseConfig{
     TargetNamespace:       "databases",
     DriftDetectionMode:    "enabled",
     InstallCRDs:           "CreateReplace",
-    InstallRetries:        ptr(3),
+    InstallRetries:        &installRetries,
     UpgradeCRDs:           "Skip",
     UpgradeCleanupOnFail:  true,
-    UpgradeRetries:        ptr(3),
+    UpgradeRetries:        &upgradeRetries,
     RollbackCleanupOnFail: true,
     ValuesFrom: []fluxcd.ValuesFromConfig{
         {Kind: "ConfigMap", Name: "redis-values"},

--- a/pkg/kubernetes/fluxcd/create.go
+++ b/pkg/kubernetes/fluxcd/create.go
@@ -107,18 +107,87 @@ func HelmRelease(cfg *HelmReleaseConfig) *helmv2.HelmRelease {
 		return nil
 	}
 	obj := intfluxcd.CreateHelmRelease(cfg.Name, cfg.Namespace, helmv2.HelmReleaseSpec{})
-	chart := helmv2.HelmChartTemplate{
-		Spec: helmv2.HelmChartTemplateSpec{
-			Chart:     cfg.Chart,
-			Version:   cfg.Version,
-			SourceRef: cfg.SourceRef,
-		},
+
+	if cfg.ChartRef != nil {
+		ref := &helmv2.CrossNamespaceSourceReference{
+			Kind: cfg.ChartRef.Kind,
+			Name: cfg.ChartRef.Name,
+		}
+		if cfg.ChartRef.Namespace != "" {
+			ref.Namespace = cfg.ChartRef.Namespace
+		}
+		intfluxcd.SetHelmReleaseChartRef(obj, ref)
+	} else if cfg.Chart != "" {
+		chart := &helmv2.HelmChartTemplate{
+			Spec: helmv2.HelmChartTemplateSpec{
+				Chart:     cfg.Chart,
+				Version:   cfg.Version,
+				SourceRef: cfg.SourceRef,
+			},
+		}
+		intfluxcd.SetHelmReleaseChart(obj, chart)
 	}
-	intfluxcd.SetHelmReleaseChart(obj, &chart)
+
 	intfluxcd.SetHelmReleaseInterval(obj, metav1.Duration{Duration: parseDurationOrDefault(cfg.Interval)})
+
 	if cfg.ReleaseName != "" {
 		intfluxcd.SetHelmReleaseReleaseName(obj, cfg.ReleaseName)
 	}
+	if cfg.TargetNamespace != "" {
+		intfluxcd.SetHelmReleaseTargetNamespace(obj, cfg.TargetNamespace)
+	}
+	if cfg.DriftDetectionMode != "" {
+		dd := intfluxcd.CreateDriftDetection(helmv2.DriftDetectionMode(cfg.DriftDetectionMode))
+		intfluxcd.SetHelmReleaseDriftDetection(obj, dd)
+	}
+
+	if cfg.InstallCRDs != "" || cfg.InstallRetries != nil {
+		install := &helmv2.Install{}
+		if cfg.InstallCRDs != "" {
+			install.CRDs = helmv2.CRDsPolicy(cfg.InstallCRDs)
+		}
+		if cfg.InstallRetries != nil {
+			install.Remediation = &helmv2.InstallRemediation{Retries: *cfg.InstallRetries}
+		}
+		intfluxcd.SetHelmReleaseInstall(obj, install)
+	}
+
+	if cfg.UpgradeCRDs != "" || cfg.UpgradeRetries != nil || cfg.RemediateLastFailure != nil || cfg.UpgradeCleanupOnFail {
+		upgrade := &helmv2.Upgrade{}
+		if cfg.UpgradeCRDs != "" {
+			upgrade.CRDs = helmv2.CRDsPolicy(cfg.UpgradeCRDs)
+		}
+		if cfg.UpgradeCleanupOnFail {
+			upgrade.CleanupOnFail = true
+		}
+		if cfg.UpgradeRetries != nil || cfg.RemediateLastFailure != nil {
+			remediation := &helmv2.UpgradeRemediation{}
+			if cfg.UpgradeRetries != nil {
+				remediation.Retries = *cfg.UpgradeRetries
+			}
+			if cfg.RemediateLastFailure != nil {
+				remediation.RemediateLastFailure = cfg.RemediateLastFailure
+			}
+			upgrade.Remediation = remediation
+		}
+		intfluxcd.SetHelmReleaseUpgrade(obj, upgrade)
+	}
+
+	if cfg.RollbackCleanupOnFail {
+		intfluxcd.SetHelmReleaseRollback(obj, &helmv2.Rollback{CleanupOnFail: true})
+	}
+
+	for _, vf := range cfg.ValuesFrom {
+		ref := helmv2.ValuesReference{
+			Kind:       vf.Kind,
+			Name:       vf.Name,
+			ValuesKey:  vf.ValuesKey,
+			TargetPath: vf.TargetPath,
+			Optional:   vf.Optional,
+		}
+		intfluxcd.AddHelmReleaseValuesFrom(obj, ref)
+	}
+
 	return obj
 }
 

--- a/pkg/kubernetes/fluxcd/create_test.go
+++ b/pkg/kubernetes/fluxcd/create_test.go
@@ -556,7 +556,6 @@ func TestHelmRelease_RollbackCleanupOnFail(t *testing.T) {
 }
 
 func TestHelmRelease_ValuesFrom(t *testing.T) {
-	optional := true
 	cfg := &HelmReleaseConfig{
 		Name:      "my-app",
 		Namespace: "flux-system",
@@ -568,7 +567,6 @@ func TestHelmRelease_ValuesFrom(t *testing.T) {
 			{Kind: "Secret", Name: "my-secret", TargetPath: "secret.key", Optional: true},
 		},
 	}
-	_ = optional
 	hr := HelmRelease(cfg)
 	if len(hr.Spec.ValuesFrom) != 2 {
 		t.Fatalf("expected 2 ValuesFrom entries, got %d", len(hr.Spec.ValuesFrom))

--- a/pkg/kubernetes/fluxcd/create_test.go
+++ b/pkg/kubernetes/fluxcd/create_test.go
@@ -413,6 +413,200 @@ func TestHelmRelease_Success(t *testing.T) {
 	}
 }
 
+func TestHelmRelease_ChartRef(t *testing.T) {
+	cfg := &HelmReleaseConfig{
+		Name:      "my-app",
+		Namespace: "apps",
+		Interval:  "10m",
+		ChartRef: &ChartRefConfig{
+			Kind:      "OCIRepository",
+			Name:      "my-oci-source",
+			Namespace: "flux-system",
+		},
+	}
+	hr := HelmRelease(cfg)
+	if hr == nil {
+		t.Fatal("expected non-nil HelmRelease")
+	}
+	if hr.Spec.ChartRef == nil {
+		t.Fatal("expected non-nil ChartRef")
+	}
+	if hr.Spec.ChartRef.Kind != "OCIRepository" {
+		t.Errorf("expected ChartRef.Kind OCIRepository, got %s", hr.Spec.ChartRef.Kind)
+	}
+	if hr.Spec.ChartRef.Name != "my-oci-source" {
+		t.Errorf("expected ChartRef.Name my-oci-source, got %s", hr.Spec.ChartRef.Name)
+	}
+	if hr.Spec.ChartRef.Namespace != "flux-system" {
+		t.Errorf("expected ChartRef.Namespace flux-system, got %s", hr.Spec.ChartRef.Namespace)
+	}
+	if hr.Spec.Chart != nil {
+		t.Error("expected nil Chart when ChartRef is set")
+	}
+}
+
+func TestHelmRelease_ChartRefNoNamespace(t *testing.T) {
+	cfg := &HelmReleaseConfig{
+		Name:      "my-app",
+		Namespace: "apps",
+		Interval:  "10m",
+		ChartRef:  &ChartRefConfig{Kind: "HelmChart", Name: "local-chart"},
+	}
+	hr := HelmRelease(cfg)
+	if hr.Spec.ChartRef == nil {
+		t.Fatal("expected non-nil ChartRef")
+	}
+	if hr.Spec.ChartRef.Namespace != "" {
+		t.Errorf("expected empty Namespace, got %q", hr.Spec.ChartRef.Namespace)
+	}
+}
+
+func TestHelmRelease_TargetNamespace(t *testing.T) {
+	cfg := &HelmReleaseConfig{
+		Name:            "my-app",
+		Namespace:       "flux-system",
+		Interval:        "10m",
+		Chart:           "nginx",
+		SourceRef:       helmv2.CrossNamespaceObjectReference{Kind: "HelmRepository", Name: "bitnami"},
+		TargetNamespace: "production",
+	}
+	hr := HelmRelease(cfg)
+	if hr.Spec.TargetNamespace != "production" {
+		t.Errorf("expected TargetNamespace production, got %s", hr.Spec.TargetNamespace)
+	}
+}
+
+func TestHelmRelease_DriftDetection(t *testing.T) {
+	cfg := &HelmReleaseConfig{
+		Name:               "my-app",
+		Namespace:          "flux-system",
+		Interval:           "10m",
+		Chart:              "nginx",
+		SourceRef:          helmv2.CrossNamespaceObjectReference{Kind: "HelmRepository", Name: "bitnami"},
+		DriftDetectionMode: "enabled",
+	}
+	hr := HelmRelease(cfg)
+	if hr.Spec.DriftDetection == nil {
+		t.Fatal("expected non-nil DriftDetection")
+	}
+	if string(hr.Spec.DriftDetection.Mode) != "enabled" {
+		t.Errorf("expected DriftDetection.Mode enabled, got %s", hr.Spec.DriftDetection.Mode)
+	}
+}
+
+func TestHelmRelease_InstallUpgrade(t *testing.T) {
+	retries := 3
+	remediateLastFailure := true
+	cfg := &HelmReleaseConfig{
+		Name:                 "my-app",
+		Namespace:            "flux-system",
+		Interval:             "10m",
+		Chart:                "nginx",
+		SourceRef:            helmv2.CrossNamespaceObjectReference{Kind: "HelmRepository", Name: "bitnami"},
+		InstallCRDs:          "CreateReplace",
+		InstallRetries:       &retries,
+		UpgradeCRDs:          "Skip",
+		UpgradeRetries:       &retries,
+		RemediateLastFailure: &remediateLastFailure,
+		UpgradeCleanupOnFail: true,
+	}
+	hr := HelmRelease(cfg)
+	if hr.Spec.Install == nil {
+		t.Fatal("expected non-nil Install")
+	}
+	if string(hr.Spec.Install.CRDs) != "CreateReplace" {
+		t.Errorf("expected Install.CRDs CreateReplace, got %s", hr.Spec.Install.CRDs)
+	}
+	if hr.Spec.Install.Remediation == nil || hr.Spec.Install.Remediation.Retries != 3 {
+		t.Errorf("expected Install.Remediation.Retries 3, got %v", hr.Spec.Install.Remediation)
+	}
+	if hr.Spec.Upgrade == nil {
+		t.Fatal("expected non-nil Upgrade")
+	}
+	if string(hr.Spec.Upgrade.CRDs) != "Skip" {
+		t.Errorf("expected Upgrade.CRDs Skip, got %s", hr.Spec.Upgrade.CRDs)
+	}
+	if !hr.Spec.Upgrade.CleanupOnFail {
+		t.Error("expected Upgrade.CleanupOnFail true")
+	}
+	if hr.Spec.Upgrade.Remediation == nil || hr.Spec.Upgrade.Remediation.Retries != 3 {
+		t.Errorf("expected Upgrade.Remediation.Retries 3, got %v", hr.Spec.Upgrade.Remediation)
+	}
+	if hr.Spec.Upgrade.Remediation.RemediateLastFailure == nil || !*hr.Spec.Upgrade.Remediation.RemediateLastFailure {
+		t.Error("expected RemediateLastFailure true")
+	}
+}
+
+func TestHelmRelease_RollbackCleanupOnFail(t *testing.T) {
+	cfg := &HelmReleaseConfig{
+		Name:                  "my-app",
+		Namespace:             "flux-system",
+		Interval:              "10m",
+		Chart:                 "nginx",
+		SourceRef:             helmv2.CrossNamespaceObjectReference{Kind: "HelmRepository", Name: "bitnami"},
+		RollbackCleanupOnFail: true,
+	}
+	hr := HelmRelease(cfg)
+	if hr.Spec.Rollback == nil {
+		t.Fatal("expected non-nil Rollback")
+	}
+	if !hr.Spec.Rollback.CleanupOnFail {
+		t.Error("expected Rollback.CleanupOnFail true")
+	}
+}
+
+func TestHelmRelease_ValuesFrom(t *testing.T) {
+	optional := true
+	cfg := &HelmReleaseConfig{
+		Name:      "my-app",
+		Namespace: "flux-system",
+		Interval:  "10m",
+		Chart:     "nginx",
+		SourceRef: helmv2.CrossNamespaceObjectReference{Kind: "HelmRepository", Name: "bitnami"},
+		ValuesFrom: []ValuesFromConfig{
+			{Kind: "ConfigMap", Name: "my-values", ValuesKey: "values.yaml"},
+			{Kind: "Secret", Name: "my-secret", TargetPath: "secret.key", Optional: true},
+		},
+	}
+	_ = optional
+	hr := HelmRelease(cfg)
+	if len(hr.Spec.ValuesFrom) != 2 {
+		t.Fatalf("expected 2 ValuesFrom entries, got %d", len(hr.Spec.ValuesFrom))
+	}
+	if hr.Spec.ValuesFrom[0].Kind != "ConfigMap" || hr.Spec.ValuesFrom[0].Name != "my-values" {
+		t.Errorf("unexpected ValuesFrom[0]: %+v", hr.Spec.ValuesFrom[0])
+	}
+	if hr.Spec.ValuesFrom[1].Kind != "Secret" || !hr.Spec.ValuesFrom[1].Optional {
+		t.Errorf("unexpected ValuesFrom[1]: %+v", hr.Spec.ValuesFrom[1])
+	}
+	if hr.Spec.ValuesFrom[1].TargetPath != "secret.key" {
+		t.Errorf("expected TargetPath secret.key, got %s", hr.Spec.ValuesFrom[1].TargetPath)
+	}
+}
+
+func TestHelmRelease_NoDriftDetectionWhenEmpty(t *testing.T) {
+	cfg := &HelmReleaseConfig{
+		Name:      "my-app",
+		Namespace: "flux-system",
+		Interval:  "10m",
+		Chart:     "nginx",
+		SourceRef: helmv2.CrossNamespaceObjectReference{Kind: "HelmRepository", Name: "bitnami"},
+	}
+	hr := HelmRelease(cfg)
+	if hr.Spec.DriftDetection != nil {
+		t.Errorf("expected nil DriftDetection when mode is empty, got %+v", hr.Spec.DriftDetection)
+	}
+	if hr.Spec.Install != nil {
+		t.Errorf("expected nil Install when no install fields set, got %+v", hr.Spec.Install)
+	}
+	if hr.Spec.Upgrade != nil {
+		t.Errorf("expected nil Upgrade when no upgrade fields set, got %+v", hr.Spec.Upgrade)
+	}
+	if hr.Spec.Rollback != nil {
+		t.Errorf("expected nil Rollback when RollbackCleanupOnFail is false, got %+v", hr.Spec.Rollback)
+	}
+}
+
 func TestProvider_Success(t *testing.T) {
 	cfg := &ProviderConfig{
 		Name:      "slack-provider",

--- a/pkg/kubernetes/fluxcd/types.go
+++ b/pkg/kubernetes/fluxcd/types.go
@@ -65,15 +65,60 @@ type KustomizationConfig struct {
 	SourceRef kustv1.CrossNamespaceSourceReference `yaml:"sourceRef"`
 }
 
+// ChartRefConfig references an existing Flux source (OCIRepository or HelmChart)
+// for use as the chart source in chartRef mode.
+type ChartRefConfig struct {
+	Kind      string `yaml:"kind"` // "OCIRepository" or "HelmChart"
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace,omitempty"`
+}
+
+// ValuesFromConfig describes a single entry in spec.valuesFrom.
+type ValuesFromConfig struct {
+	Kind       string `yaml:"kind"` // "ConfigMap" or "Secret"
+	Name       string `yaml:"name"`
+	ValuesKey  string `yaml:"valuesKey,omitempty"` // defaults to "values.yaml" when empty
+	TargetPath string `yaml:"targetPath,omitempty"`
+	Optional   bool   `yaml:"optional,omitempty"`
+}
+
 // HelmReleaseConfig contains the configuration for a HelmRelease.
+// ChartRef and Chart/Version/SourceRef are mutually exclusive:
+// when ChartRef is non-nil the chart template fields are ignored.
 type HelmReleaseConfig struct {
-	Name        string                               `yaml:"name"`
-	Namespace   string                               `yaml:"namespace"`
-	Chart       string                               `yaml:"chart"`
-	Version     string                               `yaml:"version,omitempty"`
-	SourceRef   helmv2.CrossNamespaceObjectReference `yaml:"sourceRef"`
-	Interval    string                               `yaml:"interval"`
-	ReleaseName string                               `yaml:"releaseName,omitempty"`
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace"`
+	// Chart source via inline HelmChartTemplate (mutually exclusive with ChartRef).
+	Chart     string                               `yaml:"chart,omitempty"`
+	Version   string                               `yaml:"version,omitempty"`
+	SourceRef helmv2.CrossNamespaceObjectReference `yaml:"sourceRef,omitempty"`
+	// ChartRef references an existing OCIRepository or HelmChart (mutually exclusive with Chart/Version/SourceRef).
+	ChartRef    *ChartRefConfig `yaml:"chartRef,omitempty"`
+	Interval    string          `yaml:"interval"`
+	ReleaseName string          `yaml:"releaseName,omitempty"`
+	// TargetNamespace deploys Helm-managed resources into a namespace other than
+	// the HelmRelease CR itself.
+	TargetNamespace string `yaml:"targetNamespace,omitempty"`
+	// DriftDetectionMode is "enabled", "warn", or "disabled". When empty, drift
+	// detection is not configured.
+	DriftDetectionMode string `yaml:"driftDetectionMode,omitempty"`
+	// InstallCRDs controls CRD handling on install: "Skip", "Create", or "CreateReplace".
+	InstallCRDs string `yaml:"installCRDs,omitempty"`
+	// InstallRetries sets spec.install.remediation.retries.
+	InstallRetries *int `yaml:"installRetries,omitempty"`
+	// UpgradeCRDs controls CRD handling on upgrade: "Skip", "Create", or "CreateReplace".
+	UpgradeCRDs string `yaml:"upgradeCRDs,omitempty"`
+	// UpgradeRetries sets spec.upgrade.remediation.retries.
+	UpgradeRetries *int `yaml:"upgradeRetries,omitempty"`
+	// RemediateLastFailure sets spec.upgrade.remediation.remediateLastFailure.
+	RemediateLastFailure *bool `yaml:"remediateLastFailure,omitempty"`
+	// UpgradeCleanupOnFail sets spec.upgrade.cleanupOnFail.
+	UpgradeCleanupOnFail bool `yaml:"upgradeCleanupOnFail,omitempty"`
+	// RollbackCleanupOnFail sets spec.rollback.cleanupOnFail.
+	RollbackCleanupOnFail bool `yaml:"rollbackCleanupOnFail,omitempty"`
+	// ValuesFrom is a list of references to ConfigMaps or Secrets whose data
+	// is merged into the Helm values.
+	ValuesFrom []ValuesFromConfig `yaml:"valuesFrom,omitempty"`
 }
 
 // ProviderConfig contains the configuration for a notification Provider.


### PR DESCRIPTION
Closes #496

## Summary

- Adds `ChartRefConfig` struct for referencing existing OCIRepository or HelmChart sources (chartRef mode, mutually exclusive with Chart/Version/SourceRef)
- Adds `ValuesFromConfig` domain struct for `spec.valuesFrom` entries (Kind, Name, ValuesKey, TargetPath, Optional)
- Extends `HelmReleaseConfig` with: `TargetNamespace`, `DriftDetectionMode`, `InstallCRDs`, `InstallRetries`, `UpgradeCRDs`, `UpgradeRetries`, `RemediateLastFailure`, `UpgradeCleanupOnFail`, `RollbackCleanupOnFail`, `ValuesFrom`
- Updates `HelmRelease()` builder to map all new fields via existing internal setters
- Covers the complete field set used by crane's unstructured HelmRelease construction (`internal/transform/components/helmrelease.go`)

## Why

Crane builds HelmRelease objects via `unstructured.Unstructured` because the previous `HelmReleaseConfig` only covered chart name, version, source ref, interval, and release name. This change brings the full field set into the kure builder, allowing crane to eliminate its raw struct construction entirely.

## Crane consumer reference

`crane/internal/transform/components/helmrelease.go:417–556` (`createHelmRelease`) — complete field-by-field mapping is now possible.

## Test plan

- [ ] `TestHelmRelease_Success` — existing chart template mode continues to pass
- [ ] `TestHelmRelease_ChartRef` — ChartRef mode produces correct `spec.chartRef`
- [ ] `TestHelmRelease_ChartRefNoNamespace` — namespace omitted when empty
- [ ] `TestHelmRelease_TargetNamespace` — `spec.targetNamespace` set correctly
- [ ] `TestHelmRelease_DriftDetection` — `spec.driftDetection.mode` set correctly
- [ ] `TestHelmRelease_InstallUpgrade` — install/upgrade CRDs, retries, cleanupOnFail, remediateLastFailure
- [ ] `TestHelmRelease_RollbackCleanupOnFail` — `spec.rollback.cleanupOnFail` set correctly
- [ ] `TestHelmRelease_ValuesFrom` — `spec.valuesFrom` entries including Optional and TargetPath
- [ ] `TestHelmRelease_NoDriftDetectionWhenEmpty` — nil blocks when fields are not set
- [ ] `mise run verify` passes (tidy, lint, all tests)