### PR TITLE
fix(kubernetes): remove deprecated SetServiceLoadBalancerIP

### DIFF
--- a/pkg/kubernetes/doc.go
+++ b/pkg/kubernetes/doc.go
@@ -81,7 +81,7 @@
 // The remaining helpers follow the Add*/Set* convention:
 //
 //   - [AddServicePort], [SetServiceSelector], [SetServiceType]
-//   - [SetServiceClusterIP], [AddServiceExternalIP], [SetServiceLoadBalancerIP]
+//   - [SetServiceClusterIP], [AddServiceExternalIP]
 //   - [SetServiceExternalTrafficPolicy], [SetServiceSessionAffinity]
 //   - [SetServiceLoadBalancerClass], [SetServicePublishNotReadyAddresses]
 //   - [AddServiceLabel], [AddServiceAnnotation], [SetServiceLabels], [SetServiceAnnotations]

--- a/pkg/kubernetes/service.go
+++ b/pkg/kubernetes/service.go
@@ -78,19 +78,6 @@ func AddServiceExternalIP(service *corev1.Service, ip string) error {
 	return nil
 }
 
-// SetServiceLoadBalancerIP sets the load balancer IP on the Service spec.
-//
-// Deprecated: This field was under-specified and its meaning varies across
-// implementations. As of Kubernetes v1.24, users are encouraged to use
-// implementation-specific annotations when available.
-func SetServiceLoadBalancerIP(service *corev1.Service, ip string) error {
-	if service == nil {
-		return errors.ErrNilService
-	}
-	service.Spec.LoadBalancerIP = ip
-	return nil
-}
-
 // SetServiceExternalTrafficPolicy sets the external traffic policy on the
 // Service spec.
 func SetServiceExternalTrafficPolicy(service *corev1.Service, trafficPolicy corev1.ServiceExternalTrafficPolicy) error {

--- a/pkg/kubernetes/service_test.go
+++ b/pkg/kubernetes/service_test.go
@@ -40,9 +40,6 @@ func TestServiceNilErrors(t *testing.T) {
 	if err := AddServiceExternalIP(nil, "1.2.3.4"); err == nil {
 		t.Error("expected error for nil Service on AddServiceExternalIP")
 	}
-	if err := SetServiceLoadBalancerIP(nil, "1.2.3.4"); err == nil {
-		t.Error("expected error for nil Service on SetServiceLoadBalancerIP")
-	}
 	if err := SetServiceExternalTrafficPolicy(nil, corev1.ServiceExternalTrafficPolicyLocal); err == nil {
 		t.Error("expected error for nil Service on SetServiceExternalTrafficPolicy")
 	}
@@ -158,13 +155,6 @@ func TestServiceFunctions(t *testing.T) {
 	}
 	if len(svc.Spec.ExternalIPs) != 1 || svc.Spec.ExternalIPs[0] != "192.168.1.2" {
 		t.Errorf("external IP not added")
-	}
-
-	if err := SetServiceLoadBalancerIP(svc, "1.1.1.1"); err != nil {
-		t.Fatalf("SetServiceLoadBalancerIP returned error: %v", err)
-	}
-	if svc.Spec.LoadBalancerIP != "1.1.1.1" {
-		t.Errorf("loadBalancerIP not set")
 	}
 
 	if err := SetServicePublishNotReadyAddresses(svc, true); err != nil {


### PR DESCRIPTION
Closes #521

**Breaking change:** `SetServiceLoadBalancerIP` is removed.

`Service.Spec.LoadBalancerIP` was deprecated in Kubernetes v1.24 and is ignored by
most cloud providers and load balancer implementations. kure targets k8s 1.36. Keeping
the function misleads users into using a no-op field.

Callers must switch to implementation-specific annotations, for example
`metallb.universe.tf/loadBalancerIPs` for MetalLB.