### PR TITLE
ci: route cache through in-cluster server, rename runner label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ env:
   # Go version is read from mise.toml (single source of truth)
   # GO_VERSION is set dynamically in each job that needs it
   GOLANGCI_LINT_VERSION: 'v2.10.1'
+  # Force actions/cache to use legacy REST API (v1) so it reads ACTIONS_CACHE_URL
+  # from the runner pod env, routing cache traffic through the in-cluster cache server.
+  # Without this, cache@v5 uses twirp API via ACTIONS_RESULTS_URL which GitHub's
+  # job dispatch overwrites, bypassing the local cache server entirely.
+  ACTIONS_CACHE_SERVICE_V2: 'false'
 
 # Avoid duplicate runs on the same commit
 concurrency:
@@ -30,7 +35,7 @@ jobs:
 
   rebase-check:
     name: rebase-check
-    runs-on: autops-kube
+    runs-on: autops-kube-kure
     timeout-minutes: 2
     if: github.event_name == 'pull_request'
 
@@ -56,7 +61,7 @@ jobs:
 
   changes:
     name: detect-changes
-    runs-on: autops-kube
+    runs-on: autops-kube-kure
     timeout-minutes: 2
     outputs:
       go: ${{ steps.filter.outputs.go }}
@@ -87,7 +92,7 @@ jobs:
 
   validate:
     name: lint
-    runs-on: autops-kube
+    runs-on: autops-kube-kure
     timeout-minutes: 15
     needs: [changes]
     if: |
@@ -181,7 +186,7 @@ jobs:
 
   test:
     name: test
-    runs-on: autops-kube
+    runs-on: autops-kube-kure
     timeout-minutes: 15
     needs: [changes]
     if: |
@@ -244,7 +249,7 @@ jobs:
 
   security:
     name: Security
-    runs-on: autops-kube
+    runs-on: autops-kube-kure
     timeout-minutes: 10
     needs: [changes]
     if: |
@@ -312,7 +317,7 @@ jobs:
 
   coverage-check:
     name: Coverage Check
-    runs-on: autops-kube
+    runs-on: autops-kube-kure
     timeout-minutes: 5
     needs: test
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
@@ -382,7 +387,7 @@ jobs:
 
   build-binaries:
     name: Build ${{ matrix.target }}
-    runs-on: autops-kube
+    runs-on: autops-kube-kure
     timeout-minutes: 10
     needs: [changes, test]
     if: |
@@ -438,7 +443,7 @@ jobs:
 
   build:
     name: build
-    runs-on: autops-kube
+    runs-on: autops-kube-kure
     timeout-minutes: 1
     needs: [validate, test, build-binaries, docs-build, coverage-check]
     if: always()
@@ -463,7 +468,7 @@ jobs:
 
   cross-platform:
     name: Cross-Platform Build
-    runs-on: autops-kube
+    runs-on: autops-kube-kure
     timeout-minutes: 15
     needs: build-binaries
     if: |
@@ -544,7 +549,7 @@ jobs:
 
   docs-build:
     name: docs-build
-    runs-on: autops-kube
+    runs-on: autops-kube-kure
     timeout-minutes: 15
     needs: [changes]
     if: |
@@ -647,7 +652,7 @@ jobs:
 
   analyze-changes:
     name: Analyze Changes
-    runs-on: autops-kube
+    runs-on: autops-kube-kure
     timeout-minutes: 5
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
 
@@ -696,7 +701,7 @@ jobs:
 
   docs-check:
     name: Docs Check
-    runs-on: autops-kube
+    runs-on: autops-kube-kure
     timeout-minutes: 5
     needs: [changes]
     if: |
@@ -750,7 +755,7 @@ jobs:
 
   mirror-to-gitlab:
     name: Mirror to GitLab
-    runs-on: autops-kube
+    runs-on: autops-kube-kure
     timeout-minutes: 5
     needs: [build, security, cross-platform, docs-build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
   deploy:
     name: Build and Deploy
-    runs-on: autops-kube
+    runs-on: autops-kube-kure
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/manage-docs.yml
+++ b/.github/workflows/manage-docs.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   remove-version:
     name: Remove version
-    runs-on: autops-kube
+    runs-on: autops-kube-kure
     timeout-minutes: 5
     if: inputs.action == 'remove-version'
 
@@ -56,7 +56,7 @@ jobs:
 
   set-latest:
     name: Set latest version
-    runs-on: autops-kube
+    runs-on: autops-kube-kure
     timeout-minutes: 5
     if: inputs.action == 'set-latest'
 
@@ -76,7 +76,7 @@ jobs:
 
   rebuild-version:
     name: Rebuild version
-    runs-on: autops-kube
+    runs-on: autops-kube-kure
     timeout-minutes: 5
     if: inputs.action == 'rebuild-version'
 


### PR DESCRIPTION
## Summary

- Add `ACTIONS_CACHE_SERVICE_V2: 'false'` to global `env:` block in `ci.yml`
- Rename all `runs-on: autops-kube` → `runs-on: autops-kube-kure` across `ci.yml`, `deploy-docs.yml`, `manage-docs.yml`

## Cache routing fix

GitHub's job dispatch **overwrites** `ACTIONS_RESULTS_URL` in the runner container env when it dispatches a job. `actions/cache@v5` defaults to the twirp/v2 API which reads this variable — so all cache traffic goes to GitHub's cloud cache, not the in-cluster falcondev server (backed by Garage S3).

`ACTIONS_CACHE_URL` is **not** overwritten by GitHub. Setting `ACTIONS_CACHE_SERVICE_V2: 'false'` forces the legacy REST API (v1) which reads `ACTIONS_CACHE_URL`, routing all cache traffic in-cluster.

Paired changes:
- opsmaster: runner pod now has `ACTIONS_CACHE_URL` set (committed)
- launcher PR #23: same cache fix + runner rename

## Runner rename

`autops-kube-kure` makes it explicit that this runner scale set serves the `go-kure` GitHub org. The opsmaster helmrelease `releaseName` will be updated in a coordinated commit once both PRs are ready to merge.

## Test plan

- [ ] CI completes without timeout
- [ ] Subsequent runs show cache hits (speedup)
- [ ] Garage S3 `actions-cache` bucket receives writes