### PR TITLE
ci: set ACTIONS_CACHE_URL in workflow env to route cache in-cluster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,13 @@ env:
   # Go version is read from mise.toml (single source of truth)
   # GO_VERSION is set dynamically in each job that needs it
   GOLANGCI_LINT_VERSION: 'v2.10.1'
-  # Force actions/cache to use legacy REST API (v1) so it reads ACTIONS_CACHE_URL
-  # from the runner pod env, routing cache traffic through the in-cluster cache server.
-  # Without this, cache@v5 uses twirp API via ACTIONS_RESULTS_URL which GitHub's
-  # job dispatch overwrites, bypassing the local cache server entirely.
+  # Route cache through in-cluster falcondev cache server (backed by Garage S3).
+  # GitHub's job dispatch overwrites both ACTIONS_RESULTS_URL (twirp/v2) and
+  # ACTIONS_CACHE_URL (REST/v1) in the runner process env. Workflow-level env vars
+  # take precedence over runner-injected values, so we re-assert ACTIONS_CACHE_URL
+  # here and force v1 to ensure actions/cache reads it instead of ACTIONS_RESULTS_URL.
   ACTIONS_CACHE_SERVICE_V2: 'false'
+  ACTIONS_CACHE_URL: 'http://actions-cache-server.arc-runners.svc.cluster.local:3000/'
 
 # Avoid duplicate runs on the same commit
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
   test:
     name: test
     runs-on: autops-kube-kure
-    timeout-minutes: 15
+    timeout-minutes: 25
     needs: [changes]
     if: |
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
@@ -218,12 +218,10 @@ jobs:
     - name: Cache Go modules
       uses: actions/cache@v5
       with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ runner.os }}-gomod-
 
     - name: Install dependencies
       run: make deps
@@ -423,12 +421,10 @@ jobs:
     - name: Cache Go modules
       uses: actions/cache@v5
       with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ runner.os }}-gomod-
 
     - name: Install dependencies
       run: make deps
@@ -509,12 +505,10 @@ jobs:
     - name: Cache Go modules
       uses: actions/cache@v5
       with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ runner.os }}-gomod-
 
     - name: Install dependencies
       run: make deps


### PR DESCRIPTION
## Problem

GitHub's job dispatch overwrites **both** `ACTIONS_RESULTS_URL` and `ACTIONS_CACHE_URL` in the runner process env. The previous fix (`ACTIONS_CACHE_SERVICE_V2: 'false'`) forced v1 REST API but left `ACTIONS_CACHE_URL` pointing to GitHub's cloud.

Confirmed from job logs: the POST step tried to save via v1 REST ("Unable to reserve cache...") but to GitHub's servers — the in-cluster Garage S3 bucket remained empty.

## Fix

Workflow-level `env:` vars take precedence over runner-injected process env. Adding `ACTIONS_CACHE_URL` to the workflow env block re-asserts the in-cluster server URL, overriding the GitHub-injected value.