### PR TITLE
feat(ci): add actions:read permission to release-create workflow

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -29,6 +29,7 @@ on:
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
   release-create:


### PR DESCRIPTION
## Summary

- Adds `actions: read` to the top-level permissions of the `release-create.yml` caller workflow.

Required by the updated shared workflow (`go-kure/.github` feat/release-create-improvements) which now:
1. Checks `gh run list` to verify CI passed on HEAD before tagging
2. Watches the downstream `release.yml` run after the tag is pushed

Depends on: go-kure/.github#<shared-workflow-pr>

## Test plan

- [ ] Merge shared workflow PR first, then this one
- [ ] Trigger a release and confirm the `release-create` workflow waits for the full release pipeline