### PR TITLE
feat(cilium): add builders for remaining stable Cilium CRDs

### DIFF
--- a/internal/cilium/ciliumbgp.go
+++ b/internal/cilium/ciliumbgp.go
@@ -1,0 +1,158 @@
+package cilium
+
+import (
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateCiliumBGPClusterConfig returns a new CiliumBGPClusterConfig with
+// TypeMeta and ObjectMeta set. The resource is cluster-scoped.
+func CreateCiliumBGPClusterConfig(name string) *ciliumv2.CiliumBGPClusterConfig {
+	return &ciliumv2.CiliumBGPClusterConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       ciliumv2.BGPCCKindDefinition,
+			APIVersion: ciliumv2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+// SetCiliumBGPClusterConfigSpec sets the full spec on the config.
+func SetCiliumBGPClusterConfigSpec(obj *ciliumv2.CiliumBGPClusterConfig, spec ciliumv2.CiliumBGPClusterConfigSpec) {
+	obj.Spec = spec
+}
+
+// SetCiliumBGPClusterConfigNodeSelector sets the node selector.
+// Uses Cilium's slim LabelSelector from github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1.
+func SetCiliumBGPClusterConfigNodeSelector(obj *ciliumv2.CiliumBGPClusterConfig, sel *slimv1.LabelSelector) {
+	obj.Spec.NodeSelector = sel
+}
+
+// AddCiliumBGPClusterConfigBGPInstance appends a BGP instance.
+func AddCiliumBGPClusterConfigBGPInstance(obj *ciliumv2.CiliumBGPClusterConfig, instance ciliumv2.CiliumBGPInstance) {
+	obj.Spec.BGPInstances = append(obj.Spec.BGPInstances, instance)
+}
+
+// CreateCiliumBGPPeerConfig returns a new CiliumBGPPeerConfig with TypeMeta
+// and ObjectMeta set. The resource is cluster-scoped.
+func CreateCiliumBGPPeerConfig(name string) *ciliumv2.CiliumBGPPeerConfig {
+	return &ciliumv2.CiliumBGPPeerConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       ciliumv2.BGPPCKindDefinition,
+			APIVersion: ciliumv2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+// SetCiliumBGPPeerConfigSpec sets the full spec on the config.
+func SetCiliumBGPPeerConfigSpec(obj *ciliumv2.CiliumBGPPeerConfig, spec ciliumv2.CiliumBGPPeerConfigSpec) {
+	obj.Spec = spec
+}
+
+// SetCiliumBGPPeerConfigTransport sets the transport configuration.
+func SetCiliumBGPPeerConfigTransport(obj *ciliumv2.CiliumBGPPeerConfig, transport *ciliumv2.CiliumBGPTransport) {
+	obj.Spec.Transport = transport
+}
+
+// SetCiliumBGPPeerConfigTimers sets the BGP timer configuration.
+func SetCiliumBGPPeerConfigTimers(obj *ciliumv2.CiliumBGPPeerConfig, timers *ciliumv2.CiliumBGPTimers) {
+	obj.Spec.Timers = timers
+}
+
+// SetCiliumBGPPeerConfigAuthSecretRef sets the BGP authentication secret name.
+func SetCiliumBGPPeerConfigAuthSecretRef(obj *ciliumv2.CiliumBGPPeerConfig, ref string) {
+	obj.Spec.AuthSecretRef = &ref
+}
+
+// SetCiliumBGPPeerConfigEBGPMultihop sets the eBGP multihop TTL.
+func SetCiliumBGPPeerConfigEBGPMultihop(obj *ciliumv2.CiliumBGPPeerConfig, ttl int32) {
+	obj.Spec.EBGPMultihop = &ttl
+}
+
+// SetCiliumBGPPeerConfigGracefulRestart sets the graceful restart configuration.
+func SetCiliumBGPPeerConfigGracefulRestart(obj *ciliumv2.CiliumBGPPeerConfig, gr *ciliumv2.CiliumBGPNeighborGracefulRestart) {
+	obj.Spec.GracefulRestart = gr
+}
+
+// AddCiliumBGPPeerConfigFamily appends an address family with advertisements.
+func AddCiliumBGPPeerConfigFamily(obj *ciliumv2.CiliumBGPPeerConfig, family ciliumv2.CiliumBGPFamilyWithAdverts) {
+	obj.Spec.Families = append(obj.Spec.Families, family)
+}
+
+// CreateCiliumBGPAdvertisement returns a new CiliumBGPAdvertisement with
+// TypeMeta and ObjectMeta set. The resource is cluster-scoped.
+func CreateCiliumBGPAdvertisement(name string) *ciliumv2.CiliumBGPAdvertisement {
+	return &ciliumv2.CiliumBGPAdvertisement{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       ciliumv2.BGPAKindDefinition,
+			APIVersion: ciliumv2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+// SetCiliumBGPAdvertisementSpec sets the full spec on the advertisement.
+func SetCiliumBGPAdvertisementSpec(obj *ciliumv2.CiliumBGPAdvertisement, spec ciliumv2.CiliumBGPAdvertisementSpec) {
+	obj.Spec = spec
+}
+
+// AddCiliumBGPAdvertisementEntry appends a BGP advertisement entry.
+func AddCiliumBGPAdvertisementEntry(obj *ciliumv2.CiliumBGPAdvertisement, advert ciliumv2.BGPAdvertisement) {
+	obj.Spec.Advertisements = append(obj.Spec.Advertisements, advert)
+}
+
+// CreateCiliumBGPNodeConfig returns a new CiliumBGPNodeConfig with TypeMeta
+// and ObjectMeta set. The resource is cluster-scoped.
+func CreateCiliumBGPNodeConfig(name string) *ciliumv2.CiliumBGPNodeConfig {
+	return &ciliumv2.CiliumBGPNodeConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       ciliumv2.BGPNCKindDefinition,
+			APIVersion: ciliumv2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+// SetCiliumBGPNodeConfigSpec sets the full spec on the node config.
+func SetCiliumBGPNodeConfigSpec(obj *ciliumv2.CiliumBGPNodeConfig, spec ciliumv2.CiliumBGPNodeSpec) {
+	obj.Spec = spec
+}
+
+// AddCiliumBGPNodeConfigBGPInstance appends a BGP node instance.
+func AddCiliumBGPNodeConfigBGPInstance(obj *ciliumv2.CiliumBGPNodeConfig, instance ciliumv2.CiliumBGPNodeInstance) {
+	obj.Spec.BGPInstances = append(obj.Spec.BGPInstances, instance)
+}
+
+// CreateCiliumBGPNodeConfigOverride returns a new CiliumBGPNodeConfigOverride
+// with TypeMeta and ObjectMeta set. The resource is cluster-scoped.
+func CreateCiliumBGPNodeConfigOverride(name string) *ciliumv2.CiliumBGPNodeConfigOverride {
+	return &ciliumv2.CiliumBGPNodeConfigOverride{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       ciliumv2.BGPNCOKindDefinition,
+			APIVersion: ciliumv2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+// SetCiliumBGPNodeConfigOverrideSpec sets the full spec on the override.
+func SetCiliumBGPNodeConfigOverrideSpec(obj *ciliumv2.CiliumBGPNodeConfigOverride, spec ciliumv2.CiliumBGPNodeConfigOverrideSpec) {
+	obj.Spec = spec
+}
+
+// AddCiliumBGPNodeConfigOverrideBGPInstance appends a BGP instance override.
+func AddCiliumBGPNodeConfigOverrideBGPInstance(obj *ciliumv2.CiliumBGPNodeConfigOverride, instance ciliumv2.CiliumBGPNodeConfigInstanceOverride) {
+	obj.Spec.BGPInstances = append(obj.Spec.BGPInstances, instance)
+}

--- a/internal/cilium/ciliumbgp_test.go
+++ b/internal/cilium/ciliumbgp_test.go
@@ -1,0 +1,161 @@
+package cilium
+
+import (
+	"testing"
+
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+func TestCreateCiliumBGPClusterConfig(t *testing.T) {
+	obj := CreateCiliumBGPClusterConfig("my-bgp")
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumBGPClusterConfig")
+	}
+	if obj.Name != "my-bgp" {
+		t.Errorf("expected Name 'my-bgp', got %s", obj.Name)
+	}
+	if obj.Namespace != "" {
+		t.Errorf("expected empty Namespace for cluster-scoped resource, got %s", obj.Namespace)
+	}
+	if obj.Kind != "CiliumBGPClusterConfig" {
+		t.Errorf("expected Kind 'CiliumBGPClusterConfig', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestSetCiliumBGPClusterConfigNodeSelector(t *testing.T) {
+	obj := CreateCiliumBGPClusterConfig("p")
+	sel := &slimv1.LabelSelector{MatchLabels: map[string]string{"bgp": "enabled"}}
+	SetCiliumBGPClusterConfigNodeSelector(obj, sel)
+	if obj.Spec.NodeSelector == nil {
+		t.Fatal("expected non-nil NodeSelector")
+	}
+}
+
+func TestAddCiliumBGPClusterConfigBGPInstance(t *testing.T) {
+	obj := CreateCiliumBGPClusterConfig("p")
+	instance := ciliumv2.CiliumBGPInstance{Name: "instance-1"}
+	AddCiliumBGPClusterConfigBGPInstance(obj, instance)
+	AddCiliumBGPClusterConfigBGPInstance(obj, instance)
+	if len(obj.Spec.BGPInstances) != 2 {
+		t.Fatalf("expected 2 BGP instances, got %d", len(obj.Spec.BGPInstances))
+	}
+}
+
+func TestCreateCiliumBGPPeerConfig(t *testing.T) {
+	obj := CreateCiliumBGPPeerConfig("my-peer")
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumBGPPeerConfig")
+	}
+	if obj.Kind != "CiliumBGPPeerConfig" {
+		t.Errorf("expected Kind 'CiliumBGPPeerConfig', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestSetCiliumBGPPeerConfigAuthSecretRef(t *testing.T) {
+	obj := CreateCiliumBGPPeerConfig("p")
+	SetCiliumBGPPeerConfigAuthSecretRef(obj, "bgp-secret")
+	if obj.Spec.AuthSecretRef == nil || *obj.Spec.AuthSecretRef != "bgp-secret" {
+		t.Errorf("unexpected AuthSecretRef: %v", obj.Spec.AuthSecretRef)
+	}
+}
+
+func TestSetCiliumBGPPeerConfigEBGPMultihop(t *testing.T) {
+	obj := CreateCiliumBGPPeerConfig("p")
+	SetCiliumBGPPeerConfigEBGPMultihop(obj, 3)
+	if obj.Spec.EBGPMultihop == nil || *obj.Spec.EBGPMultihop != 3 {
+		t.Errorf("unexpected EBGPMultihop: %v", obj.Spec.EBGPMultihop)
+	}
+}
+
+func TestAddCiliumBGPPeerConfigFamily(t *testing.T) {
+	obj := CreateCiliumBGPPeerConfig("p")
+	fam := ciliumv2.CiliumBGPFamilyWithAdverts{
+		CiliumBGPFamily: ciliumv2.CiliumBGPFamily{Afi: "ipv4", Safi: "unicast"},
+	}
+	AddCiliumBGPPeerConfigFamily(obj, fam)
+	AddCiliumBGPPeerConfigFamily(obj, fam)
+	if len(obj.Spec.Families) != 2 {
+		t.Fatalf("expected 2 families, got %d", len(obj.Spec.Families))
+	}
+}
+
+func TestCreateCiliumBGPAdvertisement(t *testing.T) {
+	obj := CreateCiliumBGPAdvertisement("my-advert")
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumBGPAdvertisement")
+	}
+	if obj.Kind != "CiliumBGPAdvertisement" {
+		t.Errorf("expected Kind 'CiliumBGPAdvertisement', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestAddCiliumBGPAdvertisementEntry(t *testing.T) {
+	obj := CreateCiliumBGPAdvertisement("p")
+	entry := ciliumv2.BGPAdvertisement{AdvertisementType: ciliumv2.BGPServiceAdvert}
+	AddCiliumBGPAdvertisementEntry(obj, entry)
+	AddCiliumBGPAdvertisementEntry(obj, entry)
+	if len(obj.Spec.Advertisements) != 2 {
+		t.Fatalf("expected 2 advertisement entries, got %d", len(obj.Spec.Advertisements))
+	}
+}
+
+func TestCreateCiliumBGPNodeConfig(t *testing.T) {
+	obj := CreateCiliumBGPNodeConfig("my-node-config")
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumBGPNodeConfig")
+	}
+	if obj.Kind != "CiliumBGPNodeConfig" {
+		t.Errorf("expected Kind 'CiliumBGPNodeConfig', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestAddCiliumBGPNodeConfigBGPInstance(t *testing.T) {
+	obj := CreateCiliumBGPNodeConfig("p")
+	instance := ciliumv2.CiliumBGPNodeInstance{Name: "instance-1"}
+	AddCiliumBGPNodeConfigBGPInstance(obj, instance)
+	if len(obj.Spec.BGPInstances) != 1 {
+		t.Fatalf("expected 1 BGP node instance, got %d", len(obj.Spec.BGPInstances))
+	}
+}
+
+func TestCreateCiliumBGPNodeConfigOverride(t *testing.T) {
+	obj := CreateCiliumBGPNodeConfigOverride("my-override")
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumBGPNodeConfigOverride")
+	}
+	if obj.Kind != "CiliumBGPNodeConfigOverride" {
+		t.Errorf("expected Kind 'CiliumBGPNodeConfigOverride', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestAddCiliumBGPNodeConfigOverrideBGPInstance(t *testing.T) {
+	obj := CreateCiliumBGPNodeConfigOverride("p")
+	routerID := "10.0.0.1"
+	instance := ciliumv2.CiliumBGPNodeConfigInstanceOverride{
+		Name:     "instance-1",
+		RouterID: &routerID,
+	}
+	AddCiliumBGPNodeConfigOverrideBGPInstance(obj, instance)
+	if len(obj.Spec.BGPInstances) != 1 {
+		t.Fatalf("expected 1 BGP instance override, got %d", len(obj.Spec.BGPInstances))
+	}
+	if *obj.Spec.BGPInstances[0].RouterID != "10.0.0.1" {
+		t.Errorf("unexpected RouterID: %s", *obj.Spec.BGPInstances[0].RouterID)
+	}
+}

--- a/internal/cilium/ciliumegressgatewaypolicy.go
+++ b/internal/cilium/ciliumegressgatewaypolicy.go
@@ -1,0 +1,50 @@
+package cilium
+
+import (
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateCiliumEgressGatewayPolicy returns a new CiliumEgressGatewayPolicy with
+// TypeMeta and ObjectMeta set. The resource is cluster-scoped.
+func CreateCiliumEgressGatewayPolicy(name string) *ciliumv2.CiliumEgressGatewayPolicy {
+	return &ciliumv2.CiliumEgressGatewayPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       ciliumv2.CEGPKindDefinition,
+			APIVersion: ciliumv2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+// SetCiliumEgressGatewayPolicySpec sets the full spec on the policy.
+func SetCiliumEgressGatewayPolicySpec(obj *ciliumv2.CiliumEgressGatewayPolicy, spec ciliumv2.CiliumEgressGatewayPolicySpec) {
+	obj.Spec = spec
+}
+
+// AddCiliumEgressGatewayPolicySelectorRule appends an egress selector rule.
+func AddCiliumEgressGatewayPolicySelectorRule(obj *ciliumv2.CiliumEgressGatewayPolicy, rule ciliumv2.EgressRule) {
+	obj.Spec.Selectors = append(obj.Spec.Selectors, rule)
+}
+
+// AddCiliumEgressGatewayPolicyDestinationCIDR appends a destination CIDR.
+func AddCiliumEgressGatewayPolicyDestinationCIDR(obj *ciliumv2.CiliumEgressGatewayPolicy, cidr ciliumv2.CIDR) {
+	obj.Spec.DestinationCIDRs = append(obj.Spec.DestinationCIDRs, cidr)
+}
+
+// AddCiliumEgressGatewayPolicyExcludedCIDR appends an excluded CIDR.
+func AddCiliumEgressGatewayPolicyExcludedCIDR(obj *ciliumv2.CiliumEgressGatewayPolicy, cidr ciliumv2.CIDR) {
+	obj.Spec.ExcludedCIDRs = append(obj.Spec.ExcludedCIDRs, cidr)
+}
+
+// SetCiliumEgressGatewayPolicyEgressGateway sets the primary egress gateway.
+func SetCiliumEgressGatewayPolicyEgressGateway(obj *ciliumv2.CiliumEgressGatewayPolicy, gw *ciliumv2.EgressGateway) {
+	obj.Spec.EgressGateway = gw
+}
+
+// AddCiliumEgressGatewayPolicyEgressGateway appends to the multi-gateway list.
+func AddCiliumEgressGatewayPolicyEgressGateway(obj *ciliumv2.CiliumEgressGatewayPolicy, gw ciliumv2.EgressGateway) {
+	obj.Spec.EgressGateways = append(obj.Spec.EgressGateways, gw)
+}

--- a/internal/cilium/ciliumegressgatewaypolicy_test.go
+++ b/internal/cilium/ciliumegressgatewaypolicy_test.go
@@ -1,0 +1,95 @@
+package cilium
+
+import (
+	"testing"
+
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+func TestCreateCiliumEgressGatewayPolicy(t *testing.T) {
+	obj := CreateCiliumEgressGatewayPolicy("my-egress")
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumEgressGatewayPolicy")
+	}
+	if obj.Name != "my-egress" {
+		t.Errorf("expected Name 'my-egress', got %s", obj.Name)
+	}
+	if obj.Namespace != "" {
+		t.Errorf("expected empty Namespace for cluster-scoped resource, got %s", obj.Namespace)
+	}
+	if obj.Kind != "CiliumEgressGatewayPolicy" {
+		t.Errorf("expected Kind 'CiliumEgressGatewayPolicy', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestSetCiliumEgressGatewayPolicySpec(t *testing.T) {
+	obj := CreateCiliumEgressGatewayPolicy("p")
+	spec := ciliumv2.CiliumEgressGatewayPolicySpec{
+		DestinationCIDRs: []ciliumv2.CIDR{"10.0.0.0/8"},
+	}
+	SetCiliumEgressGatewayPolicySpec(obj, spec)
+	if len(obj.Spec.DestinationCIDRs) != 1 {
+		t.Fatalf("expected 1 destination CIDR, got %d", len(obj.Spec.DestinationCIDRs))
+	}
+}
+
+func TestAddCiliumEgressGatewayPolicySelectorRule(t *testing.T) {
+	obj := CreateCiliumEgressGatewayPolicy("p")
+	rule := ciliumv2.EgressRule{
+		PodSelector: &slimv1.LabelSelector{
+			MatchLabels: map[string]string{"app": "frontend"},
+		},
+	}
+	AddCiliumEgressGatewayPolicySelectorRule(obj, rule)
+	if len(obj.Spec.Selectors) != 1 {
+		t.Fatalf("expected 1 selector rule, got %d", len(obj.Spec.Selectors))
+	}
+}
+
+func TestAddCiliumEgressGatewayPolicyDestinationCIDR(t *testing.T) {
+	obj := CreateCiliumEgressGatewayPolicy("p")
+	AddCiliumEgressGatewayPolicyDestinationCIDR(obj, ciliumv2.CIDR("10.0.0.0/8"))
+	AddCiliumEgressGatewayPolicyDestinationCIDR(obj, ciliumv2.CIDR("192.168.0.0/16"))
+	if len(obj.Spec.DestinationCIDRs) != 2 {
+		t.Fatalf("expected 2 destination CIDRs, got %d", len(obj.Spec.DestinationCIDRs))
+	}
+}
+
+func TestAddCiliumEgressGatewayPolicyExcludedCIDR(t *testing.T) {
+	obj := CreateCiliumEgressGatewayPolicy("p")
+	AddCiliumEgressGatewayPolicyExcludedCIDR(obj, ciliumv2.CIDR("10.0.1.0/24"))
+	if len(obj.Spec.ExcludedCIDRs) != 1 {
+		t.Fatalf("expected 1 excluded CIDR, got %d", len(obj.Spec.ExcludedCIDRs))
+	}
+}
+
+func TestSetCiliumEgressGatewayPolicyEgressGateway(t *testing.T) {
+	obj := CreateCiliumEgressGatewayPolicy("p")
+	gw := &ciliumv2.EgressGateway{
+		NodeSelector: &slimv1.LabelSelector{
+			MatchLabels: map[string]string{"role": "egress"},
+		},
+	}
+	SetCiliumEgressGatewayPolicyEgressGateway(obj, gw)
+	if obj.Spec.EgressGateway == nil {
+		t.Fatal("expected non-nil EgressGateway")
+	}
+}
+
+func TestAddCiliumEgressGatewayPolicyEgressGateway(t *testing.T) {
+	obj := CreateCiliumEgressGatewayPolicy("p")
+	gw := ciliumv2.EgressGateway{
+		NodeSelector: &slimv1.LabelSelector{
+			MatchLabels: map[string]string{"role": "egress"},
+		},
+	}
+	AddCiliumEgressGatewayPolicyEgressGateway(obj, gw)
+	AddCiliumEgressGatewayPolicyEgressGateway(obj, gw)
+	if len(obj.Spec.EgressGateways) != 2 {
+		t.Fatalf("expected 2 egress gateways, got %d", len(obj.Spec.EgressGateways))
+	}
+}

--- a/internal/cilium/ciliumenvoyconfig.go
+++ b/internal/cilium/ciliumenvoyconfig.go
@@ -1,0 +1,88 @@
+package cilium
+
+import (
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateCiliumEnvoyConfig returns a new CiliumEnvoyConfig with TypeMeta and
+// ObjectMeta set. The resource is namespace-scoped.
+func CreateCiliumEnvoyConfig(name, namespace string) *ciliumv2.CiliumEnvoyConfig {
+	return &ciliumv2.CiliumEnvoyConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       ciliumv2.CECKindDefinition,
+			APIVersion: ciliumv2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+// SetCiliumEnvoyConfigSpec sets the full spec on the config.
+func SetCiliumEnvoyConfigSpec(obj *ciliumv2.CiliumEnvoyConfig, spec ciliumv2.CiliumEnvoyConfigSpec) {
+	obj.Spec = spec
+}
+
+// AddCiliumEnvoyConfigService appends a service listener.
+func AddCiliumEnvoyConfigService(obj *ciliumv2.CiliumEnvoyConfig, svc *ciliumv2.ServiceListener) {
+	obj.Spec.Services = append(obj.Spec.Services, svc)
+}
+
+// AddCiliumEnvoyConfigBackendService appends a backend service.
+func AddCiliumEnvoyConfigBackendService(obj *ciliumv2.CiliumEnvoyConfig, svc *ciliumv2.Service) {
+	obj.Spec.BackendServices = append(obj.Spec.BackendServices, svc)
+}
+
+// AddCiliumEnvoyConfigResource appends an Envoy xDS resource.
+func AddCiliumEnvoyConfigResource(obj *ciliumv2.CiliumEnvoyConfig, res ciliumv2.XDSResource) {
+	obj.Spec.Resources = append(obj.Spec.Resources, res)
+}
+
+// SetCiliumEnvoyConfigNodeSelector sets the node selector on the config.
+// Uses Cilium's slim LabelSelector from github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1.
+func SetCiliumEnvoyConfigNodeSelector(obj *ciliumv2.CiliumEnvoyConfig, sel *slimv1.LabelSelector) {
+	obj.Spec.NodeSelector = sel
+}
+
+// CreateCiliumClusterwideEnvoyConfig returns a new CiliumClusterwideEnvoyConfig
+// with TypeMeta and ObjectMeta set. The resource is cluster-scoped.
+func CreateCiliumClusterwideEnvoyConfig(name string) *ciliumv2.CiliumClusterwideEnvoyConfig {
+	return &ciliumv2.CiliumClusterwideEnvoyConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       ciliumv2.CCECKindDefinition,
+			APIVersion: ciliumv2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+// SetCiliumClusterwideEnvoyConfigSpec sets the full spec on the config.
+func SetCiliumClusterwideEnvoyConfigSpec(obj *ciliumv2.CiliumClusterwideEnvoyConfig, spec ciliumv2.CiliumEnvoyConfigSpec) {
+	obj.Spec = spec
+}
+
+// AddCiliumClusterwideEnvoyConfigService appends a service listener.
+func AddCiliumClusterwideEnvoyConfigService(obj *ciliumv2.CiliumClusterwideEnvoyConfig, svc *ciliumv2.ServiceListener) {
+	obj.Spec.Services = append(obj.Spec.Services, svc)
+}
+
+// AddCiliumClusterwideEnvoyConfigBackendService appends a backend service.
+func AddCiliumClusterwideEnvoyConfigBackendService(obj *ciliumv2.CiliumClusterwideEnvoyConfig, svc *ciliumv2.Service) {
+	obj.Spec.BackendServices = append(obj.Spec.BackendServices, svc)
+}
+
+// AddCiliumClusterwideEnvoyConfigResource appends an Envoy xDS resource.
+func AddCiliumClusterwideEnvoyConfigResource(obj *ciliumv2.CiliumClusterwideEnvoyConfig, res ciliumv2.XDSResource) {
+	obj.Spec.Resources = append(obj.Spec.Resources, res)
+}
+
+// SetCiliumClusterwideEnvoyConfigNodeSelector sets the node selector on the config.
+// Uses Cilium's slim LabelSelector from github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1.
+func SetCiliumClusterwideEnvoyConfigNodeSelector(obj *ciliumv2.CiliumClusterwideEnvoyConfig, sel *slimv1.LabelSelector) {
+	obj.Spec.NodeSelector = sel
+}

--- a/internal/cilium/ciliumenvoyconfig_test.go
+++ b/internal/cilium/ciliumenvoyconfig_test.go
@@ -1,0 +1,124 @@
+package cilium
+
+import (
+	"testing"
+
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+func TestCreateCiliumEnvoyConfig(t *testing.T) {
+	obj := CreateCiliumEnvoyConfig("my-cec", "default")
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumEnvoyConfig")
+	}
+	if obj.Name != "my-cec" {
+		t.Errorf("expected Name 'my-cec', got %s", obj.Name)
+	}
+	if obj.Namespace != "default" {
+		t.Errorf("expected Namespace 'default', got %s", obj.Namespace)
+	}
+	if obj.Kind != "CiliumEnvoyConfig" {
+		t.Errorf("expected Kind 'CiliumEnvoyConfig', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestSetCiliumEnvoyConfigSpec(t *testing.T) {
+	obj := CreateCiliumEnvoyConfig("p", "ns")
+	spec := ciliumv2.CiliumEnvoyConfigSpec{
+		Resources: []ciliumv2.XDSResource{{}},
+	}
+	SetCiliumEnvoyConfigSpec(obj, spec)
+	if len(obj.Spec.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(obj.Spec.Resources))
+	}
+}
+
+func TestAddCiliumEnvoyConfigService(t *testing.T) {
+	obj := CreateCiliumEnvoyConfig("p", "ns")
+	svc := &ciliumv2.ServiceListener{Name: "my-service", Namespace: "default"}
+	AddCiliumEnvoyConfigService(obj, svc)
+	AddCiliumEnvoyConfigService(obj, svc)
+	if len(obj.Spec.Services) != 2 {
+		t.Fatalf("expected 2 services, got %d", len(obj.Spec.Services))
+	}
+}
+
+func TestAddCiliumEnvoyConfigBackendService(t *testing.T) {
+	obj := CreateCiliumEnvoyConfig("p", "ns")
+	svc := &ciliumv2.Service{Name: "backend", Namespace: "default"}
+	AddCiliumEnvoyConfigBackendService(obj, svc)
+	if len(obj.Spec.BackendServices) != 1 {
+		t.Fatalf("expected 1 backend service, got %d", len(obj.Spec.BackendServices))
+	}
+}
+
+func TestAddCiliumEnvoyConfigResource(t *testing.T) {
+	obj := CreateCiliumEnvoyConfig("p", "ns")
+	AddCiliumEnvoyConfigResource(obj, ciliumv2.XDSResource{})
+	if len(obj.Spec.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(obj.Spec.Resources))
+	}
+}
+
+func TestSetCiliumEnvoyConfigNodeSelector(t *testing.T) {
+	obj := CreateCiliumEnvoyConfig("p", "ns")
+	sel := &slimv1.LabelSelector{
+		MatchLabels: map[string]string{"node": "worker"},
+	}
+	SetCiliumEnvoyConfigNodeSelector(obj, sel)
+	if obj.Spec.NodeSelector == nil {
+		t.Fatal("expected non-nil NodeSelector")
+	}
+}
+
+func TestCreateCiliumClusterwideEnvoyConfig(t *testing.T) {
+	obj := CreateCiliumClusterwideEnvoyConfig("my-ccec")
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumClusterwideEnvoyConfig")
+	}
+	if obj.Name != "my-ccec" {
+		t.Errorf("expected Name 'my-ccec', got %s", obj.Name)
+	}
+	if obj.Namespace != "" {
+		t.Errorf("expected empty Namespace for cluster-scoped resource, got %s", obj.Namespace)
+	}
+	if obj.Kind != "CiliumClusterwideEnvoyConfig" {
+		t.Errorf("expected Kind 'CiliumClusterwideEnvoyConfig', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestSetCiliumClusterwideEnvoyConfigSpec(t *testing.T) {
+	obj := CreateCiliumClusterwideEnvoyConfig("p")
+	spec := ciliumv2.CiliumEnvoyConfigSpec{
+		Resources: []ciliumv2.XDSResource{{}, {}},
+	}
+	SetCiliumClusterwideEnvoyConfigSpec(obj, spec)
+	if len(obj.Spec.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(obj.Spec.Resources))
+	}
+}
+
+func TestAddCiliumClusterwideEnvoyConfigService(t *testing.T) {
+	obj := CreateCiliumClusterwideEnvoyConfig("p")
+	svc := &ciliumv2.ServiceListener{Name: "svc", Namespace: "ns"}
+	AddCiliumClusterwideEnvoyConfigService(obj, svc)
+	if len(obj.Spec.Services) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(obj.Spec.Services))
+	}
+}
+
+func TestSetCiliumClusterwideEnvoyConfigNodeSelector(t *testing.T) {
+	obj := CreateCiliumClusterwideEnvoyConfig("p")
+	sel := &slimv1.LabelSelector{MatchLabels: map[string]string{"node": "worker"}}
+	SetCiliumClusterwideEnvoyConfigNodeSelector(obj, sel)
+	if obj.Spec.NodeSelector == nil {
+		t.Fatal("expected non-nil NodeSelector")
+	}
+}

--- a/internal/cilium/ciliumloadbalancerippool.go
+++ b/internal/cilium/ciliumloadbalancerippool.go
@@ -1,0 +1,48 @@
+package cilium
+
+import (
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateCiliumLoadBalancerIPPool returns a new CiliumLoadBalancerIPPool with
+// TypeMeta and ObjectMeta set. The resource is cluster-scoped.
+func CreateCiliumLoadBalancerIPPool(name string) *ciliumv2.CiliumLoadBalancerIPPool {
+	return &ciliumv2.CiliumLoadBalancerIPPool{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       ciliumv2.PoolKindDefinition,
+			APIVersion: ciliumv2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+// SetCiliumLoadBalancerIPPoolSpec sets the full spec on the pool.
+func SetCiliumLoadBalancerIPPoolSpec(obj *ciliumv2.CiliumLoadBalancerIPPool, spec ciliumv2.CiliumLoadBalancerIPPoolSpec) {
+	obj.Spec = spec
+}
+
+// SetCiliumLoadBalancerIPPoolServiceSelector sets the service selector.
+// Uses Cilium's slim LabelSelector from github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1.
+func SetCiliumLoadBalancerIPPoolServiceSelector(obj *ciliumv2.CiliumLoadBalancerIPPool, sel *slimv1.LabelSelector) {
+	obj.Spec.ServiceSelector = sel
+}
+
+// AddCiliumLoadBalancerIPPoolBlock appends a CIDR block to the pool.
+func AddCiliumLoadBalancerIPPoolBlock(obj *ciliumv2.CiliumLoadBalancerIPPool, block ciliumv2.CiliumLoadBalancerIPPoolIPBlock) {
+	obj.Spec.Blocks = append(obj.Spec.Blocks, block)
+}
+
+// SetCiliumLoadBalancerIPPoolDisabled enables or disables the pool.
+func SetCiliumLoadBalancerIPPoolDisabled(obj *ciliumv2.CiliumLoadBalancerIPPool, disabled bool) {
+	obj.Spec.Disabled = disabled
+}
+
+// SetCiliumLoadBalancerIPPoolAllowFirstLastIPs controls first/last IP
+// allocation behaviour.
+func SetCiliumLoadBalancerIPPoolAllowFirstLastIPs(obj *ciliumv2.CiliumLoadBalancerIPPool, allow ciliumv2.AllowFirstLastIPType) {
+	obj.Spec.AllowFirstLastIPs = allow
+}

--- a/internal/cilium/ciliumloadbalancerippool_test.go
+++ b/internal/cilium/ciliumloadbalancerippool_test.go
@@ -1,0 +1,76 @@
+package cilium
+
+import (
+	"testing"
+
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+func TestCreateCiliumLoadBalancerIPPool(t *testing.T) {
+	obj := CreateCiliumLoadBalancerIPPool("my-pool")
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumLoadBalancerIPPool")
+	}
+	if obj.Name != "my-pool" {
+		t.Errorf("expected Name 'my-pool', got %s", obj.Name)
+	}
+	if obj.Namespace != "" {
+		t.Errorf("expected empty Namespace for cluster-scoped resource, got %s", obj.Namespace)
+	}
+	if obj.Kind != "CiliumLoadBalancerIPPool" {
+		t.Errorf("expected Kind 'CiliumLoadBalancerIPPool', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestSetCiliumLoadBalancerIPPoolSpec(t *testing.T) {
+	obj := CreateCiliumLoadBalancerIPPool("p")
+	spec := ciliumv2.CiliumLoadBalancerIPPoolSpec{
+		Blocks: []ciliumv2.CiliumLoadBalancerIPPoolIPBlock{
+			{Cidr: "10.0.0.0/8"},
+		},
+	}
+	SetCiliumLoadBalancerIPPoolSpec(obj, spec)
+	if len(obj.Spec.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(obj.Spec.Blocks))
+	}
+}
+
+func TestSetCiliumLoadBalancerIPPoolServiceSelector(t *testing.T) {
+	obj := CreateCiliumLoadBalancerIPPool("p")
+	sel := &slimv1.LabelSelector{
+		MatchLabels: map[string]string{"service": "lb"},
+	}
+	SetCiliumLoadBalancerIPPoolServiceSelector(obj, sel)
+	if obj.Spec.ServiceSelector == nil {
+		t.Fatal("expected non-nil ServiceSelector")
+	}
+}
+
+func TestAddCiliumLoadBalancerIPPoolBlock(t *testing.T) {
+	obj := CreateCiliumLoadBalancerIPPool("p")
+	AddCiliumLoadBalancerIPPoolBlock(obj, ciliumv2.CiliumLoadBalancerIPPoolIPBlock{Cidr: "192.168.0.0/16"})
+	AddCiliumLoadBalancerIPPoolBlock(obj, ciliumv2.CiliumLoadBalancerIPPoolIPBlock{Cidr: "10.0.0.0/8"})
+	if len(obj.Spec.Blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(obj.Spec.Blocks))
+	}
+}
+
+func TestSetCiliumLoadBalancerIPPoolDisabled(t *testing.T) {
+	obj := CreateCiliumLoadBalancerIPPool("p")
+	SetCiliumLoadBalancerIPPoolDisabled(obj, true)
+	if !obj.Spec.Disabled {
+		t.Error("expected Disabled to be true")
+	}
+}
+
+func TestSetCiliumLoadBalancerIPPoolAllowFirstLastIPs(t *testing.T) {
+	obj := CreateCiliumLoadBalancerIPPool("p")
+	SetCiliumLoadBalancerIPPoolAllowFirstLastIPs(obj, ciliumv2.AllowFirstLastIPYes)
+	if obj.Spec.AllowFirstLastIPs != ciliumv2.AllowFirstLastIPYes {
+		t.Errorf("unexpected AllowFirstLastIPs: %v", obj.Spec.AllowFirstLastIPs)
+	}
+}

--- a/internal/cilium/ciliumlocalredirectpolicy.go
+++ b/internal/cilium/ciliumlocalredirectpolicy.go
@@ -1,0 +1,47 @@
+package cilium
+
+import (
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateCiliumLocalRedirectPolicy returns a new CiliumLocalRedirectPolicy with
+// TypeMeta and ObjectMeta set. The resource is namespace-scoped.
+func CreateCiliumLocalRedirectPolicy(name, namespace string) *ciliumv2.CiliumLocalRedirectPolicy {
+	return &ciliumv2.CiliumLocalRedirectPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       ciliumv2.CLRPKindDefinition,
+			APIVersion: ciliumv2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+// SetCiliumLocalRedirectPolicySpec sets the full spec on the policy.
+func SetCiliumLocalRedirectPolicySpec(obj *ciliumv2.CiliumLocalRedirectPolicy, spec ciliumv2.CiliumLocalRedirectPolicySpec) {
+	obj.Spec = spec
+}
+
+// SetCiliumLocalRedirectPolicyFrontend sets the redirect frontend.
+func SetCiliumLocalRedirectPolicyFrontend(obj *ciliumv2.CiliumLocalRedirectPolicy, frontend ciliumv2.RedirectFrontend) {
+	obj.Spec.RedirectFrontend = frontend
+}
+
+// SetCiliumLocalRedirectPolicyBackend sets the redirect backend.
+func SetCiliumLocalRedirectPolicyBackend(obj *ciliumv2.CiliumLocalRedirectPolicy, backend ciliumv2.RedirectBackend) {
+	obj.Spec.RedirectBackend = backend
+}
+
+// SetCiliumLocalRedirectPolicyDescription sets the description on the policy.
+func SetCiliumLocalRedirectPolicyDescription(obj *ciliumv2.CiliumLocalRedirectPolicy, desc string) {
+	obj.Spec.Description = desc
+}
+
+// SetCiliumLocalRedirectPolicySkipRedirectFromBackend sets whether to skip
+// redirect for traffic originating from the backend itself.
+func SetCiliumLocalRedirectPolicySkipRedirectFromBackend(obj *ciliumv2.CiliumLocalRedirectPolicy, skip bool) {
+	obj.Spec.SkipRedirectFromBackend = skip
+}

--- a/internal/cilium/ciliumlocalredirectpolicy_test.go
+++ b/internal/cilium/ciliumlocalredirectpolicy_test.go
@@ -1,0 +1,62 @@
+package cilium
+
+import (
+	"testing"
+
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+)
+
+func TestCreateCiliumLocalRedirectPolicy(t *testing.T) {
+	obj := CreateCiliumLocalRedirectPolicy("my-lrp", "default")
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumLocalRedirectPolicy")
+	}
+	if obj.Name != "my-lrp" {
+		t.Errorf("expected Name 'my-lrp', got %s", obj.Name)
+	}
+	if obj.Namespace != "default" {
+		t.Errorf("expected Namespace 'default', got %s", obj.Namespace)
+	}
+	if obj.Kind != "CiliumLocalRedirectPolicy" {
+		t.Errorf("expected Kind 'CiliumLocalRedirectPolicy', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestSetCiliumLocalRedirectPolicySpec(t *testing.T) {
+	obj := CreateCiliumLocalRedirectPolicy("p", "ns")
+	spec := ciliumv2.CiliumLocalRedirectPolicySpec{
+		Description: "redirect health",
+	}
+	SetCiliumLocalRedirectPolicySpec(obj, spec)
+	if obj.Spec.Description != "redirect health" {
+		t.Errorf("unexpected Description: %s", obj.Spec.Description)
+	}
+}
+
+func TestSetCiliumLocalRedirectPolicyDescription(t *testing.T) {
+	obj := CreateCiliumLocalRedirectPolicy("p", "ns")
+	SetCiliumLocalRedirectPolicyDescription(obj, "health check redirect")
+	if obj.Spec.Description != "health check redirect" {
+		t.Errorf("unexpected Description: %s", obj.Spec.Description)
+	}
+}
+
+func TestSetCiliumLocalRedirectPolicySkipRedirectFromBackend(t *testing.T) {
+	obj := CreateCiliumLocalRedirectPolicy("p", "ns")
+	SetCiliumLocalRedirectPolicySkipRedirectFromBackend(obj, true)
+	if !obj.Spec.SkipRedirectFromBackend {
+		t.Error("expected SkipRedirectFromBackend to be true")
+	}
+}
+
+func TestSetCiliumLocalRedirectPolicyFrontendAndBackend(t *testing.T) {
+	obj := CreateCiliumLocalRedirectPolicy("p", "ns")
+	frontend := ciliumv2.RedirectFrontend{}
+	backend := ciliumv2.RedirectBackend{}
+	SetCiliumLocalRedirectPolicyFrontend(obj, frontend)
+	SetCiliumLocalRedirectPolicyBackend(obj, backend)
+	// Verify no panic and assignment succeeded — structs are value types
+}

--- a/pkg/kubernetes/cilium/README.md
+++ b/pkg/kubernetes/cilium/README.md
@@ -1,4 +1,4 @@
-# Cilium Builders - Cilium Network Policy Resource Constructors
+# Cilium Builders - Cilium Resource Constructors
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/go-kure/kure/pkg/kubernetes/cilium.svg)](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/cilium)
 
@@ -73,24 +73,193 @@ group := cilium.CiliumCIDRGroup(&cilium.CiliumCIDRGroupConfig{
 })
 ```
 
+### CiliumEgressGatewayPolicy
+
+Cluster-scoped policy that routes egress traffic through a gateway node:
+
+```go
+import ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+
+cegp := cilium.CiliumEgressGatewayPolicy(&cilium.CiliumEgressGatewayPolicyConfig{
+    Name: "prod-egress",
+    Spec: ciliumv2.CiliumEgressGatewayPolicySpec{
+        DestinationCIDRs: []ciliumv2.CIDR{"0.0.0.0/0"},
+        EgressGateway:    &ciliumv2.EgressGateway{Interface: "eth0"},
+    },
+})
+```
+
+### CiliumLocalRedirectPolicy
+
+Namespace-scoped policy that redirects traffic to a local backend:
+
+```go
+lrp := cilium.CiliumLocalRedirectPolicy(&cilium.CiliumLocalRedirectPolicyConfig{
+    Name:      "dns-redirect",
+    Namespace: "kube-system",
+    Spec: ciliumv2.CiliumLocalRedirectPolicySpec{
+        RedirectFrontend: ciliumv2.RedirectFrontend{
+            AddressMatcher: &ciliumv2.Frontend{IP: "169.254.20.10", ToPorts: []ciliumv2.PortInfo{{Port: "53", Protocol: "ANY"}}},
+        },
+        RedirectBackend: ciliumv2.RedirectBackend{
+            LocalEndpointSelector: slimv1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "coredns"}},
+            ToPorts:               []ciliumv2.PortInfo{{Port: "53", Protocol: "ANY"}},
+        },
+    },
+})
+```
+
+### CiliumLoadBalancerIPPool
+
+Cluster-scoped pool of IP addresses for LoadBalancer services:
+
+```go
+pool := cilium.CiliumLoadBalancerIPPool(&cilium.CiliumLoadBalancerIPPoolConfig{
+    Name: "public-pool",
+    Spec: ciliumv2.CiliumLoadBalancerIPPoolSpec{
+        Blocks: []ciliumv2.CiliumLoadBalancerIPPoolIPBlock{{Cidr: "203.0.113.0/24"}},
+    },
+})
+// Add blocks incrementally:
+cilium.AddCiliumLoadBalancerIPPoolBlock(pool, ciliumv2.CiliumLoadBalancerIPPoolIPBlock{Cidr: "198.51.100.0/24"})
+```
+
+### CiliumEnvoyConfig
+
+Namespace-scoped Envoy proxy configuration:
+
+```go
+cec := cilium.CiliumEnvoyConfig(&cilium.CiliumEnvoyConfigConfig{
+    Name:      "my-proxy",
+    Namespace: "default",
+})
+cilium.AddCiliumEnvoyConfigService(cec, &ciliumv2.ServiceListener{Name: "my-svc", Namespace: "default"})
+cilium.AddCiliumEnvoyConfigResource(cec, xdsResource)
+```
+
+### CiliumClusterwideEnvoyConfig
+
+Cluster-scoped Envoy proxy configuration with the same spec shape as `CiliumEnvoyConfig`:
+
+```go
+ccec := cilium.CiliumClusterwideEnvoyConfig(&cilium.CiliumClusterwideEnvoyConfigConfig{
+    Name: "cluster-proxy",
+})
+```
+
+### CiliumBGPClusterConfig
+
+Cluster-scoped BGP configuration selecting nodes and defining BGP instances:
+
+```go
+bgpcc := cilium.CiliumBGPClusterConfig(&cilium.CiliumBGPClusterConfigConfig{
+    Name: "default-bgp",
+})
+cilium.SetCiliumBGPClusterConfigNodeSelector(bgpcc, &slimv1.LabelSelector{
+    MatchLabels: map[string]string{"bgp": "enabled"},
+})
+cilium.AddCiliumBGPClusterConfigBGPInstance(bgpcc, ciliumv2.CiliumBGPInstance{
+    Name: "instance-65000",
+})
+```
+
+### CiliumBGPPeerConfig
+
+Cluster-scoped BGP peer configuration (transport, timers, families):
+
+```go
+peer := cilium.CiliumBGPPeerConfig(&cilium.CiliumBGPPeerConfigConfig{
+    Name: "peer-65001",
+})
+cilium.SetCiliumBGPPeerConfigEBGPMultihop(peer, 2)
+cilium.AddCiliumBGPPeerConfigFamily(peer, ciliumv2.CiliumBGPFamilyWithAdverts{
+    CiliumBGPFamily: ciliumv2.CiliumBGPFamily{Afi: "ipv4", Safi: "unicast"},
+})
+```
+
+### CiliumBGPAdvertisement
+
+Cluster-scoped BGP advertisement configuration:
+
+```go
+advert := cilium.CiliumBGPAdvertisement(&cilium.CiliumBGPAdvertisementConfig{
+    Name: "pod-cidr-advert",
+})
+cilium.AddCiliumBGPAdvertisementEntry(advert, ciliumv2.BGPAdvertisement{
+    AdvertisementType: ciliumv2.BGPPodCIDRAdvert,
+})
+```
+
+### CiliumBGPNodeConfig
+
+Cluster-scoped per-node BGP configuration (typically managed by the Cilium operator):
+
+```go
+nc := cilium.CiliumBGPNodeConfig(&cilium.CiliumBGPNodeConfigConfig{
+    Name: "node-worker-1",
+})
+cilium.AddCiliumBGPNodeConfigBGPInstance(nc, ciliumv2.CiliumBGPNodeInstance{
+    Name: "instance-65000",
+})
+```
+
+### CiliumBGPNodeConfigOverride
+
+Cluster-scoped per-node BGP override for router ID and local AS:
+
+```go
+routerID := "10.0.0.1"
+override := cilium.CiliumBGPNodeConfigOverride(&cilium.CiliumBGPNodeConfigOverrideConfig{
+    Name: "node-worker-1",
+})
+cilium.AddCiliumBGPNodeConfigOverrideBGPInstance(override, ciliumv2.CiliumBGPNodeConfigInstanceOverride{
+    Name:     "instance-65000",
+    RouterID: &routerID,
+})
+```
+
 ## Modifier Functions
 
 Update existing resources after construction:
 
 ```go
-// Set or replace spec
+// Network policies
 cilium.SetCiliumNetworkPolicySpec(policy, newRule)
 cilium.SetCiliumClusterwideNetworkPolicyNodeSelector(ccnp, nodeSelector)
-
-// Add individual rules (auto-initialise Spec if nil)
 cilium.AddCiliumNetworkPolicyIngressRule(policy, ingressRule)
 cilium.AddCiliumNetworkPolicyEgressRule(policy, egressRule)
 cilium.AddCiliumNetworkPolicyIngressDenyRule(policy, ingressDenyRule)
 cilium.AddCiliumNetworkPolicyEgressDenyRule(policy, egressDenyRule)
 
-// Manage CIDR groups
+// CIDR groups
 cilium.AddCiliumCIDRGroupCIDR(group, "203.0.113.0/24")
 cilium.SetCiliumCIDRGroupCIDRs(group, newCIDRSlice)
+
+// Egress gateway
+cilium.AddCiliumEgressGatewayPolicySelectorRule(cegp, selectorRule)
+cilium.AddCiliumEgressGatewayPolicyDestinationCIDR(cegp, "10.0.0.0/8")
+cilium.SetCiliumEgressGatewayPolicyEgressGateway(cegp, &egressGateway)
+
+// LB IP pool
+cilium.AddCiliumLoadBalancerIPPoolBlock(pool, block)
+cilium.SetCiliumLoadBalancerIPPoolServiceSelector(pool, selector)
+cilium.SetCiliumLoadBalancerIPPoolDisabled(pool, true)
+
+// Envoy config
+cilium.AddCiliumEnvoyConfigService(cec, serviceListener)
+cilium.AddCiliumEnvoyConfigBackendService(cec, backendService)
+cilium.AddCiliumEnvoyConfigResource(cec, xdsResource)
+cilium.SetCiliumEnvoyConfigNodeSelector(cec, nodeSelector)
+
+// BGP
+cilium.SetCiliumBGPClusterConfigNodeSelector(bgpcc, nodeSelector)
+cilium.AddCiliumBGPClusterConfigBGPInstance(bgpcc, instance)
+cilium.SetCiliumBGPPeerConfigTransport(peer, transport)
+cilium.SetCiliumBGPPeerConfigTimers(peer, timers)
+cilium.AddCiliumBGPPeerConfigFamily(peer, family)
+cilium.AddCiliumBGPAdvertisementEntry(advert, advertisement)
+cilium.AddCiliumBGPNodeConfigBGPInstance(nc, instance)
+cilium.AddCiliumBGPNodeConfigOverrideBGPInstance(override, instanceOverride)
 ```
 
 ## Related Packages

--- a/pkg/kubernetes/cilium/create.go
+++ b/pkg/kubernetes/cilium/create.go
@@ -48,3 +48,103 @@ func CiliumCIDRGroup(cfg *CiliumCIDRGroupConfig) *ciliumv2.CiliumCIDRGroup {
 	}
 	return obj
 }
+
+// CiliumEgressGatewayPolicy converts the config to a CiliumEgressGatewayPolicy object.
+func CiliumEgressGatewayPolicy(cfg *CiliumEgressGatewayPolicyConfig) *ciliumv2.CiliumEgressGatewayPolicy {
+	if cfg == nil {
+		return nil
+	}
+	obj := intcilium.CreateCiliumEgressGatewayPolicy(cfg.Name)
+	intcilium.SetCiliumEgressGatewayPolicySpec(obj, cfg.Spec)
+	return obj
+}
+
+// CiliumLocalRedirectPolicy converts the config to a CiliumLocalRedirectPolicy object.
+func CiliumLocalRedirectPolicy(cfg *CiliumLocalRedirectPolicyConfig) *ciliumv2.CiliumLocalRedirectPolicy {
+	if cfg == nil {
+		return nil
+	}
+	obj := intcilium.CreateCiliumLocalRedirectPolicy(cfg.Name, cfg.Namespace)
+	intcilium.SetCiliumLocalRedirectPolicySpec(obj, cfg.Spec)
+	return obj
+}
+
+// CiliumLoadBalancerIPPool converts the config to a CiliumLoadBalancerIPPool object.
+func CiliumLoadBalancerIPPool(cfg *CiliumLoadBalancerIPPoolConfig) *ciliumv2.CiliumLoadBalancerIPPool {
+	if cfg == nil {
+		return nil
+	}
+	obj := intcilium.CreateCiliumLoadBalancerIPPool(cfg.Name)
+	intcilium.SetCiliumLoadBalancerIPPoolSpec(obj, cfg.Spec)
+	return obj
+}
+
+// CiliumEnvoyConfig converts the config to a CiliumEnvoyConfig object.
+func CiliumEnvoyConfig(cfg *CiliumEnvoyConfigConfig) *ciliumv2.CiliumEnvoyConfig {
+	if cfg == nil {
+		return nil
+	}
+	obj := intcilium.CreateCiliumEnvoyConfig(cfg.Name, cfg.Namespace)
+	intcilium.SetCiliumEnvoyConfigSpec(obj, cfg.Spec)
+	return obj
+}
+
+// CiliumClusterwideEnvoyConfig converts the config to a CiliumClusterwideEnvoyConfig object.
+func CiliumClusterwideEnvoyConfig(cfg *CiliumClusterwideEnvoyConfigConfig) *ciliumv2.CiliumClusterwideEnvoyConfig {
+	if cfg == nil {
+		return nil
+	}
+	obj := intcilium.CreateCiliumClusterwideEnvoyConfig(cfg.Name)
+	intcilium.SetCiliumClusterwideEnvoyConfigSpec(obj, cfg.Spec)
+	return obj
+}
+
+// CiliumBGPClusterConfig converts the config to a CiliumBGPClusterConfig object.
+func CiliumBGPClusterConfig(cfg *CiliumBGPClusterConfigConfig) *ciliumv2.CiliumBGPClusterConfig {
+	if cfg == nil {
+		return nil
+	}
+	obj := intcilium.CreateCiliumBGPClusterConfig(cfg.Name)
+	intcilium.SetCiliumBGPClusterConfigSpec(obj, cfg.Spec)
+	return obj
+}
+
+// CiliumBGPPeerConfig converts the config to a CiliumBGPPeerConfig object.
+func CiliumBGPPeerConfig(cfg *CiliumBGPPeerConfigConfig) *ciliumv2.CiliumBGPPeerConfig {
+	if cfg == nil {
+		return nil
+	}
+	obj := intcilium.CreateCiliumBGPPeerConfig(cfg.Name)
+	intcilium.SetCiliumBGPPeerConfigSpec(obj, cfg.Spec)
+	return obj
+}
+
+// CiliumBGPAdvertisement converts the config to a CiliumBGPAdvertisement object.
+func CiliumBGPAdvertisement(cfg *CiliumBGPAdvertisementConfig) *ciliumv2.CiliumBGPAdvertisement {
+	if cfg == nil {
+		return nil
+	}
+	obj := intcilium.CreateCiliumBGPAdvertisement(cfg.Name)
+	intcilium.SetCiliumBGPAdvertisementSpec(obj, cfg.Spec)
+	return obj
+}
+
+// CiliumBGPNodeConfig converts the config to a CiliumBGPNodeConfig object.
+func CiliumBGPNodeConfig(cfg *CiliumBGPNodeConfigConfig) *ciliumv2.CiliumBGPNodeConfig {
+	if cfg == nil {
+		return nil
+	}
+	obj := intcilium.CreateCiliumBGPNodeConfig(cfg.Name)
+	intcilium.SetCiliumBGPNodeConfigSpec(obj, cfg.Spec)
+	return obj
+}
+
+// CiliumBGPNodeConfigOverride converts the config to a CiliumBGPNodeConfigOverride object.
+func CiliumBGPNodeConfigOverride(cfg *CiliumBGPNodeConfigOverrideConfig) *ciliumv2.CiliumBGPNodeConfigOverride {
+	if cfg == nil {
+		return nil
+	}
+	obj := intcilium.CreateCiliumBGPNodeConfigOverride(cfg.Name)
+	intcilium.SetCiliumBGPNodeConfigOverrideSpec(obj, cfg.Spec)
+	return obj
+}

--- a/pkg/kubernetes/cilium/create_test.go
+++ b/pkg/kubernetes/cilium/create_test.go
@@ -3,6 +3,7 @@ package cilium
 import (
 	"testing"
 
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
 
@@ -208,9 +209,260 @@ func TestAllConstructorsWithNilConfig(t *testing.T) {
 				t.Error("CiliumCIDRGroup should return nil for nil config")
 			}
 		}},
+		{"CiliumEgressGatewayPolicy", func(t *testing.T) {
+			if CiliumEgressGatewayPolicy(nil) != nil {
+				t.Error("CiliumEgressGatewayPolicy should return nil for nil config")
+			}
+		}},
+		{"CiliumLocalRedirectPolicy", func(t *testing.T) {
+			if CiliumLocalRedirectPolicy(nil) != nil {
+				t.Error("CiliumLocalRedirectPolicy should return nil for nil config")
+			}
+		}},
+		{"CiliumLoadBalancerIPPool", func(t *testing.T) {
+			if CiliumLoadBalancerIPPool(nil) != nil {
+				t.Error("CiliumLoadBalancerIPPool should return nil for nil config")
+			}
+		}},
+		{"CiliumEnvoyConfig", func(t *testing.T) {
+			if CiliumEnvoyConfig(nil) != nil {
+				t.Error("CiliumEnvoyConfig should return nil for nil config")
+			}
+		}},
+		{"CiliumClusterwideEnvoyConfig", func(t *testing.T) {
+			if CiliumClusterwideEnvoyConfig(nil) != nil {
+				t.Error("CiliumClusterwideEnvoyConfig should return nil for nil config")
+			}
+		}},
+		{"CiliumBGPClusterConfig", func(t *testing.T) {
+			if CiliumBGPClusterConfig(nil) != nil {
+				t.Error("CiliumBGPClusterConfig should return nil for nil config")
+			}
+		}},
+		{"CiliumBGPPeerConfig", func(t *testing.T) {
+			if CiliumBGPPeerConfig(nil) != nil {
+				t.Error("CiliumBGPPeerConfig should return nil for nil config")
+			}
+		}},
+		{"CiliumBGPAdvertisement", func(t *testing.T) {
+			if CiliumBGPAdvertisement(nil) != nil {
+				t.Error("CiliumBGPAdvertisement should return nil for nil config")
+			}
+		}},
+		{"CiliumBGPNodeConfig", func(t *testing.T) {
+			if CiliumBGPNodeConfig(nil) != nil {
+				t.Error("CiliumBGPNodeConfig should return nil for nil config")
+			}
+		}},
+		{"CiliumBGPNodeConfigOverride", func(t *testing.T) {
+			if CiliumBGPNodeConfigOverride(nil) != nil {
+				t.Error("CiliumBGPNodeConfigOverride should return nil for nil config")
+			}
+		}},
 	}
 
 	for _, constructor := range constructors {
 		t.Run(constructor.name, constructor.fn)
+	}
+}
+
+func TestCiliumEgressGatewayPolicy_Success(t *testing.T) {
+	cfg := &CiliumEgressGatewayPolicyConfig{Name: "egress-gw"}
+	obj := CiliumEgressGatewayPolicy(cfg)
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumEgressGatewayPolicy")
+	}
+	if obj.Name != "egress-gw" {
+		t.Errorf("expected Name 'egress-gw', got %s", obj.Name)
+	}
+	if obj.Namespace != "" {
+		t.Errorf("expected empty Namespace for cluster-scoped resource, got %s", obj.Namespace)
+	}
+	if obj.Kind != "CiliumEgressGatewayPolicy" {
+		t.Errorf("expected Kind 'CiliumEgressGatewayPolicy', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestCiliumEgressGatewayPolicy_WithSpec(t *testing.T) {
+	cfg := &CiliumEgressGatewayPolicyConfig{
+		Name: "egress-gw",
+		Spec: ciliumv2.CiliumEgressGatewayPolicySpec{
+			DestinationCIDRs: []ciliumv2.CIDR{"10.0.0.0/8"},
+		},
+	}
+	obj := CiliumEgressGatewayPolicy(cfg)
+	if len(obj.Spec.DestinationCIDRs) != 1 {
+		t.Fatalf("expected 1 DestinationCIDR, got %d", len(obj.Spec.DestinationCIDRs))
+	}
+}
+
+func TestCiliumLocalRedirectPolicy_Success(t *testing.T) {
+	cfg := &CiliumLocalRedirectPolicyConfig{Name: "lrp", Namespace: "kube-system"}
+	obj := CiliumLocalRedirectPolicy(cfg)
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumLocalRedirectPolicy")
+	}
+	if obj.Name != "lrp" {
+		t.Errorf("expected Name 'lrp', got %s", obj.Name)
+	}
+	if obj.Namespace != "kube-system" {
+		t.Errorf("expected Namespace 'kube-system', got %s", obj.Namespace)
+	}
+	if obj.Kind != "CiliumLocalRedirectPolicy" {
+		t.Errorf("expected Kind 'CiliumLocalRedirectPolicy', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestCiliumLoadBalancerIPPool_Success(t *testing.T) {
+	cfg := &CiliumLoadBalancerIPPoolConfig{Name: "my-pool"}
+	obj := CiliumLoadBalancerIPPool(cfg)
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumLoadBalancerIPPool")
+	}
+	if obj.Name != "my-pool" {
+		t.Errorf("expected Name 'my-pool', got %s", obj.Name)
+	}
+	if obj.Namespace != "" {
+		t.Errorf("expected empty Namespace for cluster-scoped resource, got %s", obj.Namespace)
+	}
+	if obj.Kind != "CiliumLoadBalancerIPPool" {
+		t.Errorf("expected Kind 'CiliumLoadBalancerIPPool', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestCiliumEnvoyConfig_Success(t *testing.T) {
+	cfg := &CiliumEnvoyConfigConfig{Name: "my-cec", Namespace: "default"}
+	obj := CiliumEnvoyConfig(cfg)
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumEnvoyConfig")
+	}
+	if obj.Name != "my-cec" {
+		t.Errorf("expected Name 'my-cec', got %s", obj.Name)
+	}
+	if obj.Namespace != "default" {
+		t.Errorf("expected Namespace 'default', got %s", obj.Namespace)
+	}
+	if obj.Kind != "CiliumEnvoyConfig" {
+		t.Errorf("expected Kind 'CiliumEnvoyConfig', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestCiliumClusterwideEnvoyConfig_Success(t *testing.T) {
+	cfg := &CiliumClusterwideEnvoyConfigConfig{Name: "my-ccec"}
+	obj := CiliumClusterwideEnvoyConfig(cfg)
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumClusterwideEnvoyConfig")
+	}
+	if obj.Name != "my-ccec" {
+		t.Errorf("expected Name 'my-ccec', got %s", obj.Name)
+	}
+	if obj.Namespace != "" {
+		t.Errorf("expected empty Namespace for cluster-scoped resource, got %s", obj.Namespace)
+	}
+	if obj.Kind != "CiliumClusterwideEnvoyConfig" {
+		t.Errorf("expected Kind 'CiliumClusterwideEnvoyConfig', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestCiliumBGPClusterConfig_Success(t *testing.T) {
+	cfg := &CiliumBGPClusterConfigConfig{Name: "bgp-cluster"}
+	obj := CiliumBGPClusterConfig(cfg)
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumBGPClusterConfig")
+	}
+	if obj.Name != "bgp-cluster" {
+		t.Errorf("expected Name 'bgp-cluster', got %s", obj.Name)
+	}
+	if obj.Namespace != "" {
+		t.Errorf("expected empty Namespace, got %s", obj.Namespace)
+	}
+	if obj.Kind != "CiliumBGPClusterConfig" {
+		t.Errorf("expected Kind 'CiliumBGPClusterConfig', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestCiliumBGPPeerConfig_Success(t *testing.T) {
+	cfg := &CiliumBGPPeerConfigConfig{Name: "bgp-peer"}
+	obj := CiliumBGPPeerConfig(cfg)
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumBGPPeerConfig")
+	}
+	if obj.Name != "bgp-peer" {
+		t.Errorf("expected Name 'bgp-peer', got %s", obj.Name)
+	}
+	if obj.Kind != "CiliumBGPPeerConfig" {
+		t.Errorf("expected Kind 'CiliumBGPPeerConfig', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestCiliumBGPAdvertisement_Success(t *testing.T) {
+	cfg := &CiliumBGPAdvertisementConfig{Name: "bgp-advert"}
+	obj := CiliumBGPAdvertisement(cfg)
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumBGPAdvertisement")
+	}
+	if obj.Name != "bgp-advert" {
+		t.Errorf("expected Name 'bgp-advert', got %s", obj.Name)
+	}
+	if obj.Kind != "CiliumBGPAdvertisement" {
+		t.Errorf("expected Kind 'CiliumBGPAdvertisement', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestCiliumBGPNodeConfig_Success(t *testing.T) {
+	cfg := &CiliumBGPNodeConfigConfig{Name: "bgp-node"}
+	obj := CiliumBGPNodeConfig(cfg)
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumBGPNodeConfig")
+	}
+	if obj.Name != "bgp-node" {
+		t.Errorf("expected Name 'bgp-node', got %s", obj.Name)
+	}
+	if obj.Kind != "CiliumBGPNodeConfig" {
+		t.Errorf("expected Kind 'CiliumBGPNodeConfig', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
+	}
+}
+
+func TestCiliumBGPNodeConfigOverride_Success(t *testing.T) {
+	cfg := &CiliumBGPNodeConfigOverrideConfig{Name: "bgp-override"}
+	obj := CiliumBGPNodeConfigOverride(cfg)
+	if obj == nil {
+		t.Fatal("expected non-nil CiliumBGPNodeConfigOverride")
+	}
+	if obj.Name != "bgp-override" {
+		t.Errorf("expected Name 'bgp-override', got %s", obj.Name)
+	}
+	if obj.Kind != "CiliumBGPNodeConfigOverride" {
+		t.Errorf("expected Kind 'CiliumBGPNodeConfigOverride', got %s", obj.Kind)
+	}
+	if obj.APIVersion != "cilium.io/v2" {
+		t.Errorf("expected APIVersion 'cilium.io/v2', got %s", obj.APIVersion)
 	}
 }

--- a/pkg/kubernetes/cilium/types.go
+++ b/pkg/kubernetes/cilium/types.go
@@ -1,6 +1,7 @@
 package cilium
 
 import (
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
 
@@ -29,4 +30,76 @@ type CiliumClusterwideNetworkPolicyConfig struct {
 type CiliumCIDRGroupConfig struct {
 	Name          string     `yaml:"name"`
 	ExternalCIDRs []api.CIDR `yaml:"externalCIDRs,omitempty"`
+}
+
+// CiliumEgressGatewayPolicyConfig holds the configuration for a
+// CiliumEgressGatewayPolicy. The resource is cluster-scoped.
+type CiliumEgressGatewayPolicyConfig struct {
+	Name string                                 `yaml:"name"`
+	Spec ciliumv2.CiliumEgressGatewayPolicySpec `yaml:"spec,omitempty"`
+}
+
+// CiliumLocalRedirectPolicyConfig holds the configuration for a
+// CiliumLocalRedirectPolicy. The resource is namespace-scoped.
+type CiliumLocalRedirectPolicyConfig struct {
+	Name      string                                 `yaml:"name"`
+	Namespace string                                 `yaml:"namespace"`
+	Spec      ciliumv2.CiliumLocalRedirectPolicySpec `yaml:"spec,omitempty"`
+}
+
+// CiliumLoadBalancerIPPoolConfig holds the configuration for a
+// CiliumLoadBalancerIPPool. The resource is cluster-scoped.
+type CiliumLoadBalancerIPPoolConfig struct {
+	Name string                                `yaml:"name"`
+	Spec ciliumv2.CiliumLoadBalancerIPPoolSpec `yaml:"spec,omitempty"`
+}
+
+// CiliumEnvoyConfigConfig holds the configuration for a CiliumEnvoyConfig.
+// The resource is namespace-scoped.
+type CiliumEnvoyConfigConfig struct {
+	Name      string                         `yaml:"name"`
+	Namespace string                         `yaml:"namespace"`
+	Spec      ciliumv2.CiliumEnvoyConfigSpec `yaml:"spec,omitempty"`
+}
+
+// CiliumClusterwideEnvoyConfigConfig holds the configuration for a
+// CiliumClusterwideEnvoyConfig. The resource is cluster-scoped.
+type CiliumClusterwideEnvoyConfigConfig struct {
+	Name string                         `yaml:"name"`
+	Spec ciliumv2.CiliumEnvoyConfigSpec `yaml:"spec,omitempty"`
+}
+
+// CiliumBGPClusterConfigConfig holds the configuration for a
+// CiliumBGPClusterConfig. The resource is cluster-scoped.
+type CiliumBGPClusterConfigConfig struct {
+	Name string                              `yaml:"name"`
+	Spec ciliumv2.CiliumBGPClusterConfigSpec `yaml:"spec,omitempty"`
+}
+
+// CiliumBGPPeerConfigConfig holds the configuration for a CiliumBGPPeerConfig.
+// The resource is cluster-scoped.
+type CiliumBGPPeerConfigConfig struct {
+	Name string                           `yaml:"name"`
+	Spec ciliumv2.CiliumBGPPeerConfigSpec `yaml:"spec,omitempty"`
+}
+
+// CiliumBGPAdvertisementConfig holds the configuration for a
+// CiliumBGPAdvertisement. The resource is cluster-scoped.
+type CiliumBGPAdvertisementConfig struct {
+	Name string                              `yaml:"name"`
+	Spec ciliumv2.CiliumBGPAdvertisementSpec `yaml:"spec,omitempty"`
+}
+
+// CiliumBGPNodeConfigConfig holds the configuration for a CiliumBGPNodeConfig.
+// The resource is cluster-scoped.
+type CiliumBGPNodeConfigConfig struct {
+	Name string                     `yaml:"name"`
+	Spec ciliumv2.CiliumBGPNodeSpec `yaml:"spec,omitempty"`
+}
+
+// CiliumBGPNodeConfigOverrideConfig holds the configuration for a
+// CiliumBGPNodeConfigOverride. The resource is cluster-scoped.
+type CiliumBGPNodeConfigOverrideConfig struct {
+	Name string                                   `yaml:"name"`
+	Spec ciliumv2.CiliumBGPNodeConfigOverrideSpec `yaml:"spec,omitempty"`
 }

--- a/pkg/kubernetes/cilium/types_test.go
+++ b/pkg/kubernetes/cilium/types_test.go
@@ -3,6 +3,7 @@ package cilium
 import (
 	"testing"
 
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
 
@@ -59,5 +60,121 @@ func TestCiliumCIDRGroupConfig_Fields(t *testing.T) {
 	}
 	if string(cfg.ExternalCIDRs[0]) != "10.0.0.0/8" {
 		t.Errorf("unexpected first CIDR: %s", cfg.ExternalCIDRs[0])
+	}
+}
+
+func TestCiliumEgressGatewayPolicyConfig_Fields(t *testing.T) {
+	cfg := CiliumEgressGatewayPolicyConfig{
+		Name: "egress-gw",
+		Spec: ciliumv2.CiliumEgressGatewayPolicySpec{
+			DestinationCIDRs: []ciliumv2.CIDR{"10.0.0.0/8"},
+		},
+	}
+	if cfg.Name != "egress-gw" {
+		t.Errorf("expected Name 'egress-gw', got %s", cfg.Name)
+	}
+	if len(cfg.Spec.DestinationCIDRs) != 1 {
+		t.Errorf("expected 1 DestinationCIDR, got %d", len(cfg.Spec.DestinationCIDRs))
+	}
+}
+
+func TestCiliumLocalRedirectPolicyConfig_Fields(t *testing.T) {
+	cfg := CiliumLocalRedirectPolicyConfig{
+		Name:      "lrp",
+		Namespace: "kube-system",
+	}
+	if cfg.Name != "lrp" {
+		t.Errorf("expected Name 'lrp', got %s", cfg.Name)
+	}
+	if cfg.Namespace != "kube-system" {
+		t.Errorf("expected Namespace 'kube-system', got %s", cfg.Namespace)
+	}
+}
+
+func TestCiliumLoadBalancerIPPoolConfig_Fields(t *testing.T) {
+	cfg := CiliumLoadBalancerIPPoolConfig{
+		Name: "my-pool",
+		Spec: ciliumv2.CiliumLoadBalancerIPPoolSpec{
+			Blocks: []ciliumv2.CiliumLoadBalancerIPPoolIPBlock{{Cidr: "10.0.0.0/8"}},
+		},
+	}
+	if cfg.Name != "my-pool" {
+		t.Errorf("expected Name 'my-pool', got %s", cfg.Name)
+	}
+	if len(cfg.Spec.Blocks) != 1 {
+		t.Errorf("expected 1 block, got %d", len(cfg.Spec.Blocks))
+	}
+}
+
+func TestCiliumEnvoyConfigConfig_Fields(t *testing.T) {
+	cfg := CiliumEnvoyConfigConfig{
+		Name:      "my-cec",
+		Namespace: "default",
+	}
+	if cfg.Name != "my-cec" {
+		t.Errorf("expected Name 'my-cec', got %s", cfg.Name)
+	}
+	if cfg.Namespace != "default" {
+		t.Errorf("expected Namespace 'default', got %s", cfg.Namespace)
+	}
+}
+
+func TestCiliumClusterwideEnvoyConfigConfig_Fields(t *testing.T) {
+	cfg := CiliumClusterwideEnvoyConfigConfig{Name: "my-ccec"}
+	if cfg.Name != "my-ccec" {
+		t.Errorf("expected Name 'my-ccec', got %s", cfg.Name)
+	}
+}
+
+func TestCiliumBGPClusterConfigConfig_Fields(t *testing.T) {
+	cfg := CiliumBGPClusterConfigConfig{
+		Name: "bgp-cluster",
+		Spec: ciliumv2.CiliumBGPClusterConfigSpec{
+			BGPInstances: []ciliumv2.CiliumBGPInstance{{Name: "inst"}},
+		},
+	}
+	if cfg.Name != "bgp-cluster" {
+		t.Errorf("expected Name 'bgp-cluster', got %s", cfg.Name)
+	}
+	if len(cfg.Spec.BGPInstances) != 1 {
+		t.Errorf("expected 1 BGP instance, got %d", len(cfg.Spec.BGPInstances))
+	}
+}
+
+func TestCiliumBGPPeerConfigConfig_Fields(t *testing.T) {
+	cfg := CiliumBGPPeerConfigConfig{Name: "bgp-peer"}
+	if cfg.Name != "bgp-peer" {
+		t.Errorf("expected Name 'bgp-peer', got %s", cfg.Name)
+	}
+}
+
+func TestCiliumBGPAdvertisementConfig_Fields(t *testing.T) {
+	cfg := CiliumBGPAdvertisementConfig{
+		Name: "bgp-advert",
+		Spec: ciliumv2.CiliumBGPAdvertisementSpec{
+			Advertisements: []ciliumv2.BGPAdvertisement{
+				{AdvertisementType: ciliumv2.BGPServiceAdvert},
+			},
+		},
+	}
+	if cfg.Name != "bgp-advert" {
+		t.Errorf("expected Name 'bgp-advert', got %s", cfg.Name)
+	}
+	if len(cfg.Spec.Advertisements) != 1 {
+		t.Errorf("expected 1 advertisement, got %d", len(cfg.Spec.Advertisements))
+	}
+}
+
+func TestCiliumBGPNodeConfigConfig_Fields(t *testing.T) {
+	cfg := CiliumBGPNodeConfigConfig{Name: "bgp-node"}
+	if cfg.Name != "bgp-node" {
+		t.Errorf("expected Name 'bgp-node', got %s", cfg.Name)
+	}
+}
+
+func TestCiliumBGPNodeConfigOverrideConfig_Fields(t *testing.T) {
+	cfg := CiliumBGPNodeConfigOverrideConfig{Name: "bgp-override"}
+	if cfg.Name != "bgp-override" {
+		t.Errorf("expected Name 'bgp-override', got %s", cfg.Name)
 	}
 }

--- a/pkg/kubernetes/cilium/update.go
+++ b/pkg/kubernetes/cilium/update.go
@@ -4,6 +4,7 @@ import (
 	intcilium "github.com/go-kure/kure/internal/cilium"
 
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
@@ -153,4 +154,218 @@ func AddCiliumCIDRGroupCIDR(obj *ciliumv2.CiliumCIDRGroup, cidr api.CIDR) {
 // SetCiliumCIDRGroupCIDRs replaces the ExternalCIDRs list on the group.
 func SetCiliumCIDRGroupCIDRs(obj *ciliumv2.CiliumCIDRGroup, cidrs []api.CIDR) {
 	intcilium.SetCiliumCIDRGroupCIDRs(obj, cidrs)
+}
+
+// SetCiliumEgressGatewayPolicySpec sets the full spec on the policy.
+func SetCiliumEgressGatewayPolicySpec(obj *ciliumv2.CiliumEgressGatewayPolicy, spec ciliumv2.CiliumEgressGatewayPolicySpec) {
+	intcilium.SetCiliumEgressGatewayPolicySpec(obj, spec)
+}
+
+// AddCiliumEgressGatewayPolicySelectorRule appends an egress selector rule.
+func AddCiliumEgressGatewayPolicySelectorRule(obj *ciliumv2.CiliumEgressGatewayPolicy, rule ciliumv2.EgressRule) {
+	intcilium.AddCiliumEgressGatewayPolicySelectorRule(obj, rule)
+}
+
+// AddCiliumEgressGatewayPolicyDestinationCIDR appends a destination CIDR.
+func AddCiliumEgressGatewayPolicyDestinationCIDR(obj *ciliumv2.CiliumEgressGatewayPolicy, cidr ciliumv2.CIDR) {
+	intcilium.AddCiliumEgressGatewayPolicyDestinationCIDR(obj, cidr)
+}
+
+// AddCiliumEgressGatewayPolicyExcludedCIDR appends an excluded CIDR.
+func AddCiliumEgressGatewayPolicyExcludedCIDR(obj *ciliumv2.CiliumEgressGatewayPolicy, cidr ciliumv2.CIDR) {
+	intcilium.AddCiliumEgressGatewayPolicyExcludedCIDR(obj, cidr)
+}
+
+// SetCiliumEgressGatewayPolicyEgressGateway sets the primary egress gateway.
+func SetCiliumEgressGatewayPolicyEgressGateway(obj *ciliumv2.CiliumEgressGatewayPolicy, gw *ciliumv2.EgressGateway) {
+	intcilium.SetCiliumEgressGatewayPolicyEgressGateway(obj, gw)
+}
+
+// AddCiliumEgressGatewayPolicyEgressGateway appends to the multi-gateway list.
+func AddCiliumEgressGatewayPolicyEgressGateway(obj *ciliumv2.CiliumEgressGatewayPolicy, gw ciliumv2.EgressGateway) {
+	intcilium.AddCiliumEgressGatewayPolicyEgressGateway(obj, gw)
+}
+
+// SetCiliumLocalRedirectPolicySpec sets the full spec on the policy.
+func SetCiliumLocalRedirectPolicySpec(obj *ciliumv2.CiliumLocalRedirectPolicy, spec ciliumv2.CiliumLocalRedirectPolicySpec) {
+	intcilium.SetCiliumLocalRedirectPolicySpec(obj, spec)
+}
+
+// SetCiliumLocalRedirectPolicyFrontend sets the redirect frontend.
+func SetCiliumLocalRedirectPolicyFrontend(obj *ciliumv2.CiliumLocalRedirectPolicy, frontend ciliumv2.RedirectFrontend) {
+	intcilium.SetCiliumLocalRedirectPolicyFrontend(obj, frontend)
+}
+
+// SetCiliumLocalRedirectPolicyBackend sets the redirect backend.
+func SetCiliumLocalRedirectPolicyBackend(obj *ciliumv2.CiliumLocalRedirectPolicy, backend ciliumv2.RedirectBackend) {
+	intcilium.SetCiliumLocalRedirectPolicyBackend(obj, backend)
+}
+
+// SetCiliumLocalRedirectPolicyDescription sets the description.
+func SetCiliumLocalRedirectPolicyDescription(obj *ciliumv2.CiliumLocalRedirectPolicy, desc string) {
+	intcilium.SetCiliumLocalRedirectPolicyDescription(obj, desc)
+}
+
+// SetCiliumLocalRedirectPolicySkipRedirectFromBackend sets the skip-redirect flag.
+func SetCiliumLocalRedirectPolicySkipRedirectFromBackend(obj *ciliumv2.CiliumLocalRedirectPolicy, skip bool) {
+	intcilium.SetCiliumLocalRedirectPolicySkipRedirectFromBackend(obj, skip)
+}
+
+// SetCiliumLoadBalancerIPPoolSpec sets the full spec on the pool.
+func SetCiliumLoadBalancerIPPoolSpec(obj *ciliumv2.CiliumLoadBalancerIPPool, spec ciliumv2.CiliumLoadBalancerIPPoolSpec) {
+	intcilium.SetCiliumLoadBalancerIPPoolSpec(obj, spec)
+}
+
+// SetCiliumLoadBalancerIPPoolServiceSelector sets the service selector.
+// Uses Cilium's slim LabelSelector (github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1).
+func SetCiliumLoadBalancerIPPoolServiceSelector(obj *ciliumv2.CiliumLoadBalancerIPPool, sel *slimv1.LabelSelector) {
+	intcilium.SetCiliumLoadBalancerIPPoolServiceSelector(obj, sel)
+}
+
+// AddCiliumLoadBalancerIPPoolBlock appends a CIDR block to the pool.
+func AddCiliumLoadBalancerIPPoolBlock(obj *ciliumv2.CiliumLoadBalancerIPPool, block ciliumv2.CiliumLoadBalancerIPPoolIPBlock) {
+	intcilium.AddCiliumLoadBalancerIPPoolBlock(obj, block)
+}
+
+// SetCiliumLoadBalancerIPPoolDisabled enables or disables the pool.
+func SetCiliumLoadBalancerIPPoolDisabled(obj *ciliumv2.CiliumLoadBalancerIPPool, disabled bool) {
+	intcilium.SetCiliumLoadBalancerIPPoolDisabled(obj, disabled)
+}
+
+// SetCiliumLoadBalancerIPPoolAllowFirstLastIPs controls first/last IP allocation.
+func SetCiliumLoadBalancerIPPoolAllowFirstLastIPs(obj *ciliumv2.CiliumLoadBalancerIPPool, allow ciliumv2.AllowFirstLastIPType) {
+	intcilium.SetCiliumLoadBalancerIPPoolAllowFirstLastIPs(obj, allow)
+}
+
+// SetCiliumEnvoyConfigSpec sets the full spec on the config.
+func SetCiliumEnvoyConfigSpec(obj *ciliumv2.CiliumEnvoyConfig, spec ciliumv2.CiliumEnvoyConfigSpec) {
+	intcilium.SetCiliumEnvoyConfigSpec(obj, spec)
+}
+
+// AddCiliumEnvoyConfigService appends a service listener.
+func AddCiliumEnvoyConfigService(obj *ciliumv2.CiliumEnvoyConfig, svc *ciliumv2.ServiceListener) {
+	intcilium.AddCiliumEnvoyConfigService(obj, svc)
+}
+
+// AddCiliumEnvoyConfigBackendService appends a backend service.
+func AddCiliumEnvoyConfigBackendService(obj *ciliumv2.CiliumEnvoyConfig, svc *ciliumv2.Service) {
+	intcilium.AddCiliumEnvoyConfigBackendService(obj, svc)
+}
+
+// AddCiliumEnvoyConfigResource appends an Envoy xDS resource.
+func AddCiliumEnvoyConfigResource(obj *ciliumv2.CiliumEnvoyConfig, res ciliumv2.XDSResource) {
+	intcilium.AddCiliumEnvoyConfigResource(obj, res)
+}
+
+// SetCiliumEnvoyConfigNodeSelector sets the node selector.
+// Uses Cilium's slim LabelSelector (github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1).
+func SetCiliumEnvoyConfigNodeSelector(obj *ciliumv2.CiliumEnvoyConfig, sel *slimv1.LabelSelector) {
+	intcilium.SetCiliumEnvoyConfigNodeSelector(obj, sel)
+}
+
+// SetCiliumClusterwideEnvoyConfigSpec sets the full spec on the config.
+func SetCiliumClusterwideEnvoyConfigSpec(obj *ciliumv2.CiliumClusterwideEnvoyConfig, spec ciliumv2.CiliumEnvoyConfigSpec) {
+	intcilium.SetCiliumClusterwideEnvoyConfigSpec(obj, spec)
+}
+
+// AddCiliumClusterwideEnvoyConfigService appends a service listener.
+func AddCiliumClusterwideEnvoyConfigService(obj *ciliumv2.CiliumClusterwideEnvoyConfig, svc *ciliumv2.ServiceListener) {
+	intcilium.AddCiliumClusterwideEnvoyConfigService(obj, svc)
+}
+
+// AddCiliumClusterwideEnvoyConfigBackendService appends a backend service.
+func AddCiliumClusterwideEnvoyConfigBackendService(obj *ciliumv2.CiliumClusterwideEnvoyConfig, svc *ciliumv2.Service) {
+	intcilium.AddCiliumClusterwideEnvoyConfigBackendService(obj, svc)
+}
+
+// AddCiliumClusterwideEnvoyConfigResource appends an Envoy xDS resource.
+func AddCiliumClusterwideEnvoyConfigResource(obj *ciliumv2.CiliumClusterwideEnvoyConfig, res ciliumv2.XDSResource) {
+	intcilium.AddCiliumClusterwideEnvoyConfigResource(obj, res)
+}
+
+// SetCiliumClusterwideEnvoyConfigNodeSelector sets the node selector.
+// Uses Cilium's slim LabelSelector (github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1).
+func SetCiliumClusterwideEnvoyConfigNodeSelector(obj *ciliumv2.CiliumClusterwideEnvoyConfig, sel *slimv1.LabelSelector) {
+	intcilium.SetCiliumClusterwideEnvoyConfigNodeSelector(obj, sel)
+}
+
+// SetCiliumBGPClusterConfigSpec sets the full spec on the config.
+func SetCiliumBGPClusterConfigSpec(obj *ciliumv2.CiliumBGPClusterConfig, spec ciliumv2.CiliumBGPClusterConfigSpec) {
+	intcilium.SetCiliumBGPClusterConfigSpec(obj, spec)
+}
+
+// SetCiliumBGPClusterConfigNodeSelector sets the node selector.
+// Uses Cilium's slim LabelSelector (github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1).
+func SetCiliumBGPClusterConfigNodeSelector(obj *ciliumv2.CiliumBGPClusterConfig, sel *slimv1.LabelSelector) {
+	intcilium.SetCiliumBGPClusterConfigNodeSelector(obj, sel)
+}
+
+// AddCiliumBGPClusterConfigBGPInstance appends a BGP instance.
+func AddCiliumBGPClusterConfigBGPInstance(obj *ciliumv2.CiliumBGPClusterConfig, instance ciliumv2.CiliumBGPInstance) {
+	intcilium.AddCiliumBGPClusterConfigBGPInstance(obj, instance)
+}
+
+// SetCiliumBGPPeerConfigSpec sets the full spec on the config.
+func SetCiliumBGPPeerConfigSpec(obj *ciliumv2.CiliumBGPPeerConfig, spec ciliumv2.CiliumBGPPeerConfigSpec) {
+	intcilium.SetCiliumBGPPeerConfigSpec(obj, spec)
+}
+
+// SetCiliumBGPPeerConfigTransport sets the transport configuration.
+func SetCiliumBGPPeerConfigTransport(obj *ciliumv2.CiliumBGPPeerConfig, transport *ciliumv2.CiliumBGPTransport) {
+	intcilium.SetCiliumBGPPeerConfigTransport(obj, transport)
+}
+
+// SetCiliumBGPPeerConfigTimers sets the BGP timer configuration.
+func SetCiliumBGPPeerConfigTimers(obj *ciliumv2.CiliumBGPPeerConfig, timers *ciliumv2.CiliumBGPTimers) {
+	intcilium.SetCiliumBGPPeerConfigTimers(obj, timers)
+}
+
+// SetCiliumBGPPeerConfigAuthSecretRef sets the BGP authentication secret name.
+func SetCiliumBGPPeerConfigAuthSecretRef(obj *ciliumv2.CiliumBGPPeerConfig, ref string) {
+	intcilium.SetCiliumBGPPeerConfigAuthSecretRef(obj, ref)
+}
+
+// SetCiliumBGPPeerConfigEBGPMultihop sets the eBGP multihop TTL.
+func SetCiliumBGPPeerConfigEBGPMultihop(obj *ciliumv2.CiliumBGPPeerConfig, ttl int32) {
+	intcilium.SetCiliumBGPPeerConfigEBGPMultihop(obj, ttl)
+}
+
+// SetCiliumBGPPeerConfigGracefulRestart sets the graceful restart configuration.
+func SetCiliumBGPPeerConfigGracefulRestart(obj *ciliumv2.CiliumBGPPeerConfig, gr *ciliumv2.CiliumBGPNeighborGracefulRestart) {
+	intcilium.SetCiliumBGPPeerConfigGracefulRestart(obj, gr)
+}
+
+// AddCiliumBGPPeerConfigFamily appends an address family with advertisements.
+func AddCiliumBGPPeerConfigFamily(obj *ciliumv2.CiliumBGPPeerConfig, family ciliumv2.CiliumBGPFamilyWithAdverts) {
+	intcilium.AddCiliumBGPPeerConfigFamily(obj, family)
+}
+
+// SetCiliumBGPAdvertisementSpec sets the full spec on the advertisement.
+func SetCiliumBGPAdvertisementSpec(obj *ciliumv2.CiliumBGPAdvertisement, spec ciliumv2.CiliumBGPAdvertisementSpec) {
+	intcilium.SetCiliumBGPAdvertisementSpec(obj, spec)
+}
+
+// AddCiliumBGPAdvertisementEntry appends a BGP advertisement entry.
+func AddCiliumBGPAdvertisementEntry(obj *ciliumv2.CiliumBGPAdvertisement, advert ciliumv2.BGPAdvertisement) {
+	intcilium.AddCiliumBGPAdvertisementEntry(obj, advert)
+}
+
+// SetCiliumBGPNodeConfigSpec sets the full spec on the node config.
+func SetCiliumBGPNodeConfigSpec(obj *ciliumv2.CiliumBGPNodeConfig, spec ciliumv2.CiliumBGPNodeSpec) {
+	intcilium.SetCiliumBGPNodeConfigSpec(obj, spec)
+}
+
+// AddCiliumBGPNodeConfigBGPInstance appends a BGP node instance.
+func AddCiliumBGPNodeConfigBGPInstance(obj *ciliumv2.CiliumBGPNodeConfig, instance ciliumv2.CiliumBGPNodeInstance) {
+	intcilium.AddCiliumBGPNodeConfigBGPInstance(obj, instance)
+}
+
+// SetCiliumBGPNodeConfigOverrideSpec sets the full spec on the override.
+func SetCiliumBGPNodeConfigOverrideSpec(obj *ciliumv2.CiliumBGPNodeConfigOverride, spec ciliumv2.CiliumBGPNodeConfigOverrideSpec) {
+	intcilium.SetCiliumBGPNodeConfigOverrideSpec(obj, spec)
+}
+
+// AddCiliumBGPNodeConfigOverrideBGPInstance appends a BGP instance override.
+func AddCiliumBGPNodeConfigOverrideBGPInstance(obj *ciliumv2.CiliumBGPNodeConfigOverride, instance ciliumv2.CiliumBGPNodeConfigInstanceOverride) {
+	intcilium.AddCiliumBGPNodeConfigOverrideBGPInstance(obj, instance)
 }

--- a/pkg/kubernetes/cilium/update_test.go
+++ b/pkg/kubernetes/cilium/update_test.go
@@ -3,6 +3,8 @@ package cilium
 import (
 	"testing"
 
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
@@ -247,5 +249,403 @@ func TestSetCiliumCIDRGroupCIDRs(t *testing.T) {
 	}
 	if string(obj.Spec.ExternalCIDRs[0]) != "172.16.0.0/12" {
 		t.Errorf("unexpected CIDR: %s", obj.Spec.ExternalCIDRs[0])
+	}
+}
+
+func TestSetCiliumEgressGatewayPolicySpec(t *testing.T) {
+	obj := CiliumEgressGatewayPolicy(&CiliumEgressGatewayPolicyConfig{Name: "p"})
+	spec := ciliumv2.CiliumEgressGatewayPolicySpec{
+		DestinationCIDRs: []ciliumv2.CIDR{"10.0.0.0/8"},
+	}
+	SetCiliumEgressGatewayPolicySpec(obj, spec)
+	if len(obj.Spec.DestinationCIDRs) != 1 {
+		t.Fatalf("expected 1 DestinationCIDR, got %d", len(obj.Spec.DestinationCIDRs))
+	}
+}
+
+func TestAddCiliumEgressGatewayPolicySelectorRule(t *testing.T) {
+	obj := CiliumEgressGatewayPolicy(&CiliumEgressGatewayPolicyConfig{Name: "p"})
+	rule := ciliumv2.EgressRule{}
+	AddCiliumEgressGatewayPolicySelectorRule(obj, rule)
+	AddCiliumEgressGatewayPolicySelectorRule(obj, rule)
+	if len(obj.Spec.Selectors) != 2 {
+		t.Fatalf("expected 2 selectors, got %d", len(obj.Spec.Selectors))
+	}
+}
+
+func TestAddCiliumEgressGatewayPolicyDestinationCIDR(t *testing.T) {
+	obj := CiliumEgressGatewayPolicy(&CiliumEgressGatewayPolicyConfig{Name: "p"})
+	AddCiliumEgressGatewayPolicyDestinationCIDR(obj, "10.0.0.0/8")
+	AddCiliumEgressGatewayPolicyDestinationCIDR(obj, "192.168.0.0/16")
+	if len(obj.Spec.DestinationCIDRs) != 2 {
+		t.Fatalf("expected 2 DestinationCIDRs, got %d", len(obj.Spec.DestinationCIDRs))
+	}
+}
+
+func TestAddCiliumEgressGatewayPolicyExcludedCIDR(t *testing.T) {
+	obj := CiliumEgressGatewayPolicy(&CiliumEgressGatewayPolicyConfig{Name: "p"})
+	AddCiliumEgressGatewayPolicyExcludedCIDR(obj, "10.1.0.0/24")
+	if len(obj.Spec.ExcludedCIDRs) != 1 {
+		t.Fatalf("expected 1 ExcludedCIDR, got %d", len(obj.Spec.ExcludedCIDRs))
+	}
+}
+
+func TestSetCiliumEgressGatewayPolicyEgressGateway(t *testing.T) {
+	obj := CiliumEgressGatewayPolicy(&CiliumEgressGatewayPolicyConfig{Name: "p"})
+	gw := &ciliumv2.EgressGateway{Interface: "eth0"}
+	SetCiliumEgressGatewayPolicyEgressGateway(obj, gw)
+	if obj.Spec.EgressGateway == nil || obj.Spec.EgressGateway.Interface != "eth0" {
+		t.Errorf("unexpected EgressGateway: %v", obj.Spec.EgressGateway)
+	}
+}
+
+func TestAddCiliumEgressGatewayPolicyEgressGateway(t *testing.T) {
+	obj := CiliumEgressGatewayPolicy(&CiliumEgressGatewayPolicyConfig{Name: "p"})
+	AddCiliumEgressGatewayPolicyEgressGateway(obj, ciliumv2.EgressGateway{Interface: "eth0"})
+	AddCiliumEgressGatewayPolicyEgressGateway(obj, ciliumv2.EgressGateway{Interface: "eth1"})
+	if len(obj.Spec.EgressGateways) != 2 {
+		t.Fatalf("expected 2 EgressGateways, got %d", len(obj.Spec.EgressGateways))
+	}
+}
+
+func TestSetCiliumLocalRedirectPolicySpec(t *testing.T) {
+	obj := CiliumLocalRedirectPolicy(&CiliumLocalRedirectPolicyConfig{Name: "p", Namespace: "ns"})
+	spec := ciliumv2.CiliumLocalRedirectPolicySpec{Description: "redirect spec"}
+	SetCiliumLocalRedirectPolicySpec(obj, spec)
+	if obj.Spec.Description != "redirect spec" {
+		t.Errorf("unexpected Description: %s", obj.Spec.Description)
+	}
+}
+
+func TestSetCiliumLocalRedirectPolicyFrontend(t *testing.T) {
+	obj := CiliumLocalRedirectPolicy(&CiliumLocalRedirectPolicyConfig{Name: "p", Namespace: "ns"})
+	frontend := ciliumv2.RedirectFrontend{AddressMatcher: &ciliumv2.Frontend{IP: "1.2.3.4"}}
+	SetCiliumLocalRedirectPolicyFrontend(obj, frontend)
+	if obj.Spec.RedirectFrontend.AddressMatcher == nil || obj.Spec.RedirectFrontend.AddressMatcher.IP != "1.2.3.4" {
+		t.Errorf("unexpected RedirectFrontend: %v", obj.Spec.RedirectFrontend)
+	}
+}
+
+func TestSetCiliumLocalRedirectPolicyBackend(t *testing.T) {
+	obj := CiliumLocalRedirectPolicy(&CiliumLocalRedirectPolicyConfig{Name: "p", Namespace: "ns"})
+	backend := ciliumv2.RedirectBackend{LocalEndpointSelector: slimv1.LabelSelector{}}
+	SetCiliumLocalRedirectPolicyBackend(obj, backend)
+}
+
+func TestSetCiliumLocalRedirectPolicyDescription(t *testing.T) {
+	obj := CiliumLocalRedirectPolicy(&CiliumLocalRedirectPolicyConfig{Name: "p", Namespace: "ns"})
+	SetCiliumLocalRedirectPolicyDescription(obj, "test redirect")
+	if obj.Spec.Description != "test redirect" {
+		t.Errorf("unexpected Description: %s", obj.Spec.Description)
+	}
+}
+
+func TestSetCiliumLocalRedirectPolicySkipRedirectFromBackend(t *testing.T) {
+	obj := CiliumLocalRedirectPolicy(&CiliumLocalRedirectPolicyConfig{Name: "p", Namespace: "ns"})
+	SetCiliumLocalRedirectPolicySkipRedirectFromBackend(obj, true)
+	if !obj.Spec.SkipRedirectFromBackend {
+		t.Error("expected SkipRedirectFromBackend to be true")
+	}
+}
+
+func TestSetCiliumLoadBalancerIPPoolSpec(t *testing.T) {
+	obj := CiliumLoadBalancerIPPool(&CiliumLoadBalancerIPPoolConfig{Name: "p"})
+	spec := ciliumv2.CiliumLoadBalancerIPPoolSpec{
+		Blocks: []ciliumv2.CiliumLoadBalancerIPPoolIPBlock{{Cidr: "10.0.0.0/8"}},
+	}
+	SetCiliumLoadBalancerIPPoolSpec(obj, spec)
+	if len(obj.Spec.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(obj.Spec.Blocks))
+	}
+}
+
+func TestSetCiliumLoadBalancerIPPoolServiceSelector(t *testing.T) {
+	obj := CiliumLoadBalancerIPPool(&CiliumLoadBalancerIPPoolConfig{Name: "p"})
+	sel := &slimv1.LabelSelector{MatchLabels: map[string]string{"svc": "lb"}}
+	SetCiliumLoadBalancerIPPoolServiceSelector(obj, sel)
+	if obj.Spec.ServiceSelector == nil {
+		t.Fatal("expected non-nil ServiceSelector")
+	}
+}
+
+func TestAddCiliumLoadBalancerIPPoolBlock(t *testing.T) {
+	obj := CiliumLoadBalancerIPPool(&CiliumLoadBalancerIPPoolConfig{Name: "p"})
+	AddCiliumLoadBalancerIPPoolBlock(obj, ciliumv2.CiliumLoadBalancerIPPoolIPBlock{Cidr: "10.0.0.0/8"})
+	AddCiliumLoadBalancerIPPoolBlock(obj, ciliumv2.CiliumLoadBalancerIPPoolIPBlock{Cidr: "172.16.0.0/12"})
+	if len(obj.Spec.Blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(obj.Spec.Blocks))
+	}
+}
+
+func TestSetCiliumLoadBalancerIPPoolDisabled(t *testing.T) {
+	obj := CiliumLoadBalancerIPPool(&CiliumLoadBalancerIPPoolConfig{Name: "p"})
+	SetCiliumLoadBalancerIPPoolDisabled(obj, true)
+	if !obj.Spec.Disabled {
+		t.Error("expected Disabled to be true")
+	}
+}
+
+func TestSetCiliumLoadBalancerIPPoolAllowFirstLastIPs(t *testing.T) {
+	obj := CiliumLoadBalancerIPPool(&CiliumLoadBalancerIPPoolConfig{Name: "p"})
+	SetCiliumLoadBalancerIPPoolAllowFirstLastIPs(obj, ciliumv2.AllowFirstLastIPYes)
+	if obj.Spec.AllowFirstLastIPs != ciliumv2.AllowFirstLastIPYes {
+		t.Errorf("unexpected AllowFirstLastIPs: %s", obj.Spec.AllowFirstLastIPs)
+	}
+}
+
+func TestSetCiliumEnvoyConfigSpec(t *testing.T) {
+	obj := CiliumEnvoyConfig(&CiliumEnvoyConfigConfig{Name: "p", Namespace: "ns"})
+	spec := ciliumv2.CiliumEnvoyConfigSpec{Resources: []ciliumv2.XDSResource{{}, {}}}
+	SetCiliumEnvoyConfigSpec(obj, spec)
+	if len(obj.Spec.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(obj.Spec.Resources))
+	}
+}
+
+func TestAddCiliumEnvoyConfigService(t *testing.T) {
+	obj := CiliumEnvoyConfig(&CiliumEnvoyConfigConfig{Name: "p", Namespace: "ns"})
+	svc := &ciliumv2.ServiceListener{Name: "svc", Namespace: "ns"}
+	AddCiliumEnvoyConfigService(obj, svc)
+	AddCiliumEnvoyConfigService(obj, svc)
+	if len(obj.Spec.Services) != 2 {
+		t.Fatalf("expected 2 services, got %d", len(obj.Spec.Services))
+	}
+}
+
+func TestAddCiliumEnvoyConfigBackendService(t *testing.T) {
+	obj := CiliumEnvoyConfig(&CiliumEnvoyConfigConfig{Name: "p", Namespace: "ns"})
+	svc := &ciliumv2.Service{Name: "backend", Namespace: "ns"}
+	AddCiliumEnvoyConfigBackendService(obj, svc)
+	if len(obj.Spec.BackendServices) != 1 {
+		t.Fatalf("expected 1 backend service, got %d", len(obj.Spec.BackendServices))
+	}
+}
+
+func TestAddCiliumEnvoyConfigResource(t *testing.T) {
+	obj := CiliumEnvoyConfig(&CiliumEnvoyConfigConfig{Name: "p", Namespace: "ns"})
+	AddCiliumEnvoyConfigResource(obj, ciliumv2.XDSResource{})
+	if len(obj.Spec.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(obj.Spec.Resources))
+	}
+}
+
+func TestSetCiliumEnvoyConfigNodeSelector(t *testing.T) {
+	obj := CiliumEnvoyConfig(&CiliumEnvoyConfigConfig{Name: "p", Namespace: "ns"})
+	sel := &slimv1.LabelSelector{MatchLabels: map[string]string{"node": "worker"}}
+	SetCiliumEnvoyConfigNodeSelector(obj, sel)
+	if obj.Spec.NodeSelector == nil {
+		t.Fatal("expected non-nil NodeSelector")
+	}
+}
+
+func TestSetCiliumClusterwideEnvoyConfigSpec(t *testing.T) {
+	obj := CiliumClusterwideEnvoyConfig(&CiliumClusterwideEnvoyConfigConfig{Name: "p"})
+	spec := ciliumv2.CiliumEnvoyConfigSpec{Resources: []ciliumv2.XDSResource{{}}}
+	SetCiliumClusterwideEnvoyConfigSpec(obj, spec)
+	if len(obj.Spec.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(obj.Spec.Resources))
+	}
+}
+
+func TestAddCiliumClusterwideEnvoyConfigService(t *testing.T) {
+	obj := CiliumClusterwideEnvoyConfig(&CiliumClusterwideEnvoyConfigConfig{Name: "p"})
+	svc := &ciliumv2.ServiceListener{Name: "svc", Namespace: "ns"}
+	AddCiliumClusterwideEnvoyConfigService(obj, svc)
+	if len(obj.Spec.Services) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(obj.Spec.Services))
+	}
+}
+
+func TestAddCiliumClusterwideEnvoyConfigBackendService(t *testing.T) {
+	obj := CiliumClusterwideEnvoyConfig(&CiliumClusterwideEnvoyConfigConfig{Name: "p"})
+	svc := &ciliumv2.Service{Name: "backend", Namespace: "ns"}
+	AddCiliumClusterwideEnvoyConfigBackendService(obj, svc)
+	if len(obj.Spec.BackendServices) != 1 {
+		t.Fatalf("expected 1 backend service, got %d", len(obj.Spec.BackendServices))
+	}
+}
+
+func TestAddCiliumClusterwideEnvoyConfigResource(t *testing.T) {
+	obj := CiliumClusterwideEnvoyConfig(&CiliumClusterwideEnvoyConfigConfig{Name: "p"})
+	AddCiliumClusterwideEnvoyConfigResource(obj, ciliumv2.XDSResource{})
+	AddCiliumClusterwideEnvoyConfigResource(obj, ciliumv2.XDSResource{})
+	if len(obj.Spec.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(obj.Spec.Resources))
+	}
+}
+
+func TestSetCiliumClusterwideEnvoyConfigNodeSelector(t *testing.T) {
+	obj := CiliumClusterwideEnvoyConfig(&CiliumClusterwideEnvoyConfigConfig{Name: "p"})
+	sel := &slimv1.LabelSelector{MatchLabels: map[string]string{"node": "worker"}}
+	SetCiliumClusterwideEnvoyConfigNodeSelector(obj, sel)
+	if obj.Spec.NodeSelector == nil {
+		t.Fatal("expected non-nil NodeSelector")
+	}
+}
+
+func TestSetCiliumBGPClusterConfigSpec(t *testing.T) {
+	obj := CiliumBGPClusterConfig(&CiliumBGPClusterConfigConfig{Name: "p"})
+	spec := ciliumv2.CiliumBGPClusterConfigSpec{
+		BGPInstances: []ciliumv2.CiliumBGPInstance{{Name: "inst"}},
+	}
+	SetCiliumBGPClusterConfigSpec(obj, spec)
+	if len(obj.Spec.BGPInstances) != 1 {
+		t.Fatalf("expected 1 BGP instance, got %d", len(obj.Spec.BGPInstances))
+	}
+}
+
+func TestSetCiliumBGPClusterConfigNodeSelector(t *testing.T) {
+	obj := CiliumBGPClusterConfig(&CiliumBGPClusterConfigConfig{Name: "p"})
+	sel := &slimv1.LabelSelector{MatchLabels: map[string]string{"bgp": "enabled"}}
+	SetCiliumBGPClusterConfigNodeSelector(obj, sel)
+	if obj.Spec.NodeSelector == nil {
+		t.Fatal("expected non-nil NodeSelector")
+	}
+}
+
+func TestAddCiliumBGPClusterConfigBGPInstance(t *testing.T) {
+	obj := CiliumBGPClusterConfig(&CiliumBGPClusterConfigConfig{Name: "p"})
+	AddCiliumBGPClusterConfigBGPInstance(obj, ciliumv2.CiliumBGPInstance{Name: "inst-1"})
+	AddCiliumBGPClusterConfigBGPInstance(obj, ciliumv2.CiliumBGPInstance{Name: "inst-2"})
+	if len(obj.Spec.BGPInstances) != 2 {
+		t.Fatalf("expected 2 BGP instances, got %d", len(obj.Spec.BGPInstances))
+	}
+}
+
+func TestSetCiliumBGPPeerConfigSpec(t *testing.T) {
+	obj := CiliumBGPPeerConfig(&CiliumBGPPeerConfigConfig{Name: "p"})
+	ref := "bgp-secret"
+	spec := ciliumv2.CiliumBGPPeerConfigSpec{AuthSecretRef: &ref}
+	SetCiliumBGPPeerConfigSpec(obj, spec)
+	if obj.Spec.AuthSecretRef == nil || *obj.Spec.AuthSecretRef != "bgp-secret" {
+		t.Errorf("unexpected AuthSecretRef: %v", obj.Spec.AuthSecretRef)
+	}
+}
+
+func TestSetCiliumBGPPeerConfigTransport(t *testing.T) {
+	obj := CiliumBGPPeerConfig(&CiliumBGPPeerConfigConfig{Name: "p"})
+	port := int32(179)
+	transport := &ciliumv2.CiliumBGPTransport{PeerPort: &port}
+	SetCiliumBGPPeerConfigTransport(obj, transport)
+	if obj.Spec.Transport == nil || obj.Spec.Transport.PeerPort == nil || *obj.Spec.Transport.PeerPort != 179 {
+		t.Errorf("unexpected Transport: %v", obj.Spec.Transport)
+	}
+}
+
+func TestSetCiliumBGPPeerConfigTimers(t *testing.T) {
+	obj := CiliumBGPPeerConfig(&CiliumBGPPeerConfigConfig{Name: "p"})
+	hold := int32(90)
+	timers := &ciliumv2.CiliumBGPTimers{HoldTimeSeconds: &hold}
+	SetCiliumBGPPeerConfigTimers(obj, timers)
+	if obj.Spec.Timers == nil || obj.Spec.Timers.HoldTimeSeconds == nil || *obj.Spec.Timers.HoldTimeSeconds != 90 {
+		t.Errorf("unexpected Timers: %v", obj.Spec.Timers)
+	}
+}
+
+func TestSetCiliumBGPPeerConfigAuthSecretRef(t *testing.T) {
+	obj := CiliumBGPPeerConfig(&CiliumBGPPeerConfigConfig{Name: "p"})
+	SetCiliumBGPPeerConfigAuthSecretRef(obj, "my-secret")
+	if obj.Spec.AuthSecretRef == nil || *obj.Spec.AuthSecretRef != "my-secret" {
+		t.Errorf("unexpected AuthSecretRef: %v", obj.Spec.AuthSecretRef)
+	}
+}
+
+func TestSetCiliumBGPPeerConfigEBGPMultihop(t *testing.T) {
+	obj := CiliumBGPPeerConfig(&CiliumBGPPeerConfigConfig{Name: "p"})
+	SetCiliumBGPPeerConfigEBGPMultihop(obj, 5)
+	if obj.Spec.EBGPMultihop == nil || *obj.Spec.EBGPMultihop != 5 {
+		t.Errorf("unexpected EBGPMultihop: %v", obj.Spec.EBGPMultihop)
+	}
+}
+
+func TestSetCiliumBGPPeerConfigGracefulRestart(t *testing.T) {
+	obj := CiliumBGPPeerConfig(&CiliumBGPPeerConfigConfig{Name: "p"})
+	enabled := true
+	gr := &ciliumv2.CiliumBGPNeighborGracefulRestart{Enabled: enabled}
+	SetCiliumBGPPeerConfigGracefulRestart(obj, gr)
+	if obj.Spec.GracefulRestart == nil || !obj.Spec.GracefulRestart.Enabled {
+		t.Errorf("unexpected GracefulRestart: %v", obj.Spec.GracefulRestart)
+	}
+}
+
+func TestAddCiliumBGPPeerConfigFamily(t *testing.T) {
+	obj := CiliumBGPPeerConfig(&CiliumBGPPeerConfigConfig{Name: "p"})
+	fam := ciliumv2.CiliumBGPFamilyWithAdverts{
+		CiliumBGPFamily: ciliumv2.CiliumBGPFamily{Afi: "ipv4", Safi: "unicast"},
+	}
+	AddCiliumBGPPeerConfigFamily(obj, fam)
+	AddCiliumBGPPeerConfigFamily(obj, fam)
+	if len(obj.Spec.Families) != 2 {
+		t.Fatalf("expected 2 families, got %d", len(obj.Spec.Families))
+	}
+}
+
+func TestSetCiliumBGPAdvertisementSpec(t *testing.T) {
+	obj := CiliumBGPAdvertisement(&CiliumBGPAdvertisementConfig{Name: "p"})
+	spec := ciliumv2.CiliumBGPAdvertisementSpec{
+		Advertisements: []ciliumv2.BGPAdvertisement{
+			{AdvertisementType: ciliumv2.BGPServiceAdvert},
+		},
+	}
+	SetCiliumBGPAdvertisementSpec(obj, spec)
+	if len(obj.Spec.Advertisements) != 1 {
+		t.Fatalf("expected 1 advertisement, got %d", len(obj.Spec.Advertisements))
+	}
+}
+
+func TestAddCiliumBGPAdvertisementEntry(t *testing.T) {
+	obj := CiliumBGPAdvertisement(&CiliumBGPAdvertisementConfig{Name: "p"})
+	AddCiliumBGPAdvertisementEntry(obj, ciliumv2.BGPAdvertisement{AdvertisementType: ciliumv2.BGPServiceAdvert})
+	AddCiliumBGPAdvertisementEntry(obj, ciliumv2.BGPAdvertisement{AdvertisementType: ciliumv2.BGPPodCIDRAdvert})
+	if len(obj.Spec.Advertisements) != 2 {
+		t.Fatalf("expected 2 advertisements, got %d", len(obj.Spec.Advertisements))
+	}
+}
+
+func TestSetCiliumBGPNodeConfigSpec(t *testing.T) {
+	obj := CiliumBGPNodeConfig(&CiliumBGPNodeConfigConfig{Name: "p"})
+	spec := ciliumv2.CiliumBGPNodeSpec{
+		BGPInstances: []ciliumv2.CiliumBGPNodeInstance{{Name: "inst"}},
+	}
+	SetCiliumBGPNodeConfigSpec(obj, spec)
+	if len(obj.Spec.BGPInstances) != 1 {
+		t.Fatalf("expected 1 BGP node instance, got %d", len(obj.Spec.BGPInstances))
+	}
+}
+
+func TestAddCiliumBGPNodeConfigBGPInstance(t *testing.T) {
+	obj := CiliumBGPNodeConfig(&CiliumBGPNodeConfigConfig{Name: "p"})
+	AddCiliumBGPNodeConfigBGPInstance(obj, ciliumv2.CiliumBGPNodeInstance{Name: "inst-1"})
+	if len(obj.Spec.BGPInstances) != 1 {
+		t.Fatalf("expected 1 BGP node instance, got %d", len(obj.Spec.BGPInstances))
+	}
+}
+
+func TestSetCiliumBGPNodeConfigOverrideSpec(t *testing.T) {
+	obj := CiliumBGPNodeConfigOverride(&CiliumBGPNodeConfigOverrideConfig{Name: "p"})
+	routerID := "10.0.0.1"
+	spec := ciliumv2.CiliumBGPNodeConfigOverrideSpec{
+		BGPInstances: []ciliumv2.CiliumBGPNodeConfigInstanceOverride{
+			{Name: "inst", RouterID: &routerID},
+		},
+	}
+	SetCiliumBGPNodeConfigOverrideSpec(obj, spec)
+	if len(obj.Spec.BGPInstances) != 1 {
+		t.Fatalf("expected 1 BGP instance override, got %d", len(obj.Spec.BGPInstances))
+	}
+}
+
+func TestAddCiliumBGPNodeConfigOverrideBGPInstance(t *testing.T) {
+	obj := CiliumBGPNodeConfigOverride(&CiliumBGPNodeConfigOverrideConfig{Name: "p"})
+	routerID := "10.0.0.2"
+	AddCiliumBGPNodeConfigOverrideBGPInstance(obj, ciliumv2.CiliumBGPNodeConfigInstanceOverride{
+		Name:     "inst-1",
+		RouterID: &routerID,
+	})
+	if len(obj.Spec.BGPInstances) != 1 {
+		t.Fatalf("expected 1 BGP instance override, got %d", len(obj.Spec.BGPInstances))
+	}
+	if *obj.Spec.BGPInstances[0].RouterID != "10.0.0.2" {
+		t.Errorf("unexpected RouterID: %s", *obj.Spec.BGPInstances[0].RouterID)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #514.

Implements typed builder support for 10 remaining stable Cilium CRDs from `cilium.io/v2`, completing the Cilium builder layer started in #501.

**New CRDs:**
- `CiliumEgressGatewayPolicy` (cluster-scoped) — CEGP with selectors, destination/excluded CIDRs, egress gateways
- `CiliumLocalRedirectPolicy` (namespace-scoped) — frontend/backend redirect with address matcher
- `CiliumLoadBalancerIPPool` (cluster-scoped) — CIDR blocks, service selector, disabled flag, AllowFirstLastIPs
- `CiliumEnvoyConfig` (namespace-scoped) — xDS resources, services, backend services, node selector
- `CiliumClusterwideEnvoyConfig` (cluster-scoped) — same spec shape as CEC
- `CiliumBGPClusterConfig` — node selector, BGP instances
- `CiliumBGPPeerConfig` — transport, timers, auth secret, eBGP multihop, graceful restart, address families
- `CiliumBGPAdvertisement` — advertisement entries
- `CiliumBGPNodeConfig` — BGP node instances
- `CiliumBGPNodeConfigOverride` — per-instance router ID and local AS overrides

**Architecture:** Three-layer pattern consistent with existing builders — `internal/cilium/` primitives, `pkg/kubernetes/cilium/` public Config structs + constructors + setters. Uses `slimv1.LabelSelector` throughout where Cilium CRDs require it.

## Test plan

- [x] `mise run verify` (tidy + lint + test) passes green
- [x] Internal tests: all new `internal/cilium/*_test.go` files covering Create/Set/Add per CRD
- [x] Public tests: `create_test.go` covers nil-config guard + TypeMeta + Namespace for all 10 new CRDs; `update_test.go` covers all new setters; `types_test.go` covers all new Config structs