### PR TITLE
feat(fluxcd): extend builders for infra component use cases

### DIFF
--- a/pkg/kubernetes/fluxcd/README.md
+++ b/pkg/kubernetes/fluxcd/README.md
@@ -20,16 +20,25 @@ gitRepo := fluxcd.GitRepository(&fluxcd.GitRepositoryConfig{
     Name:      "my-repo",
     Namespace: "flux-system",
     URL:       "https://github.com/org/repo",
-    Branch:    "main",
+    Ref:       "main",
     Interval:  "5m",
 })
 
-// OCI repository source
+// OCI repository source — tag reference
 ociRepo := fluxcd.OCIRepository(&fluxcd.OCIRepositoryConfig{
     Name:      "my-oci",
     Namespace: "flux-system",
     URL:       "oci://registry.example.com/manifests",
-    Tag:       "latest",
+    Ref:       "latest",
+    Interval:  "10m",
+})
+
+// OCI repository source — digest (content-addressable) reference
+ociRepoDigest := fluxcd.OCIRepository(&fluxcd.OCIRepositoryConfig{
+    Name:      "my-oci-pinned",
+    Namespace: "flux-system",
+    URL:       "oci://registry.example.com/manifests",
+    Digest:    "sha256:abc123...",
     Interval:  "10m",
 })
 
@@ -38,6 +47,7 @@ helmRepo := fluxcd.HelmRepository(&fluxcd.HelmRepositoryConfig{
     Name:      "bitnami",
     Namespace: "flux-system",
     URL:       "https://charts.bitnami.com/bitnami",
+    Interval:  "10m",
 })
 
 // Helm repository (OCI registry)
@@ -46,13 +56,14 @@ ociHelmRepo := fluxcd.HelmRepository(&fluxcd.HelmRepositoryConfig{
     Namespace: "flux-system",
     URL:       "oci://ghcr.io/example/charts",
     Type:      sourcev1.HelmRepositoryTypeOCI, // "oci"
+    Interval:  "10m",
 })
 
 // Bucket source
 bucket := fluxcd.Bucket(&fluxcd.BucketConfig{
-    Name:      "my-bucket",
-    Namespace: "flux-system",
-    Endpoint:  "minio.example.com",
+    Name:       "my-bucket",
+    Namespace:  "flux-system",
+    Endpoint:   "minio.example.com",
     BucketName: "manifests",
 })
 ```
@@ -62,11 +73,13 @@ bucket := fluxcd.Bucket(&fluxcd.BucketConfig{
 ```go
 // Kustomization (reconciles manifests from a source)
 ks := fluxcd.Kustomization(&fluxcd.KustomizationConfig{
-    Name:      "my-app",
-    Namespace: "flux-system",
-    Path:      "./clusters/production/apps",
-    Interval:  "10m",
-    Prune:     true,
+    Name:            "my-app",
+    Namespace:       "flux-system",
+    Path:            "./clusters/production/apps",
+    Interval:        "10m",
+    Prune:           true,
+    TargetNamespace: "production",
+    Wait:            true,
     SourceRef: kustv1.CrossNamespaceSourceReference{
         Kind: "GitRepository",
         Name: "my-repo",
@@ -96,6 +109,9 @@ hr := fluxcd.HelmRelease(&fluxcd.HelmReleaseConfig{
         {Kind: "ConfigMap", Name: "redis-values"},
         {Kind: "Secret", Name: "redis-secret", Optional: true},
     },
+    Values: map[string]any{
+        "replicaCount": 1,
+    },
 })
 
 // HelmRelease — chartRef mode (references an existing OCIRepository or HelmChart)
@@ -120,10 +136,10 @@ hr = fluxcd.HelmRelease(&fluxcd.HelmReleaseConfig{
 ```go
 // Alert
 alert := fluxcd.Alert(&fluxcd.AlertConfig{
-    Name:      "slack-alert",
-    Namespace: "flux-system",
-    Provider:  "slack",
-    Severity:  "error",
+    Name:          "slack-alert",
+    Namespace:     "flux-system",
+    ProviderRef:   "slack",
+    EventSeverity: "error",
 })
 
 // Provider

--- a/pkg/kubernetes/fluxcd/create.go
+++ b/pkg/kubernetes/fluxcd/create.go
@@ -1,6 +1,7 @@
 package fluxcd
 
 import (
+	"encoding/json"
 	"time"
 
 	intfluxcd "github.com/go-kure/kure/internal/fluxcd"
@@ -14,6 +15,7 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
 	fluxv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -40,6 +42,9 @@ func HelmRepository(cfg *HelmRepositoryConfig) *sourcev1.HelmRepository {
 	intfluxcd.SetHelmRepositoryURL(obj, cfg.URL)
 	if cfg.Type != "" {
 		intfluxcd.SetHelmRepositoryType(obj, cfg.Type)
+	}
+	if cfg.Interval != "" {
+		intfluxcd.SetHelmRepositoryInterval(obj, metav1.Duration{Duration: parseDurationOrDefault(cfg.Interval)})
 	}
 	return obj
 }
@@ -79,9 +84,15 @@ func OCIRepository(cfg *OCIRepositoryConfig) *sourcev1.OCIRepository {
 	if cfg == nil {
 		return nil
 	}
+	ref := &sourcev1.OCIRepositoryRef{}
+	if cfg.Digest != "" {
+		ref.Digest = cfg.Digest
+	} else {
+		ref.Tag = cfg.Ref
+	}
 	spec := sourcev1.OCIRepositorySpec{
 		URL:       cfg.URL,
-		Reference: &sourcev1.OCIRepositoryRef{Tag: cfg.Ref},
+		Reference: ref,
 		Interval:  metav1.Duration{Duration: parseDurationOrDefault(cfg.Interval)},
 	}
 	return intfluxcd.CreateOCIRepository(cfg.Name, cfg.Namespace, spec)
@@ -97,6 +108,12 @@ func Kustomization(cfg *KustomizationConfig) *kustv1.Kustomization {
 	intfluxcd.SetKustomizationSourceRef(obj, cfg.SourceRef)
 	if cfg.Path != "" {
 		intfluxcd.SetKustomizationPath(obj, cfg.Path)
+	}
+	if cfg.TargetNamespace != "" {
+		intfluxcd.SetKustomizationTargetNamespace(obj, cfg.TargetNamespace)
+	}
+	if cfg.Wait {
+		intfluxcd.SetKustomizationWait(obj, true)
 	}
 	return obj
 }
@@ -186,6 +203,13 @@ func HelmRelease(cfg *HelmReleaseConfig) *helmv2.HelmRelease {
 			Optional:   vf.Optional,
 		}
 		intfluxcd.AddHelmReleaseValuesFrom(obj, ref)
+	}
+
+	if len(cfg.Values) > 0 {
+		raw, err := json.Marshal(cfg.Values)
+		if err == nil {
+			intfluxcd.SetHelmReleaseValues(obj, &apiextensionsv1.JSON{Raw: raw})
+		}
 	}
 
 	return obj

--- a/pkg/kubernetes/fluxcd/create.go
+++ b/pkg/kubernetes/fluxcd/create.go
@@ -206,6 +206,8 @@ func HelmRelease(cfg *HelmReleaseConfig) *helmv2.HelmRelease {
 	}
 
 	if len(cfg.Values) > 0 {
+		// Marshal errors are only possible for non-serialisable types (channels,
+		// funcs) which callers will never pass in a values map.
 		raw, err := json.Marshal(cfg.Values)
 		if err == nil {
 			intfluxcd.SetHelmReleaseValues(obj, &apiextensionsv1.JSON{Raw: raw})

--- a/pkg/kubernetes/fluxcd/create_test.go
+++ b/pkg/kubernetes/fluxcd/create_test.go
@@ -1,6 +1,7 @@
 package fluxcd
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -314,6 +315,29 @@ func TestOCIRepository_Digest(t *testing.T) {
 	}
 }
 
+func TestOCIRepository_DigestOnly(t *testing.T) {
+	cfg := &OCIRepositoryConfig{
+		Name:      "test-oci",
+		Namespace: "flux-system",
+		URL:       "oci://registry.example.com/repo",
+		Digest:    "sha256:def456",
+		Interval:  "1m",
+	}
+	ociRepo := OCIRepository(cfg)
+	if ociRepo == nil {
+		t.Fatal("expected non-nil OCIRepository")
+	}
+	if ociRepo.Spec.Reference == nil {
+		t.Fatal("expected non-nil Reference")
+	}
+	if ociRepo.Spec.Reference.Digest != "sha256:def456" {
+		t.Errorf("expected digest 'sha256:def456', got %s", ociRepo.Spec.Reference.Digest)
+	}
+	if ociRepo.Spec.Reference.Tag != "" {
+		t.Errorf("expected empty Tag, got %s", ociRepo.Spec.Reference.Tag)
+	}
+}
+
 func TestHelmRepository_Interval(t *testing.T) {
 	cfg := &HelmRepositoryConfig{
 		Name:      "bitnami",
@@ -448,6 +472,13 @@ func TestHelmRelease_Values(t *testing.T) {
 	raw := string(hr.Spec.Values.Raw)
 	if raw == "" {
 		t.Error("expected non-empty Values.Raw")
+	}
+	// Verify the JSON contains expected keys.
+	if !strings.Contains(raw, `"replicaCount"`) {
+		t.Errorf("expected Values.Raw to contain replicaCount, got %s", raw)
+	}
+	if !strings.Contains(raw, `"tag"`) {
+		t.Errorf("expected Values.Raw to contain image.tag, got %s", raw)
 	}
 }
 

--- a/pkg/kubernetes/fluxcd/create_test.go
+++ b/pkg/kubernetes/fluxcd/create_test.go
@@ -290,6 +290,47 @@ func TestOCIRepository_Success(t *testing.T) {
 	}
 }
 
+func TestOCIRepository_Digest(t *testing.T) {
+	cfg := &OCIRepositoryConfig{
+		Name:      "test-oci",
+		Namespace: "flux-system",
+		URL:       "oci://registry.example.com/repo",
+		Ref:       "v1.0.0",
+		Digest:    "sha256:abc123",
+		Interval:  "1m",
+	}
+	ociRepo := OCIRepository(cfg)
+	if ociRepo == nil {
+		t.Fatal("expected non-nil OCIRepository")
+	}
+	if ociRepo.Spec.Reference == nil {
+		t.Fatal("expected non-nil Reference")
+	}
+	if ociRepo.Spec.Reference.Digest != "sha256:abc123" {
+		t.Errorf("expected digest 'sha256:abc123', got %s", ociRepo.Spec.Reference.Digest)
+	}
+	if ociRepo.Spec.Reference.Tag != "" {
+		t.Errorf("expected empty Tag when Digest is set, got %s", ociRepo.Spec.Reference.Tag)
+	}
+}
+
+func TestHelmRepository_Interval(t *testing.T) {
+	cfg := &HelmRepositoryConfig{
+		Name:      "bitnami",
+		Namespace: "flux-system",
+		URL:       "https://charts.bitnami.com/bitnami",
+		Interval:  "10m",
+	}
+	helmRepo := HelmRepository(cfg)
+	if helmRepo == nil {
+		t.Fatal("expected non-nil HelmRepository")
+	}
+	expected := 10 * time.Minute
+	if helmRepo.Spec.Interval.Duration != expected {
+		t.Errorf("expected interval %v, got %v", expected, helmRepo.Spec.Interval.Duration)
+	}
+}
+
 func TestKustomization_Success(t *testing.T) {
 	sourceRef := kustv1.CrossNamespaceSourceReference{
 		Kind:      "GitRepository",
@@ -358,6 +399,55 @@ func TestKustomization_NoPath(t *testing.T) {
 	// Path should remain empty when not specified
 	if kustomization.Spec.Path != "" {
 		t.Errorf("expected empty Path, got %s", kustomization.Spec.Path)
+	}
+}
+
+func TestKustomization_TargetNamespaceAndWait(t *testing.T) {
+	cfg := &KustomizationConfig{
+		Name:            "app",
+		Namespace:       "flux-system",
+		Interval:        "5m",
+		Prune:           true,
+		SourceRef:       kustv1.CrossNamespaceSourceReference{Kind: "GitRepository", Name: "repo"},
+		TargetNamespace: "production",
+		Wait:            true,
+	}
+	ks := Kustomization(cfg)
+	if ks == nil {
+		t.Fatal("expected non-nil Kustomization")
+	}
+	if ks.Spec.TargetNamespace != "production" {
+		t.Errorf("expected TargetNamespace 'production', got %s", ks.Spec.TargetNamespace)
+	}
+	if !ks.Spec.Wait {
+		t.Error("expected Wait true")
+	}
+}
+
+func TestHelmRelease_Values(t *testing.T) {
+	cfg := &HelmReleaseConfig{
+		Name:      "my-app",
+		Namespace: "flux-system",
+		Interval:  "10m",
+		Chart:     "nginx",
+		SourceRef: helmv2.CrossNamespaceObjectReference{Kind: "HelmRepository", Name: "bitnami"},
+		Values: map[string]any{
+			"replicaCount": 3,
+			"image": map[string]any{
+				"tag": "latest",
+			},
+		},
+	}
+	hr := HelmRelease(cfg)
+	if hr == nil {
+		t.Fatal("expected non-nil HelmRelease")
+	}
+	if hr.Spec.Values == nil {
+		t.Fatal("expected non-nil Values")
+	}
+	raw := string(hr.Spec.Values.Raw)
+	if raw == "" {
+		t.Error("expected non-empty Values.Raw")
 	}
 }
 

--- a/pkg/kubernetes/fluxcd/types.go
+++ b/pkg/kubernetes/fluxcd/types.go
@@ -16,7 +16,7 @@ type OCIRepositoryConfig struct {
 	Name      string `yaml:"name"`
 	Namespace string `yaml:"namespace"`
 	URL       string `yaml:"url"`
-	Ref       string `yaml:"ref"`
+	Ref       string `yaml:"ref,omitempty"`
 	// Digest is a content-addressable reference (e.g. "sha256:abc…"). When
 	// set, Ref is ignored and spec.reference.digest is used instead.
 	Digest   string `yaml:"digest,omitempty"`

--- a/pkg/kubernetes/fluxcd/types.go
+++ b/pkg/kubernetes/fluxcd/types.go
@@ -10,12 +10,17 @@ import (
 )
 
 // OCIRepositoryConfig describes an OCIRepository resource used by Flux.
+// Ref and Digest are mutually exclusive: when Digest is non-empty it is used
+// as spec.reference.digest and Ref is ignored.
 type OCIRepositoryConfig struct {
 	Name      string `yaml:"name"`
 	Namespace string `yaml:"namespace"`
 	URL       string `yaml:"url"`
 	Ref       string `yaml:"ref"`
-	Interval  string `yaml:"interval"`
+	// Digest is a content-addressable reference (e.g. "sha256:abc…"). When
+	// set, Ref is ignored and spec.reference.digest is used instead.
+	Digest   string `yaml:"digest,omitempty"`
+	Interval string `yaml:"interval"`
 }
 
 // GitRepositoryConfig contains the minimal settings for a GitRepository.
@@ -33,6 +38,7 @@ type HelmRepositoryConfig struct {
 	Namespace string `yaml:"namespace"`
 	URL       string `yaml:"url"`
 	Type      string `yaml:"type,omitempty"`
+	Interval  string `yaml:"interval,omitempty"`
 }
 
 // BucketConfig contains the configuration for a Bucket source.
@@ -63,6 +69,10 @@ type KustomizationConfig struct {
 	Interval  string                               `yaml:"interval"`
 	Prune     bool                                 `yaml:"prune"`
 	SourceRef kustv1.CrossNamespaceSourceReference `yaml:"sourceRef"`
+	// TargetNamespace overrides the namespace for all reconciled resources.
+	TargetNamespace string `yaml:"targetNamespace,omitempty"`
+	// Wait instructs Flux to wait for all reconciled resources to become ready.
+	Wait bool `yaml:"wait,omitempty"`
 }
 
 // ChartRefConfig references an existing Flux source (OCIRepository or HelmChart)
@@ -119,6 +129,9 @@ type HelmReleaseConfig struct {
 	// ValuesFrom is a list of references to ConfigMaps or Secrets whose data
 	// is merged into the Helm values.
 	ValuesFrom []ValuesFromConfig `yaml:"valuesFrom,omitempty"`
+	// Values is an inline map of Helm values. It is encoded as JSON and set
+	// as spec.values. Takes precedence over ValuesFrom entries for the same keys.
+	Values map[string]any `yaml:"values,omitempty"`
 }
 
 // ProviderConfig contains the configuration for a notification Provider.


### PR DESCRIPTION
Closes #499

## Summary

Adds four fields to existing FluxCD config types, required by crane's infrastructure component builders (which currently mutate raw Kubernetes structs post-construction):

- **`OCIRepositoryConfig.Digest`**: when set, `spec.reference.digest` is used and `Ref` (tag) is ignored — enables content-addressable pinning
- **`HelmRepositoryConfig.Interval`**: sets `spec.interval` for the reconciliation poll
- **`KustomizationConfig.TargetNamespace`**: sets `spec.targetNamespace` to deploy reconciled resources into a different namespace
- **`KustomizationConfig.Wait`**: sets `spec.wait` to block until all reconciled resources are ready
- **`HelmReleaseConfig.Values`**: inline `map[string]any` marshalled to `spec.values` as JSON

No new types or functions; all changes extend existing config structs and their corresponding builder functions.

## Test plan

- [x] `TestOCIRepository_Digest` — Digest takes precedence over Ref; Tag is empty when Digest is set
- [x] `TestHelmRepository_Interval` — Interval is propagated to `spec.interval`
- [x] `TestKustomization_TargetNamespaceAndWait` — both fields are set on the spec
- [x] `TestHelmRelease_Values` — Values map is marshalled to non-nil `spec.values`
- [x] `mise run verify` passes (tidy + lint + test)