### PR TITLE
refactor(kubernetes)!: nil-receiver setters panic instead of returning error

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -75,7 +75,7 @@ func runInternals() error {
 	intkubernetes.AddNamespaceLabel(ns, "env", "demo")
 
 	sa := kubernetes.CreateServiceAccount("demo-sa", "demo")
-	logError("add serviceaccount secret", kubernetes.AddServiceAccountSecret(sa, apiv1.ObjectReference{Name: "sa-secret"}))
+	kubernetes.AddServiceAccountSecret(sa, apiv1.ObjectReference{Name: "sa-secret"})
 
 	secret := intkubernetes.CreateSecret("demo-secret", "demo")
 	intkubernetes.AddSecretData(secret, "cert", []byte("data"))

--- a/pkg/kubernetes/container.go
+++ b/pkg/kubernetes/container.go
@@ -3,8 +3,6 @@ package kubernetes
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-
-	"github.com/go-kure/kure/pkg/errors"
 )
 
 // CreateContainer returns a Container populated with the provided name, image,
@@ -36,102 +34,91 @@ func CreateContainer(name string, image string, command []string, args []string)
 }
 
 // AddContainerPort appends a container port to the Ports slice.
-func AddContainerPort(container *corev1.Container, port corev1.ContainerPort) error {
+func AddContainerPort(container *corev1.Container, port corev1.ContainerPort) {
 	if container == nil {
-		return errors.ErrNilContainer
+		panic("AddContainerPort: container must not be nil")
 	}
 	container.Ports = append(container.Ports, port)
-	return nil
 }
 
 // AddContainerEnv appends an environment variable to the container.
-func AddContainerEnv(container *corev1.Container, env corev1.EnvVar) error {
+func AddContainerEnv(container *corev1.Container, env corev1.EnvVar) {
 	if container == nil {
-		return errors.ErrNilContainer
+		panic("AddContainerEnv: container must not be nil")
 	}
 	container.Env = append(container.Env, env)
-	return nil
 }
 
 // AddContainerEnvFrom appends an EnvFromSource entry to the container.
-func AddContainerEnvFrom(container *corev1.Container, envFrom corev1.EnvFromSource) error {
+func AddContainerEnvFrom(container *corev1.Container, envFrom corev1.EnvFromSource) {
 	if container == nil {
-		return errors.ErrNilContainer
+		panic("AddContainerEnvFrom: container must not be nil")
 	}
 	container.EnvFrom = append(container.EnvFrom, envFrom)
-	return nil
 }
 
 // AddContainerVolumeMount appends a volume mount to the container.
-func AddContainerVolumeMount(container *corev1.Container, volumeMount corev1.VolumeMount) error {
+func AddContainerVolumeMount(container *corev1.Container, volumeMount corev1.VolumeMount) {
 	if container == nil {
-		return errors.ErrNilContainer
+		panic("AddContainerVolumeMount: container must not be nil")
 	}
 	container.VolumeMounts = append(container.VolumeMounts, volumeMount)
-	return nil
 }
 
 // AddContainerVolumeDevice appends a volume device to the container.
-func AddContainerVolumeDevice(container *corev1.Container, volumeDevice corev1.VolumeDevice) error {
+func AddContainerVolumeDevice(container *corev1.Container, volumeDevice corev1.VolumeDevice) {
 	if container == nil {
-		return errors.ErrNilContainer
+		panic("AddContainerVolumeDevice: container must not be nil")
 	}
 	container.VolumeDevices = append(container.VolumeDevices, volumeDevice)
-	return nil
 }
 
 // SetContainerLivenessProbe sets the container's liveness probe.
-func SetContainerLivenessProbe(container *corev1.Container, livenessProbe corev1.Probe) error {
+func SetContainerLivenessProbe(container *corev1.Container, livenessProbe corev1.Probe) {
 	if container == nil {
-		return errors.ErrNilContainer
+		panic("SetContainerLivenessProbe: container must not be nil")
 	}
 	container.LivenessProbe = &livenessProbe
-	return nil
 }
 
 // SetContainerReadinessProbe sets the container's readiness probe.
-func SetContainerReadinessProbe(container *corev1.Container, readinessProbe corev1.Probe) error {
+func SetContainerReadinessProbe(container *corev1.Container, readinessProbe corev1.Probe) {
 	if container == nil {
-		return errors.ErrNilContainer
+		panic("SetContainerReadinessProbe: container must not be nil")
 	}
 	container.ReadinessProbe = &readinessProbe
-	return nil
 }
 
 // SetContainerStartupProbe sets the container's startup probe.
-func SetContainerStartupProbe(container *corev1.Container, startupProbe corev1.Probe) error {
+func SetContainerStartupProbe(container *corev1.Container, startupProbe corev1.Probe) {
 	if container == nil {
-		return errors.ErrNilContainer
+		panic("SetContainerStartupProbe: container must not be nil")
 	}
 	container.StartupProbe = &startupProbe
-	return nil
 }
 
 // SetContainerResources sets resource requirements on the container.
-func SetContainerResources(container *corev1.Container, resources corev1.ResourceRequirements) error {
+func SetContainerResources(container *corev1.Container, resources corev1.ResourceRequirements) {
 	if container == nil {
-		return errors.ErrNilContainer
+		panic("SetContainerResources: container must not be nil")
 	}
 	container.Resources = resources
-	return nil
 }
 
 // SetContainerImagePullPolicy sets the image pull policy.
-func SetContainerImagePullPolicy(container *corev1.Container, imagePullPolicy corev1.PullPolicy) error {
+func SetContainerImagePullPolicy(container *corev1.Container, imagePullPolicy corev1.PullPolicy) {
 	if container == nil {
-		return errors.ErrNilContainer
+		panic("SetContainerImagePullPolicy: container must not be nil")
 	}
 	container.ImagePullPolicy = imagePullPolicy
-	return nil
 }
 
 // SetContainerSecurityContext sets the security context on the container.
-func SetContainerSecurityContext(container *corev1.Container, securityContext corev1.SecurityContext) error {
+func SetContainerSecurityContext(container *corev1.Container, securityContext corev1.SecurityContext) {
 	if container == nil {
-		return errors.ErrNilContainer
+		panic("SetContainerSecurityContext: container must not be nil")
 	}
 	container.SecurityContext = &securityContext
-	return nil
 }
 
 func SetContainerWorkingDir(container *corev1.Container, dir string) {

--- a/pkg/kubernetes/container_test.go
+++ b/pkg/kubernetes/container_test.go
@@ -124,9 +124,7 @@ func TestAddContainerEnvFrom(t *testing.T) {
 				EnvFrom: tt.initialEnvFrom,
 			}
 
-			if err := AddContainerEnvFrom(container, tt.newEnvFrom); err != nil {
-				t.Fatalf("AddContainerEnvFrom returned error: %v", err)
-			}
+			AddContainerEnvFrom(container, tt.newEnvFrom)
 			if err := compareEnvFromSources(container.EnvFrom, tt.expectedResult); err != nil {
 				t.Error(err)
 			}
@@ -392,9 +390,7 @@ func TestAddContainerPort(t *testing.T) {
 				Ports: tt.initialPorts,
 			}
 
-			if err := AddContainerPort(container, tt.newPort); err != nil {
-				t.Fatalf("AddContainerPort returned error: %v", err)
-			}
+			AddContainerPort(container, tt.newPort)
 
 			if len(container.Ports) != len(tt.expectedResult) {
 				t.Errorf("unexpected number of ports: got %d, want %d", len(container.Ports), len(tt.expectedResult))
@@ -461,9 +457,7 @@ func TestAddContainerEnv(t *testing.T) {
 				Env: tt.initialEnv,
 			}
 
-			if err := AddContainerEnv(container, tt.newEnv); err != nil {
-				t.Fatalf("AddContainerEnv returned error: %v", err)
-			}
+			AddContainerEnv(container, tt.newEnv)
 
 			if len(container.Env) != len(tt.expectedResult) {
 				t.Errorf("unexpected number of env vars: got %d, want %d", len(container.Env), len(tt.expectedResult))
@@ -482,62 +476,46 @@ func TestAdditionalContainerFunctions(t *testing.T) {
 	c := &corev1.Container{}
 
 	mount := corev1.VolumeMount{Name: "data", MountPath: "/data"}
-	if err := AddContainerVolumeMount(c, mount); err != nil {
-		t.Fatalf("AddContainerVolumeMount returned error: %v", err)
-	}
+	AddContainerVolumeMount(c, mount)
 	if len(c.VolumeMounts) != 1 || c.VolumeMounts[0] != mount {
 		t.Errorf("volume mount not added")
 	}
 
 	dev := corev1.VolumeDevice{Name: "block", DevicePath: "/dev/block"}
-	if err := AddContainerVolumeDevice(c, dev); err != nil {
-		t.Fatalf("AddContainerVolumeDevice returned error: %v", err)
-	}
+	AddContainerVolumeDevice(c, dev)
 	if len(c.VolumeDevices) != 1 || c.VolumeDevices[0] != dev {
 		t.Errorf("volume device not added")
 	}
 
 	probe := corev1.Probe{TimeoutSeconds: 5}
-	if err := SetContainerLivenessProbe(c, probe); err != nil {
-		t.Fatalf("SetContainerLivenessProbe returned error: %v", err)
-	}
+	SetContainerLivenessProbe(c, probe)
 	if c.LivenessProbe == nil || *c.LivenessProbe != probe {
 		t.Errorf("liveness probe not set")
 	}
 
-	if err := SetContainerReadinessProbe(c, probe); err != nil {
-		t.Fatalf("SetContainerReadinessProbe returned error: %v", err)
-	}
+	SetContainerReadinessProbe(c, probe)
 	if c.ReadinessProbe == nil || *c.ReadinessProbe != probe {
 		t.Errorf("readiness probe not set")
 	}
 
-	if err := SetContainerStartupProbe(c, probe); err != nil {
-		t.Fatalf("SetContainerStartupProbe returned error: %v", err)
-	}
+	SetContainerStartupProbe(c, probe)
 	if c.StartupProbe == nil || *c.StartupProbe != probe {
 		t.Errorf("startup probe not set")
 	}
 
 	resources := corev1.ResourceRequirements{}
-	if err := SetContainerResources(c, resources); err != nil {
-		t.Fatalf("SetContainerResources returned error: %v", err)
-	}
+	SetContainerResources(c, resources)
 	if !reflect.DeepEqual(c.Resources, resources) {
 		t.Errorf("resources not set")
 	}
 
-	if err := SetContainerImagePullPolicy(c, corev1.PullAlways); err != nil {
-		t.Fatalf("SetContainerImagePullPolicy returned error: %v", err)
-	}
+	SetContainerImagePullPolicy(c, corev1.PullAlways)
 	if c.ImagePullPolicy != corev1.PullAlways {
 		t.Errorf("image pull policy not set")
 	}
 
 	sc := corev1.SecurityContext{RunAsUser: new(int64)}
-	if err := SetContainerSecurityContext(c, sc); err != nil {
-		t.Fatalf("SetContainerSecurityContext returned error: %v", err)
-	}
+	SetContainerSecurityContext(c, sc)
 	if c.SecurityContext == nil || *c.SecurityContext != sc {
 		t.Errorf("security context not set")
 	}
@@ -584,29 +562,17 @@ func TestContainerMiscFunctions(t *testing.T) {
 }
 
 func TestContainerNilGuards(t *testing.T) {
-	tests := []struct {
-		name string
-		fn   func() error
-	}{
-		{"AddContainerPort", func() error { return AddContainerPort(nil, corev1.ContainerPort{}) }},
-		{"AddContainerEnv", func() error { return AddContainerEnv(nil, corev1.EnvVar{}) }},
-		{"AddContainerEnvFrom", func() error { return AddContainerEnvFrom(nil, corev1.EnvFromSource{}) }},
-		{"AddContainerVolumeMount", func() error { return AddContainerVolumeMount(nil, corev1.VolumeMount{}) }},
-		{"AddContainerVolumeDevice", func() error { return AddContainerVolumeDevice(nil, corev1.VolumeDevice{}) }},
-		{"SetContainerLivenessProbe", func() error { return SetContainerLivenessProbe(nil, corev1.Probe{}) }},
-		{"SetContainerReadinessProbe", func() error { return SetContainerReadinessProbe(nil, corev1.Probe{}) }},
-		{"SetContainerStartupProbe", func() error { return SetContainerStartupProbe(nil, corev1.Probe{}) }},
-		{"SetContainerResources", func() error { return SetContainerResources(nil, corev1.ResourceRequirements{}) }},
-		{"SetContainerImagePullPolicy", func() error { return SetContainerImagePullPolicy(nil, corev1.PullAlways) }},
-		{"SetContainerSecurityContext", func() error { return SetContainerSecurityContext(nil, corev1.SecurityContext{}) }},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.fn(); err == nil {
-				t.Errorf("%s(nil) should return error", tt.name)
-			}
-		})
-	}
+	assertPanics(t, func() { AddContainerPort(nil, corev1.ContainerPort{}) })
+	assertPanics(t, func() { AddContainerEnv(nil, corev1.EnvVar{}) })
+	assertPanics(t, func() { AddContainerEnvFrom(nil, corev1.EnvFromSource{}) })
+	assertPanics(t, func() { AddContainerVolumeMount(nil, corev1.VolumeMount{}) })
+	assertPanics(t, func() { AddContainerVolumeDevice(nil, corev1.VolumeDevice{}) })
+	assertPanics(t, func() { SetContainerLivenessProbe(nil, corev1.Probe{}) })
+	assertPanics(t, func() { SetContainerReadinessProbe(nil, corev1.Probe{}) })
+	assertPanics(t, func() { SetContainerStartupProbe(nil, corev1.Probe{}) })
+	assertPanics(t, func() { SetContainerResources(nil, corev1.ResourceRequirements{}) })
+	assertPanics(t, func() { SetContainerImagePullPolicy(nil, corev1.PullAlways) })
+	assertPanics(t, func() { SetContainerSecurityContext(nil, corev1.SecurityContext{}) })
 }
 
 func TestContainerSetters(t *testing.T) {

--- a/pkg/kubernetes/cronjob.go
+++ b/pkg/kubernetes/cronjob.go
@@ -142,105 +142,94 @@ func AddCronJobTopologySpreadConstraint(cron *batchv1.CronJob, topologySpreadCon
 
 // SetCronJobServiceAccountName sets the service account name on the CronJob's
 // pod template.
-func SetCronJobServiceAccountName(cron *batchv1.CronJob, serviceAccountName string) error {
+func SetCronJobServiceAccountName(cron *batchv1.CronJob, serviceAccountName string) {
 	if cron == nil {
-		return errors.ErrNilCronJob
+		panic("SetCronJobServiceAccountName: cron must not be nil")
 	}
 	cron.Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName = serviceAccountName
-	return nil
 }
 
 // SetCronJobSecurityContext sets the pod-level security context on the
 // CronJob's pod template.
-func SetCronJobSecurityContext(cron *batchv1.CronJob, securityContext *corev1.PodSecurityContext) error {
+func SetCronJobSecurityContext(cron *batchv1.CronJob, securityContext *corev1.PodSecurityContext) {
 	if cron == nil {
-		return errors.ErrNilCronJob
+		panic("SetCronJobSecurityContext: cron must not be nil")
 	}
 	cron.Spec.JobTemplate.Spec.Template.Spec.SecurityContext = securityContext
-	return nil
 }
 
 // SetCronJobAffinity assigns affinity rules to the CronJob's pod template.
-func SetCronJobAffinity(cron *batchv1.CronJob, affinity *corev1.Affinity) error {
+func SetCronJobAffinity(cron *batchv1.CronJob, affinity *corev1.Affinity) {
 	if cron == nil {
-		return errors.ErrNilCronJob
+		panic("SetCronJobAffinity: cron must not be nil")
 	}
 	cron.Spec.JobTemplate.Spec.Template.Spec.Affinity = affinity
-	return nil
 }
 
 // SetCronJobNodeSelector sets the node selector map on the CronJob's pod
 // template.
-func SetCronJobNodeSelector(cron *batchv1.CronJob, nodeSelector map[string]string) error {
+func SetCronJobNodeSelector(cron *batchv1.CronJob, nodeSelector map[string]string) {
 	if cron == nil {
-		return errors.ErrNilCronJob
+		panic("SetCronJobNodeSelector: cron must not be nil")
 	}
 	cron.Spec.JobTemplate.Spec.Template.Spec.NodeSelector = nodeSelector
-	return nil
 }
 
 // SetCronJobSchedule sets the cron schedule expression.
-func SetCronJobSchedule(cron *batchv1.CronJob, schedule string) error {
+func SetCronJobSchedule(cron *batchv1.CronJob, schedule string) {
 	if cron == nil {
-		return errors.ErrNilCronJob
+		panic("SetCronJobSchedule: cron must not be nil")
 	}
 	cron.Spec.Schedule = schedule
-	return nil
 }
 
 // SetCronJobConcurrencyPolicy sets the concurrency policy for the CronJob.
-func SetCronJobConcurrencyPolicy(cron *batchv1.CronJob, policy batchv1.ConcurrencyPolicy) error {
+func SetCronJobConcurrencyPolicy(cron *batchv1.CronJob, policy batchv1.ConcurrencyPolicy) {
 	if cron == nil {
-		return errors.ErrNilCronJob
+		panic("SetCronJobConcurrencyPolicy: cron must not be nil")
 	}
 	cron.Spec.ConcurrencyPolicy = policy
-	return nil
 }
 
 // SetCronJobSuspend sets whether the CronJob is suspended.
-func SetCronJobSuspend(cron *batchv1.CronJob, suspend bool) error {
+func SetCronJobSuspend(cron *batchv1.CronJob, suspend bool) {
 	if cron == nil {
-		return errors.ErrNilCronJob
+		panic("SetCronJobSuspend: cron must not be nil")
 	}
 	cron.Spec.Suspend = &suspend
-	return nil
 }
 
 // SetCronJobSuccessfulJobsHistoryLimit sets the number of successful finished
 // jobs to retain.
-func SetCronJobSuccessfulJobsHistoryLimit(cron *batchv1.CronJob, limit int32) error {
+func SetCronJobSuccessfulJobsHistoryLimit(cron *batchv1.CronJob, limit int32) {
 	if cron == nil {
-		return errors.ErrNilCronJob
+		panic("SetCronJobSuccessfulJobsHistoryLimit: cron must not be nil")
 	}
 	cron.Spec.SuccessfulJobsHistoryLimit = &limit
-	return nil
 }
 
 // SetCronJobFailedJobsHistoryLimit sets the number of failed finished jobs to
 // retain.
-func SetCronJobFailedJobsHistoryLimit(cron *batchv1.CronJob, limit int32) error {
+func SetCronJobFailedJobsHistoryLimit(cron *batchv1.CronJob, limit int32) {
 	if cron == nil {
-		return errors.ErrNilCronJob
+		panic("SetCronJobFailedJobsHistoryLimit: cron must not be nil")
 	}
 	cron.Spec.FailedJobsHistoryLimit = &limit
-	return nil
 }
 
 // SetCronJobStartingDeadlineSeconds sets the optional deadline in seconds for
 // starting the job if it misses its scheduled time.
-func SetCronJobStartingDeadlineSeconds(cron *batchv1.CronJob, sec int64) error {
+func SetCronJobStartingDeadlineSeconds(cron *batchv1.CronJob, sec int64) {
 	if cron == nil {
-		return errors.ErrNilCronJob
+		panic("SetCronJobStartingDeadlineSeconds: cron must not be nil")
 	}
 	cron.Spec.StartingDeadlineSeconds = &sec
-	return nil
 }
 
 // SetCronJobTimeZone sets the time zone for the CronJob schedule.
-func SetCronJobTimeZone(cron *batchv1.CronJob, tz *string) error {
+func SetCronJobTimeZone(cron *batchv1.CronJob, tz *string) {
 	if cron == nil {
-		return errors.ErrNilCronJob
+		panic("SetCronJobTimeZone: cron must not be nil")
 	}
 	cron.Spec.TimeZone = tz
-	return nil
 }

--- a/pkg/kubernetes/cronjob_test.go
+++ b/pkg/kubernetes/cronjob_test.go
@@ -29,6 +29,7 @@ func TestCreateCronJob(t *testing.T) {
 }
 
 func TestCronJobNilErrors(t *testing.T) {
+	// Functions with secondary nil checks — still return errors
 	if err := SetCronJobPodSpec(nil, &corev1.PodSpec{}); err == nil {
 		t.Error("expected error for nil CronJob on SetCronJobPodSpec")
 	}
@@ -50,40 +51,20 @@ func TestCronJobNilErrors(t *testing.T) {
 	if err := AddCronJobTopologySpreadConstraint(nil, &corev1.TopologySpreadConstraint{}); err == nil {
 		t.Error("expected error for nil CronJob on AddCronJobTopologySpreadConstraint")
 	}
-	if err := SetCronJobServiceAccountName(nil, "sa"); err == nil {
-		t.Error("expected error for nil CronJob on SetCronJobServiceAccountName")
-	}
-	if err := SetCronJobSecurityContext(nil, &corev1.PodSecurityContext{}); err == nil {
-		t.Error("expected error for nil CronJob on SetCronJobSecurityContext")
-	}
-	if err := SetCronJobAffinity(nil, &corev1.Affinity{}); err == nil {
-		t.Error("expected error for nil CronJob on SetCronJobAffinity")
-	}
-	if err := SetCronJobNodeSelector(nil, map[string]string{}); err == nil {
-		t.Error("expected error for nil CronJob on SetCronJobNodeSelector")
-	}
-	if err := SetCronJobSchedule(nil, "* * * * *"); err == nil {
-		t.Error("expected error for nil CronJob on SetCronJobSchedule")
-	}
-	if err := SetCronJobConcurrencyPolicy(nil, batchv1.ForbidConcurrent); err == nil {
-		t.Error("expected error for nil CronJob on SetCronJobConcurrencyPolicy")
-	}
-	if err := SetCronJobSuspend(nil, true); err == nil {
-		t.Error("expected error for nil CronJob on SetCronJobSuspend")
-	}
-	if err := SetCronJobSuccessfulJobsHistoryLimit(nil, 3); err == nil {
-		t.Error("expected error for nil CronJob on SetCronJobSuccessfulJobsHistoryLimit")
-	}
-	if err := SetCronJobFailedJobsHistoryLimit(nil, 1); err == nil {
-		t.Error("expected error for nil CronJob on SetCronJobFailedJobsHistoryLimit")
-	}
-	if err := SetCronJobStartingDeadlineSeconds(nil, 60); err == nil {
-		t.Error("expected error for nil CronJob on SetCronJobStartingDeadlineSeconds")
-	}
+
+	// Functions that now panic on nil receiver
+	assertPanics(t, func() { SetCronJobServiceAccountName(nil, "sa") })
+	assertPanics(t, func() { SetCronJobSecurityContext(nil, nil) })
+	assertPanics(t, func() { SetCronJobAffinity(nil, nil) })
+	assertPanics(t, func() { SetCronJobNodeSelector(nil, nil) })
+	assertPanics(t, func() { SetCronJobSchedule(nil, "* * * * *") })
+	assertPanics(t, func() { SetCronJobConcurrencyPolicy(nil, batchv1.ForbidConcurrent) })
+	assertPanics(t, func() { SetCronJobSuspend(nil, true) })
+	assertPanics(t, func() { SetCronJobSuccessfulJobsHistoryLimit(nil, 3) })
+	assertPanics(t, func() { SetCronJobFailedJobsHistoryLimit(nil, 1) })
+	assertPanics(t, func() { SetCronJobStartingDeadlineSeconds(nil, 60) })
 	tz := "UTC"
-	if err := SetCronJobTimeZone(nil, &tz); err == nil {
-		t.Error("expected error for nil CronJob on SetCronJobTimeZone")
-	}
+	assertPanics(t, func() { SetCronJobTimeZone(nil, &tz) })
 }
 
 func TestCronJobNilArgErrors(t *testing.T) {
@@ -233,83 +214,61 @@ func TestCronJobFunctions(t *testing.T) {
 		t.Errorf("topology constraint not added")
 	}
 
-	if err := SetCronJobServiceAccountName(cj, "sa"); err != nil {
-		t.Fatalf("SetCronJobServiceAccountName returned error: %v", err)
-	}
+	SetCronJobServiceAccountName(cj, "sa")
 	if cj.Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName != "sa" {
 		t.Errorf("service account name not set")
 	}
 
 	sc := &corev1.PodSecurityContext{RunAsUser: func(i int64) *int64 { return &i }(1)}
-	if err := SetCronJobSecurityContext(cj, sc); err != nil {
-		t.Fatalf("SetCronJobSecurityContext returned error: %v", err)
-	}
+	SetCronJobSecurityContext(cj, sc)
 	if cj.Spec.JobTemplate.Spec.Template.Spec.SecurityContext != sc {
 		t.Errorf("security context not set")
 	}
 
 	aff := &corev1.Affinity{}
-	if err := SetCronJobAffinity(cj, aff); err != nil {
-		t.Fatalf("SetCronJobAffinity returned error: %v", err)
-	}
+	SetCronJobAffinity(cj, aff)
 	if cj.Spec.JobTemplate.Spec.Template.Spec.Affinity != aff {
 		t.Errorf("affinity not set")
 	}
 
 	ns := map[string]string{"role": "db"}
-	if err := SetCronJobNodeSelector(cj, ns); err != nil {
-		t.Fatalf("SetCronJobNodeSelector returned error: %v", err)
-	}
+	SetCronJobNodeSelector(cj, ns)
 	if !reflect.DeepEqual(cj.Spec.JobTemplate.Spec.Template.Spec.NodeSelector, ns) {
 		t.Errorf("node selector not set")
 	}
 
-	if err := SetCronJobSchedule(cj, "*/5 * * * *"); err != nil {
-		t.Fatalf("SetCronJobSchedule returned error: %v", err)
-	}
+	SetCronJobSchedule(cj, "*/5 * * * *")
 	if cj.Spec.Schedule != "*/5 * * * *" {
 		t.Errorf("schedule not updated")
 	}
 
-	if err := SetCronJobConcurrencyPolicy(cj, batchv1.ForbidConcurrent); err != nil {
-		t.Fatalf("SetCronJobConcurrencyPolicy returned error: %v", err)
-	}
+	SetCronJobConcurrencyPolicy(cj, batchv1.ForbidConcurrent)
 	if cj.Spec.ConcurrencyPolicy != batchv1.ForbidConcurrent {
 		t.Errorf("concurrency policy not set")
 	}
 
-	if err := SetCronJobSuspend(cj, true); err != nil {
-		t.Fatalf("SetCronJobSuspend returned error: %v", err)
-	}
+	SetCronJobSuspend(cj, true)
 	if cj.Spec.Suspend == nil || !*cj.Spec.Suspend {
 		t.Errorf("suspend not set")
 	}
 
-	if err := SetCronJobSuccessfulJobsHistoryLimit(cj, 1); err != nil {
-		t.Fatalf("SetCronJobSuccessfulJobsHistoryLimit returned error: %v", err)
-	}
+	SetCronJobSuccessfulJobsHistoryLimit(cj, 1)
 	if cj.Spec.SuccessfulJobsHistoryLimit == nil || *cj.Spec.SuccessfulJobsHistoryLimit != 1 {
 		t.Errorf("successful jobs history limit not set")
 	}
 
-	if err := SetCronJobFailedJobsHistoryLimit(cj, 2); err != nil {
-		t.Fatalf("SetCronJobFailedJobsHistoryLimit returned error: %v", err)
-	}
+	SetCronJobFailedJobsHistoryLimit(cj, 2)
 	if cj.Spec.FailedJobsHistoryLimit == nil || *cj.Spec.FailedJobsHistoryLimit != 2 {
 		t.Errorf("failed jobs history limit not set")
 	}
 
-	if err := SetCronJobStartingDeadlineSeconds(cj, 60); err != nil {
-		t.Fatalf("SetCronJobStartingDeadlineSeconds returned error: %v", err)
-	}
+	SetCronJobStartingDeadlineSeconds(cj, 60)
 	if cj.Spec.StartingDeadlineSeconds == nil || *cj.Spec.StartingDeadlineSeconds != 60 {
 		t.Errorf("starting deadline seconds not set")
 	}
 
 	tz := "UTC"
-	if err := SetCronJobTimeZone(cj, &tz); err != nil {
-		t.Fatalf("SetCronJobTimeZone returned error: %v", err)
-	}
+	SetCronJobTimeZone(cj, &tz)
 	if cj.Spec.TimeZone == nil || *cj.Spec.TimeZone != "UTC" {
 		t.Errorf("timezone not set")
 	}

--- a/pkg/kubernetes/daemonset.go
+++ b/pkg/kubernetes/daemonset.go
@@ -1,11 +1,11 @@
 package kubernetes
 
 import (
-	"github.com/go-kure/kure/pkg/errors"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/go-kure/kure/pkg/errors"
 )
 
 // CreateDaemonSet returns a DaemonSet with sane defaults.
@@ -98,51 +98,49 @@ func AddDaemonSetTopologySpreadConstraints(ds *appsv1.DaemonSet, c *corev1.Topol
 }
 
 // SetDaemonSetServiceAccountName sets the service account name.
-func SetDaemonSetServiceAccountName(ds *appsv1.DaemonSet, name string) error {
+func SetDaemonSetServiceAccountName(ds *appsv1.DaemonSet, name string) {
 	if ds == nil {
-		return errors.ErrNilDaemonSet
+		panic("SetDaemonSetServiceAccountName: ds must not be nil")
 	}
-	return SetPodSpecServiceAccountName(&ds.Spec.Template.Spec, name)
+	SetPodSpecServiceAccountName(&ds.Spec.Template.Spec, name)
 }
 
 // SetDaemonSetSecurityContext sets the pod security context.
-func SetDaemonSetSecurityContext(ds *appsv1.DaemonSet, sc *corev1.PodSecurityContext) error {
+func SetDaemonSetSecurityContext(ds *appsv1.DaemonSet, sc *corev1.PodSecurityContext) {
 	if ds == nil {
-		return errors.ErrNilDaemonSet
+		panic("SetDaemonSetSecurityContext: ds must not be nil")
 	}
-	return SetPodSpecSecurityContext(&ds.Spec.Template.Spec, sc)
+	SetPodSpecSecurityContext(&ds.Spec.Template.Spec, sc)
 }
 
 // SetDaemonSetAffinity sets the pod affinity rules.
-func SetDaemonSetAffinity(ds *appsv1.DaemonSet, aff *corev1.Affinity) error {
+func SetDaemonSetAffinity(ds *appsv1.DaemonSet, aff *corev1.Affinity) {
 	if ds == nil {
-		return errors.ErrNilDaemonSet
+		panic("SetDaemonSetAffinity: ds must not be nil")
 	}
-	return SetPodSpecAffinity(&ds.Spec.Template.Spec, aff)
+	SetPodSpecAffinity(&ds.Spec.Template.Spec, aff)
 }
 
 // SetDaemonSetNodeSelector sets the node selector.
-func SetDaemonSetNodeSelector(ds *appsv1.DaemonSet, ns map[string]string) error {
+func SetDaemonSetNodeSelector(ds *appsv1.DaemonSet, ns map[string]string) {
 	if ds == nil {
-		return errors.ErrNilDaemonSet
+		panic("SetDaemonSetNodeSelector: ds must not be nil")
 	}
-	return SetPodSpecNodeSelector(&ds.Spec.Template.Spec, ns)
+	SetPodSpecNodeSelector(&ds.Spec.Template.Spec, ns)
 }
 
 // SetDaemonSetUpdateStrategy sets the update strategy.
-func SetDaemonSetUpdateStrategy(ds *appsv1.DaemonSet, strategy appsv1.DaemonSetUpdateStrategy) error {
+func SetDaemonSetUpdateStrategy(ds *appsv1.DaemonSet, strategy appsv1.DaemonSetUpdateStrategy) {
 	if ds == nil {
-		return errors.ErrNilDaemonSet
+		panic("SetDaemonSetUpdateStrategy: ds must not be nil")
 	}
 	ds.Spec.UpdateStrategy = strategy
-	return nil
 }
 
 // SetDaemonSetRevisionHistoryLimit sets the revision history limit.
-func SetDaemonSetRevisionHistoryLimit(ds *appsv1.DaemonSet, limit *int32) error {
+func SetDaemonSetRevisionHistoryLimit(ds *appsv1.DaemonSet, limit *int32) {
 	if ds == nil {
-		return errors.ErrNilDaemonSet
+		panic("SetDaemonSetRevisionHistoryLimit: ds must not be nil")
 	}
 	ds.Spec.RevisionHistoryLimit = limit
-	return nil
 }

--- a/pkg/kubernetes/daemonset_test.go
+++ b/pkg/kubernetes/daemonset_test.go
@@ -128,49 +128,37 @@ func TestDaemonSetFunctions(t *testing.T) {
 		t.Errorf("topology constraint not added")
 	}
 
-	if err := SetDaemonSetServiceAccountName(ds, "sa"); err != nil {
-		t.Fatalf("SetDaemonSetServiceAccountName returned error: %v", err)
-	}
+	SetDaemonSetServiceAccountName(ds, "sa")
 	if ds.Spec.Template.Spec.ServiceAccountName != "sa" {
 		t.Errorf("service account name not set")
 	}
 
 	sc := &corev1.PodSecurityContext{}
-	if err := SetDaemonSetSecurityContext(ds, sc); err != nil {
-		t.Fatalf("SetDaemonSetSecurityContext returned error: %v", err)
-	}
+	SetDaemonSetSecurityContext(ds, sc)
 	if ds.Spec.Template.Spec.SecurityContext != sc {
 		t.Errorf("security context not set")
 	}
 
 	aff := &corev1.Affinity{}
-	if err := SetDaemonSetAffinity(ds, aff); err != nil {
-		t.Fatalf("SetDaemonSetAffinity returned error: %v", err)
-	}
+	SetDaemonSetAffinity(ds, aff)
 	if ds.Spec.Template.Spec.Affinity != aff {
 		t.Errorf("affinity not set")
 	}
 
 	ns := map[string]string{"role": "db"}
-	if err := SetDaemonSetNodeSelector(ds, ns); err != nil {
-		t.Fatalf("SetDaemonSetNodeSelector returned error: %v", err)
-	}
+	SetDaemonSetNodeSelector(ds, ns)
 	if !reflect.DeepEqual(ds.Spec.Template.Spec.NodeSelector, ns) {
 		t.Errorf("node selector not set")
 	}
 
 	strategy := appsv1.DaemonSetUpdateStrategy{Type: appsv1.RollingUpdateDaemonSetStrategyType}
-	if err := SetDaemonSetUpdateStrategy(ds, strategy); err != nil {
-		t.Fatalf("SetDaemonSetUpdateStrategy returned error: %v", err)
-	}
+	SetDaemonSetUpdateStrategy(ds, strategy)
 	if ds.Spec.UpdateStrategy.Type != appsv1.RollingUpdateDaemonSetStrategyType {
 		t.Errorf("update strategy not set")
 	}
 
 	rhl := int32(3)
-	if err := SetDaemonSetRevisionHistoryLimit(ds, &rhl); err != nil {
-		t.Fatalf("SetDaemonSetRevisionHistoryLimit returned error: %v", err)
-	}
+	SetDaemonSetRevisionHistoryLimit(ds, &rhl)
 	if ds.Spec.RevisionHistoryLimit == nil || *ds.Spec.RevisionHistoryLimit != 3 {
 		t.Errorf("revision history limit not set")
 	}
@@ -178,35 +166,35 @@ func TestDaemonSetFunctions(t *testing.T) {
 
 func TestDaemonSetNilGuards(t *testing.T) {
 	rhl := int32(1)
-	tests := []struct {
-		name string
-		fn   func() error
-	}{
-		{"SetDaemonSetPodSpec", func() error { return SetDaemonSetPodSpec(nil, &corev1.PodSpec{}) }},
-		{"AddDaemonSetContainer", func() error { return AddDaemonSetContainer(nil, &corev1.Container{}) }},
-		{"AddDaemonSetInitContainer", func() error { return AddDaemonSetInitContainer(nil, &corev1.Container{}) }},
-		{"AddDaemonSetVolume", func() error { return AddDaemonSetVolume(nil, &corev1.Volume{}) }},
-		{"AddDaemonSetImagePullSecret", func() error {
-			return AddDaemonSetImagePullSecret(nil, &corev1.LocalObjectReference{})
-		}},
-		{"AddDaemonSetToleration", func() error { return AddDaemonSetToleration(nil, &corev1.Toleration{}) }},
-		{"AddDaemonSetTopologySpreadConstraints", func() error {
-			return AddDaemonSetTopologySpreadConstraints(nil, &corev1.TopologySpreadConstraint{})
-		}},
-		{"SetDaemonSetServiceAccountName", func() error { return SetDaemonSetServiceAccountName(nil, "sa") }},
-		{"SetDaemonSetSecurityContext", func() error { return SetDaemonSetSecurityContext(nil, nil) }},
-		{"SetDaemonSetAffinity", func() error { return SetDaemonSetAffinity(nil, nil) }},
-		{"SetDaemonSetNodeSelector", func() error { return SetDaemonSetNodeSelector(nil, nil) }},
-		{"SetDaemonSetUpdateStrategy", func() error {
-			return SetDaemonSetUpdateStrategy(nil, appsv1.DaemonSetUpdateStrategy{})
-		}},
-		{"SetDaemonSetRevisionHistoryLimit", func() error { return SetDaemonSetRevisionHistoryLimit(nil, &rhl) }},
+
+	// Functions with secondary nil checks — still return errors
+	if err := SetDaemonSetPodSpec(nil, &corev1.PodSpec{}); err == nil {
+		t.Error("SetDaemonSetPodSpec(nil) should return error")
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.fn(); err == nil {
-				t.Errorf("%s(nil) should return error", tt.name)
-			}
-		})
+	if err := AddDaemonSetContainer(nil, &corev1.Container{}); err == nil {
+		t.Error("AddDaemonSetContainer(nil) should return error")
 	}
+	if err := AddDaemonSetInitContainer(nil, &corev1.Container{}); err == nil {
+		t.Error("AddDaemonSetInitContainer(nil) should return error")
+	}
+	if err := AddDaemonSetVolume(nil, &corev1.Volume{}); err == nil {
+		t.Error("AddDaemonSetVolume(nil) should return error")
+	}
+	if err := AddDaemonSetImagePullSecret(nil, &corev1.LocalObjectReference{}); err == nil {
+		t.Error("AddDaemonSetImagePullSecret(nil) should return error")
+	}
+	if err := AddDaemonSetToleration(nil, &corev1.Toleration{}); err == nil {
+		t.Error("AddDaemonSetToleration(nil) should return error")
+	}
+	if err := AddDaemonSetTopologySpreadConstraints(nil, &corev1.TopologySpreadConstraint{}); err == nil {
+		t.Error("AddDaemonSetTopologySpreadConstraints(nil) should return error")
+	}
+
+	// Functions that now panic on nil receiver
+	assertPanics(t, func() { SetDaemonSetServiceAccountName(nil, "sa") })
+	assertPanics(t, func() { SetDaemonSetSecurityContext(nil, nil) })
+	assertPanics(t, func() { SetDaemonSetAffinity(nil, nil) })
+	assertPanics(t, func() { SetDaemonSetNodeSelector(nil, nil) })
+	assertPanics(t, func() { SetDaemonSetUpdateStrategy(nil, appsv1.DaemonSetUpdateStrategy{}) })
+	assertPanics(t, func() { SetDaemonSetRevisionHistoryLimit(nil, &rhl) })
 }

--- a/pkg/kubernetes/deployment.go
+++ b/pkg/kubernetes/deployment.go
@@ -133,87 +133,78 @@ func AddDeploymentTopologySpreadConstraints(deployment *appsv1.Deployment, topol
 
 // SetDeploymentServiceAccountName sets the service account name on the
 // Deployment's pod template.
-func SetDeploymentServiceAccountName(deployment *appsv1.Deployment, serviceAccountName string) error {
+func SetDeploymentServiceAccountName(deployment *appsv1.Deployment, serviceAccountName string) {
 	if deployment == nil {
-		return errors.ErrNilDeployment
+		panic("SetDeploymentServiceAccountName: deployment must not be nil")
 	}
 	deployment.Spec.Template.Spec.ServiceAccountName = serviceAccountName
-	return nil
 }
 
 // SetDeploymentSecurityContext sets the pod-level security context on the
 // Deployment's pod template.
-func SetDeploymentSecurityContext(deployment *appsv1.Deployment, securityContext *corev1.PodSecurityContext) error {
+func SetDeploymentSecurityContext(deployment *appsv1.Deployment, securityContext *corev1.PodSecurityContext) {
 	if deployment == nil {
-		return errors.ErrNilDeployment
+		panic("SetDeploymentSecurityContext: deployment must not be nil")
 	}
 	deployment.Spec.Template.Spec.SecurityContext = securityContext
-	return nil
 }
 
 // SetDeploymentAffinity assigns affinity rules to the Deployment's pod template.
-func SetDeploymentAffinity(deployment *appsv1.Deployment, affinity *corev1.Affinity) error {
+func SetDeploymentAffinity(deployment *appsv1.Deployment, affinity *corev1.Affinity) {
 	if deployment == nil {
-		return errors.ErrNilDeployment
+		panic("SetDeploymentAffinity: deployment must not be nil")
 	}
 	deployment.Spec.Template.Spec.Affinity = affinity
-	return nil
 }
 
 // SetDeploymentNodeSelector sets the node selector map on the Deployment's pod
 // template.
-func SetDeploymentNodeSelector(deployment *appsv1.Deployment, nodeSelector map[string]string) error {
+func SetDeploymentNodeSelector(deployment *appsv1.Deployment, nodeSelector map[string]string) {
 	if deployment == nil {
-		return errors.ErrNilDeployment
+		panic("SetDeploymentNodeSelector: deployment must not be nil")
 	}
 	deployment.Spec.Template.Spec.NodeSelector = nodeSelector
-	return nil
 }
 
 // SetDeploymentReplicas sets the desired replica count.
-func SetDeploymentReplicas(deployment *appsv1.Deployment, replicas int32) error {
+func SetDeploymentReplicas(deployment *appsv1.Deployment, replicas int32) {
 	if deployment == nil {
-		return errors.ErrNilDeployment
+		panic("SetDeploymentReplicas: deployment must not be nil")
 	}
 	if deployment.Spec.Replicas == nil {
 		deployment.Spec.Replicas = new(int32)
 	}
 	*deployment.Spec.Replicas = replicas
-	return nil
 }
 
 // SetDeploymentStrategy sets the deployment strategy.
-func SetDeploymentStrategy(deployment *appsv1.Deployment, strategy appsv1.DeploymentStrategy) error {
+func SetDeploymentStrategy(deployment *appsv1.Deployment, strategy appsv1.DeploymentStrategy) {
 	if deployment == nil {
-		return errors.ErrNilDeployment
+		panic("SetDeploymentStrategy: deployment must not be nil")
 	}
 	deployment.Spec.Strategy = strategy
-	return nil
 }
 
 // SetDeploymentRevisionHistoryLimit sets the revision history limit.
-func SetDeploymentRevisionHistoryLimit(deployment *appsv1.Deployment, limit int32) error {
+func SetDeploymentRevisionHistoryLimit(deployment *appsv1.Deployment, limit int32) {
 	if deployment == nil {
-		return errors.ErrNilDeployment
+		panic("SetDeploymentRevisionHistoryLimit: deployment must not be nil")
 	}
 	deployment.Spec.RevisionHistoryLimit = &limit
-	return nil
 }
 
 // SetDeploymentMinReadySeconds sets the minimum ready seconds.
-func SetDeploymentMinReadySeconds(deployment *appsv1.Deployment, secs int32) error {
+func SetDeploymentMinReadySeconds(deployment *appsv1.Deployment, secs int32) {
 	if deployment == nil {
-		return errors.ErrNilDeployment
+		panic("SetDeploymentMinReadySeconds: deployment must not be nil")
 	}
 	deployment.Spec.MinReadySeconds = secs
-	return nil
 }
 
 // SetDeploymentProgressDeadlineSeconds sets the progress deadline seconds.
-func SetDeploymentProgressDeadlineSeconds(deployment *appsv1.Deployment, secs int32) error {
+func SetDeploymentProgressDeadlineSeconds(deployment *appsv1.Deployment, secs int32) {
 	if deployment == nil {
-		return errors.ErrNilDeployment
+		panic("SetDeploymentProgressDeadlineSeconds: deployment must not be nil")
 	}
 	deployment.Spec.ProgressDeadlineSeconds = &secs
-	return nil
 }

--- a/pkg/kubernetes/deployment_test.go
+++ b/pkg/kubernetes/deployment_test.go
@@ -23,6 +23,7 @@ func TestCreateDeployment(t *testing.T) {
 }
 
 func TestDeploymentNilErrors(t *testing.T) {
+	// Functions with secondary nil checks — still return error on nil receiver
 	if err := SetDeploymentPodSpec(nil, &corev1.PodSpec{}); err == nil {
 		t.Error("expected error for nil Deployment on SetDeploymentPodSpec")
 	}
@@ -44,33 +45,17 @@ func TestDeploymentNilErrors(t *testing.T) {
 	if err := AddDeploymentTopologySpreadConstraints(nil, &corev1.TopologySpreadConstraint{}); err == nil {
 		t.Error("expected error for nil Deployment on AddDeploymentTopologySpreadConstraints")
 	}
-	if err := SetDeploymentServiceAccountName(nil, "sa"); err == nil {
-		t.Error("expected error for nil Deployment on SetDeploymentServiceAccountName")
-	}
-	if err := SetDeploymentSecurityContext(nil, &corev1.PodSecurityContext{}); err == nil {
-		t.Error("expected error for nil Deployment on SetDeploymentSecurityContext")
-	}
-	if err := SetDeploymentAffinity(nil, &corev1.Affinity{}); err == nil {
-		t.Error("expected error for nil Deployment on SetDeploymentAffinity")
-	}
-	if err := SetDeploymentNodeSelector(nil, map[string]string{}); err == nil {
-		t.Error("expected error for nil Deployment on SetDeploymentNodeSelector")
-	}
-	if err := SetDeploymentReplicas(nil, 3); err == nil {
-		t.Error("expected error for nil Deployment on SetDeploymentReplicas")
-	}
-	if err := SetDeploymentStrategy(nil, appsv1.DeploymentStrategy{}); err == nil {
-		t.Error("expected error for nil Deployment on SetDeploymentStrategy")
-	}
-	if err := SetDeploymentRevisionHistoryLimit(nil, 5); err == nil {
-		t.Error("expected error for nil Deployment on SetDeploymentRevisionHistoryLimit")
-	}
-	if err := SetDeploymentMinReadySeconds(nil, 10); err == nil {
-		t.Error("expected error for nil Deployment on SetDeploymentMinReadySeconds")
-	}
-	if err := SetDeploymentProgressDeadlineSeconds(nil, 60); err == nil {
-		t.Error("expected error for nil Deployment on SetDeploymentProgressDeadlineSeconds")
-	}
+
+	// Functions that now panic on nil receiver
+	assertPanics(t, func() { SetDeploymentServiceAccountName(nil, "sa") })
+	assertPanics(t, func() { SetDeploymentSecurityContext(nil, &corev1.PodSecurityContext{}) })
+	assertPanics(t, func() { SetDeploymentAffinity(nil, &corev1.Affinity{}) })
+	assertPanics(t, func() { SetDeploymentNodeSelector(nil, map[string]string{}) })
+	assertPanics(t, func() { SetDeploymentReplicas(nil, 3) })
+	assertPanics(t, func() { SetDeploymentStrategy(nil, appsv1.DeploymentStrategy{}) })
+	assertPanics(t, func() { SetDeploymentRevisionHistoryLimit(nil, 5) })
+	assertPanics(t, func() { SetDeploymentMinReadySeconds(nil, 10) })
+	assertPanics(t, func() { SetDeploymentProgressDeadlineSeconds(nil, 60) })
 }
 
 func TestDeploymentNilArgErrors(t *testing.T) {
@@ -220,69 +205,51 @@ func TestDeploymentFunctions(t *testing.T) {
 		t.Errorf("topology constraint not added")
 	}
 
-	if err := SetDeploymentServiceAccountName(dep, "sa"); err != nil {
-		t.Fatalf("SetDeploymentServiceAccountName returned error: %v", err)
-	}
+	SetDeploymentServiceAccountName(dep, "sa")
 	if dep.Spec.Template.Spec.ServiceAccountName != "sa" {
 		t.Errorf("service account name not set")
 	}
 
 	sc := &corev1.PodSecurityContext{RunAsUser: func(i int64) *int64 { return &i }(1)}
-	if err := SetDeploymentSecurityContext(dep, sc); err != nil {
-		t.Fatalf("SetDeploymentSecurityContext returned error: %v", err)
-	}
+	SetDeploymentSecurityContext(dep, sc)
 	if dep.Spec.Template.Spec.SecurityContext != sc {
 		t.Errorf("security context not set")
 	}
 
 	aff := &corev1.Affinity{}
-	if err := SetDeploymentAffinity(dep, aff); err != nil {
-		t.Fatalf("SetDeploymentAffinity returned error: %v", err)
-	}
+	SetDeploymentAffinity(dep, aff)
 	if dep.Spec.Template.Spec.Affinity != aff {
 		t.Errorf("affinity not set")
 	}
 
 	ns := map[string]string{"role": "db"}
-	if err := SetDeploymentNodeSelector(dep, ns); err != nil {
-		t.Fatalf("SetDeploymentNodeSelector returned error: %v", err)
-	}
+	SetDeploymentNodeSelector(dep, ns)
 	if !reflect.DeepEqual(dep.Spec.Template.Spec.NodeSelector, ns) {
 		t.Errorf("node selector not set")
 	}
 
-	if err := SetDeploymentReplicas(dep, 3); err != nil {
-		t.Fatalf("SetDeploymentReplicas returned error: %v", err)
-	}
+	SetDeploymentReplicas(dep, 3)
 	if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 3 {
 		t.Errorf("replicas not set")
 	}
 
 	strategy := appsv1.DeploymentStrategy{Type: appsv1.RollingUpdateDeploymentStrategyType}
-	if err := SetDeploymentStrategy(dep, strategy); err != nil {
-		t.Fatalf("SetDeploymentStrategy returned error: %v", err)
-	}
+	SetDeploymentStrategy(dep, strategy)
 	if dep.Spec.Strategy.Type != appsv1.RollingUpdateDeploymentStrategyType {
 		t.Errorf("strategy not set")
 	}
 
-	if err := SetDeploymentRevisionHistoryLimit(dep, 5); err != nil {
-		t.Fatalf("SetDeploymentRevisionHistoryLimit returned error: %v", err)
-	}
+	SetDeploymentRevisionHistoryLimit(dep, 5)
 	if dep.Spec.RevisionHistoryLimit == nil || *dep.Spec.RevisionHistoryLimit != 5 {
 		t.Errorf("revision history limit not set")
 	}
 
-	if err := SetDeploymentMinReadySeconds(dep, 10); err != nil {
-		t.Fatalf("SetDeploymentMinReadySeconds returned error: %v", err)
-	}
+	SetDeploymentMinReadySeconds(dep, 10)
 	if dep.Spec.MinReadySeconds != 10 {
 		t.Errorf("min ready seconds not set")
 	}
 
-	if err := SetDeploymentProgressDeadlineSeconds(dep, 60); err != nil {
-		t.Fatalf("SetDeploymentProgressDeadlineSeconds returned error: %v", err)
-	}
+	SetDeploymentProgressDeadlineSeconds(dep, 60)
 	if dep.Spec.ProgressDeadlineSeconds == nil || *dep.Spec.ProgressDeadlineSeconds != 60 {
 		t.Errorf("progress deadline seconds not set")
 	}

--- a/pkg/kubernetes/hpa.go
+++ b/pkg/kubernetes/hpa.go
@@ -4,8 +4,6 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/go-kure/kure/pkg/errors"
 )
 
 // CreateHorizontalPodAutoscaler creates a new HorizontalPodAutoscaler with the
@@ -32,33 +30,31 @@ func CreateHorizontalPodAutoscaler(name, namespace string) *autoscalingv2.Horizo
 
 // SetHPAScaleTargetRef sets the scale target reference for the HPA, identifying
 // the resource (e.g. Deployment) that the autoscaler controls.
-func SetHPAScaleTargetRef(hpa *autoscalingv2.HorizontalPodAutoscaler, apiVersion, kind, name string) error {
+func SetHPAScaleTargetRef(hpa *autoscalingv2.HorizontalPodAutoscaler, apiVersion, kind, name string) {
 	if hpa == nil {
-		return errors.ErrNilHorizontalPodAutoscaler
+		panic("SetHPAScaleTargetRef: hpa must not be nil")
 	}
 	hpa.Spec.ScaleTargetRef = autoscalingv2.CrossVersionObjectReference{
 		APIVersion: apiVersion,
 		Kind:       kind,
 		Name:       name,
 	}
-	return nil
 }
 
 // SetHPAMinMaxReplicas sets the minimum and maximum replica counts for the HPA.
-func SetHPAMinMaxReplicas(hpa *autoscalingv2.HorizontalPodAutoscaler, min, max int32) error {
+func SetHPAMinMaxReplicas(hpa *autoscalingv2.HorizontalPodAutoscaler, min, max int32) {
 	if hpa == nil {
-		return errors.ErrNilHorizontalPodAutoscaler
+		panic("SetHPAMinMaxReplicas: hpa must not be nil")
 	}
 	hpa.Spec.MinReplicas = &min
 	hpa.Spec.MaxReplicas = max
-	return nil
 }
 
 // AddHPACPUMetric adds a CPU utilization metric to the HPA. The
 // targetUtilization is a percentage (e.g. 80 means 80%).
-func AddHPACPUMetric(hpa *autoscalingv2.HorizontalPodAutoscaler, targetUtilization int32) error {
+func AddHPACPUMetric(hpa *autoscalingv2.HorizontalPodAutoscaler, targetUtilization int32) {
 	if hpa == nil {
-		return errors.ErrNilHorizontalPodAutoscaler
+		panic("AddHPACPUMetric: hpa must not be nil")
 	}
 	hpa.Spec.Metrics = append(hpa.Spec.Metrics, autoscalingv2.MetricSpec{
 		Type: autoscalingv2.ResourceMetricSourceType,
@@ -70,14 +66,13 @@ func AddHPACPUMetric(hpa *autoscalingv2.HorizontalPodAutoscaler, targetUtilizati
 			},
 		},
 	})
-	return nil
 }
 
 // AddHPAMemoryMetric adds a memory utilization metric to the HPA. The
 // targetUtilization is a percentage (e.g. 70 means 70%).
-func AddHPAMemoryMetric(hpa *autoscalingv2.HorizontalPodAutoscaler, targetUtilization int32) error {
+func AddHPAMemoryMetric(hpa *autoscalingv2.HorizontalPodAutoscaler, targetUtilization int32) {
 	if hpa == nil {
-		return errors.ErrNilHorizontalPodAutoscaler
+		panic("AddHPAMemoryMetric: hpa must not be nil")
 	}
 	hpa.Spec.Metrics = append(hpa.Spec.Metrics, autoscalingv2.MetricSpec{
 		Type: autoscalingv2.ResourceMetricSourceType,
@@ -89,44 +84,39 @@ func AddHPAMemoryMetric(hpa *autoscalingv2.HorizontalPodAutoscaler, targetUtiliz
 			},
 		},
 	})
-	return nil
 }
 
 // AddHPACustomMetric adds a caller-defined MetricSpec to the HPA. Use this for
 // pod metrics, object metrics, or external metrics that are not covered by the
 // built-in CPU and memory helpers.
-func AddHPACustomMetric(hpa *autoscalingv2.HorizontalPodAutoscaler, metric autoscalingv2.MetricSpec) error {
+func AddHPACustomMetric(hpa *autoscalingv2.HorizontalPodAutoscaler, metric autoscalingv2.MetricSpec) {
 	if hpa == nil {
-		return errors.ErrNilHorizontalPodAutoscaler
+		panic("AddHPACustomMetric: hpa must not be nil")
 	}
 	hpa.Spec.Metrics = append(hpa.Spec.Metrics, metric)
-	return nil
 }
 
 // SetHPABehavior sets the scaling behavior for the HPA, controlling scale-up
 // and scale-down stabilization windows and policies.
-func SetHPABehavior(hpa *autoscalingv2.HorizontalPodAutoscaler, behavior *autoscalingv2.HorizontalPodAutoscalerBehavior) error {
+func SetHPABehavior(hpa *autoscalingv2.HorizontalPodAutoscaler, behavior *autoscalingv2.HorizontalPodAutoscalerBehavior) {
 	if hpa == nil {
-		return errors.ErrNilHorizontalPodAutoscaler
+		panic("SetHPABehavior: hpa must not be nil")
 	}
 	hpa.Spec.Behavior = behavior
-	return nil
 }
 
 // SetHPALabels replaces the labels on the HPA with the provided map.
-func SetHPALabels(hpa *autoscalingv2.HorizontalPodAutoscaler, labels map[string]string) error {
+func SetHPALabels(hpa *autoscalingv2.HorizontalPodAutoscaler, labels map[string]string) {
 	if hpa == nil {
-		return errors.ErrNilHorizontalPodAutoscaler
+		panic("SetHPALabels: hpa must not be nil")
 	}
 	hpa.Labels = labels
-	return nil
 }
 
 // SetHPAAnnotations replaces the annotations on the HPA with the provided map.
-func SetHPAAnnotations(hpa *autoscalingv2.HorizontalPodAutoscaler, annotations map[string]string) error {
+func SetHPAAnnotations(hpa *autoscalingv2.HorizontalPodAutoscaler, annotations map[string]string) {
 	if hpa == nil {
-		return errors.ErrNilHorizontalPodAutoscaler
+		panic("SetHPAAnnotations: hpa must not be nil")
 	}
 	hpa.Annotations = annotations
-	return nil
 }

--- a/pkg/kubernetes/hpa_test.go
+++ b/pkg/kubernetes/hpa_test.go
@@ -20,37 +20,20 @@ func TestCreateHorizontalPodAutoscaler(t *testing.T) {
 }
 
 func TestHPANilErrors(t *testing.T) {
-	if err := SetHPAScaleTargetRef(nil, "apps/v1", "Deployment", "web"); err == nil {
-		t.Error("expected error for nil HPA")
-	}
-	if err := SetHPAMinMaxReplicas(nil, 1, 10); err == nil {
-		t.Error("expected error for nil HPA")
-	}
-	if err := AddHPACPUMetric(nil, 80); err == nil {
-		t.Error("expected error for nil HPA")
-	}
-	if err := AddHPAMemoryMetric(nil, 80); err == nil {
-		t.Error("expected error for nil HPA")
-	}
-	if err := AddHPACustomMetric(nil, autoscalingv2.MetricSpec{}); err == nil {
-		t.Error("expected error for nil HPA")
-	}
-	if err := SetHPABehavior(nil, &autoscalingv2.HorizontalPodAutoscalerBehavior{}); err == nil {
-		t.Error("expected error for nil HPA")
-	}
-	if err := SetHPALabels(nil, map[string]string{}); err == nil {
-		t.Error("expected error for nil HPA")
-	}
-	if err := SetHPAAnnotations(nil, map[string]string{}); err == nil {
-		t.Error("expected error for nil HPA")
-	}
+	// All HPA functions now panic on nil receiver
+	assertPanics(t, func() { SetHPAScaleTargetRef(nil, "apps/v1", "Deployment", "web") })
+	assertPanics(t, func() { SetHPAMinMaxReplicas(nil, 1, 10) })
+	assertPanics(t, func() { AddHPACPUMetric(nil, 80) })
+	assertPanics(t, func() { AddHPAMemoryMetric(nil, 80) })
+	assertPanics(t, func() { AddHPACustomMetric(nil, autoscalingv2.MetricSpec{}) })
+	assertPanics(t, func() { SetHPABehavior(nil, &autoscalingv2.HorizontalPodAutoscalerBehavior{}) })
+	assertPanics(t, func() { SetHPALabels(nil, map[string]string{}) })
+	assertPanics(t, func() { SetHPAAnnotations(nil, map[string]string{}) })
 }
 
 func TestHPAScaleTargetRef(t *testing.T) {
 	hpa := CreateHorizontalPodAutoscaler("test", "default")
-	if err := SetHPAScaleTargetRef(hpa, "apps/v1", "Deployment", "web"); err != nil {
-		t.Fatalf("SetHPAScaleTargetRef: %v", err)
-	}
+	SetHPAScaleTargetRef(hpa, "apps/v1", "Deployment", "web")
 	ref := hpa.Spec.ScaleTargetRef
 	if ref.APIVersion != "apps/v1" || ref.Kind != "Deployment" || ref.Name != "web" {
 		t.Errorf("scale target ref mismatch: %+v", ref)
@@ -59,9 +42,7 @@ func TestHPAScaleTargetRef(t *testing.T) {
 
 func TestHPAMinMaxReplicas(t *testing.T) {
 	hpa := CreateHorizontalPodAutoscaler("test", "default")
-	if err := SetHPAMinMaxReplicas(hpa, 2, 10); err != nil {
-		t.Fatalf("SetHPAMinMaxReplicas: %v", err)
-	}
+	SetHPAMinMaxReplicas(hpa, 2, 10)
 	if hpa.Spec.MinReplicas == nil || *hpa.Spec.MinReplicas != 2 {
 		t.Errorf("min replicas not set")
 	}
@@ -73,9 +54,7 @@ func TestHPAMinMaxReplicas(t *testing.T) {
 func TestHPAMetrics(t *testing.T) {
 	hpa := CreateHorizontalPodAutoscaler("test", "default")
 
-	if err := AddHPACPUMetric(hpa, 80); err != nil {
-		t.Fatalf("AddHPACPUMetric: %v", err)
-	}
+	AddHPACPUMetric(hpa, 80)
 	if len(hpa.Spec.Metrics) != 1 {
 		t.Fatalf("expected 1 metric, got %d", len(hpa.Spec.Metrics))
 	}
@@ -83,9 +62,7 @@ func TestHPAMetrics(t *testing.T) {
 		t.Errorf("CPU metric not set correctly")
 	}
 
-	if err := AddHPAMemoryMetric(hpa, 70); err != nil {
-		t.Fatalf("AddHPAMemoryMetric: %v", err)
-	}
+	AddHPAMemoryMetric(hpa, 70)
 	if len(hpa.Spec.Metrics) != 2 {
 		t.Fatalf("expected 2 metrics, got %d", len(hpa.Spec.Metrics))
 	}
@@ -93,9 +70,7 @@ func TestHPAMetrics(t *testing.T) {
 	custom := autoscalingv2.MetricSpec{
 		Type: autoscalingv2.PodsMetricSourceType,
 	}
-	if err := AddHPACustomMetric(hpa, custom); err != nil {
-		t.Fatalf("AddHPACustomMetric: %v", err)
-	}
+	AddHPACustomMetric(hpa, custom)
 	if len(hpa.Spec.Metrics) != 3 {
 		t.Fatalf("expected 3 metrics, got %d", len(hpa.Spec.Metrics))
 	}
@@ -108,9 +83,7 @@ func TestHPABehavior(t *testing.T) {
 			StabilizationWindowSeconds: func(i int32) *int32 { return &i }(300),
 		},
 	}
-	if err := SetHPABehavior(hpa, behavior); err != nil {
-		t.Fatalf("SetHPABehavior: %v", err)
-	}
+	SetHPABehavior(hpa, behavior)
 	if hpa.Spec.Behavior == nil || hpa.Spec.Behavior.ScaleDown == nil {
 		t.Errorf("behavior not set correctly")
 	}
@@ -120,17 +93,13 @@ func TestHPALabelsAndAnnotations(t *testing.T) {
 	hpa := CreateHorizontalPodAutoscaler("test", "default")
 
 	labels := map[string]string{"env": "prod"}
-	if err := SetHPALabels(hpa, labels); err != nil {
-		t.Fatalf("SetHPALabels: %v", err)
-	}
+	SetHPALabels(hpa, labels)
 	if hpa.Labels["env"] != "prod" {
 		t.Errorf("labels not set correctly")
 	}
 
 	annotations := map[string]string{"note": "test"}
-	if err := SetHPAAnnotations(hpa, annotations); err != nil {
-		t.Fatalf("SetHPAAnnotations: %v", err)
-	}
+	SetHPAAnnotations(hpa, annotations)
 	if hpa.Annotations["note"] != "test" {
 		t.Errorf("annotations not set correctly")
 	}

--- a/pkg/kubernetes/httproute.go
+++ b/pkg/kubernetes/httproute.go
@@ -3,8 +3,6 @@ package kubernetes
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
-
-	"github.com/go-kure/kure/pkg/errors"
 )
 
 // CreateHTTPRoute returns an HTTPRoute with default labels, annotations,
@@ -33,57 +31,51 @@ func CreateHTTPRoute(name, namespace string) *gwapiv1.HTTPRoute {
 }
 
 // AddHTTPRouteHostname appends a hostname to the HTTPRoute.
-func AddHTTPRouteHostname(route *gwapiv1.HTTPRoute, hostname gwapiv1.Hostname) error {
+func AddHTTPRouteHostname(route *gwapiv1.HTTPRoute, hostname gwapiv1.Hostname) {
 	if route == nil {
-		return errors.ErrNilHTTPRoute
+		panic("AddHTTPRouteHostname: route must not be nil")
 	}
 	route.Spec.Hostnames = append(route.Spec.Hostnames, hostname)
-	return nil
 }
 
 // SetHTTPRouteHostnames replaces all hostnames on the HTTPRoute.
-func SetHTTPRouteHostnames(route *gwapiv1.HTTPRoute, hostnames []gwapiv1.Hostname) error {
+func SetHTTPRouteHostnames(route *gwapiv1.HTTPRoute, hostnames []gwapiv1.Hostname) {
 	if route == nil {
-		return errors.ErrNilHTTPRoute
+		panic("SetHTTPRouteHostnames: route must not be nil")
 	}
 	route.Spec.Hostnames = hostnames
-	return nil
 }
 
 // AddHTTPRouteParentRef appends a parent reference (typically a Gateway) to the HTTPRoute.
-func AddHTTPRouteParentRef(route *gwapiv1.HTTPRoute, ref gwapiv1.ParentReference) error {
+func AddHTTPRouteParentRef(route *gwapiv1.HTTPRoute, ref gwapiv1.ParentReference) {
 	if route == nil {
-		return errors.ErrNilHTTPRoute
+		panic("AddHTTPRouteParentRef: route must not be nil")
 	}
 	route.Spec.ParentRefs = append(route.Spec.ParentRefs, ref)
-	return nil
 }
 
 // SetHTTPRouteParentRefs replaces the parent references on the HTTPRoute.
-func SetHTTPRouteParentRefs(route *gwapiv1.HTTPRoute, refs []gwapiv1.ParentReference) error {
+func SetHTTPRouteParentRefs(route *gwapiv1.HTTPRoute, refs []gwapiv1.ParentReference) {
 	if route == nil {
-		return errors.ErrNilHTTPRoute
+		panic("SetHTTPRouteParentRefs: route must not be nil")
 	}
 	route.Spec.ParentRefs = refs
-	return nil
 }
 
 // AddHTTPRouteRule appends a routing rule to the HTTPRoute.
-func AddHTTPRouteRule(route *gwapiv1.HTTPRoute, rule gwapiv1.HTTPRouteRule) error {
+func AddHTTPRouteRule(route *gwapiv1.HTTPRoute, rule gwapiv1.HTTPRouteRule) {
 	if route == nil {
-		return errors.ErrNilHTTPRoute
+		panic("AddHTTPRouteRule: route must not be nil")
 	}
 	route.Spec.Rules = append(route.Spec.Rules, rule)
-	return nil
 }
 
 // SetHTTPRouteRules replaces the routing rules on the HTTPRoute.
-func SetHTTPRouteRules(route *gwapiv1.HTTPRoute, rules []gwapiv1.HTTPRouteRule) error {
+func SetHTTPRouteRules(route *gwapiv1.HTTPRoute, rules []gwapiv1.HTTPRouteRule) {
 	if route == nil {
-		return errors.ErrNilHTTPRoute
+		panic("SetHTTPRouteRules: route must not be nil")
 	}
 	route.Spec.Rules = rules
-	return nil
 }
 
 // AddHTTPRouteRuleMatch appends a match condition to an HTTPRouteRule.

--- a/pkg/kubernetes/httproute_test.go
+++ b/pkg/kubernetes/httproute_test.go
@@ -30,73 +30,50 @@ func TestCreateHTTPRoute(t *testing.T) {
 }
 
 func TestHTTPRouteNilErrors(t *testing.T) {
-	if err := AddHTTPRouteHostname(nil, "example.com"); err == nil {
-		t.Error("expected error for nil HTTPRoute on AddHTTPRouteHostname")
-	}
-	if err := SetHTTPRouteHostnames(nil, nil); err == nil {
-		t.Error("expected error for nil HTTPRoute on SetHTTPRouteHostnames")
-	}
-	if err := AddHTTPRouteParentRef(nil, gwapiv1.ParentReference{}); err == nil {
-		t.Error("expected error for nil HTTPRoute on AddHTTPRouteParentRef")
-	}
-	if err := SetHTTPRouteParentRefs(nil, nil); err == nil {
-		t.Error("expected error for nil HTTPRoute on SetHTTPRouteParentRefs")
-	}
-	if err := AddHTTPRouteRule(nil, gwapiv1.HTTPRouteRule{}); err == nil {
-		t.Error("expected error for nil HTTPRoute on AddHTTPRouteRule")
-	}
-	if err := SetHTTPRouteRules(nil, nil); err == nil {
-		t.Error("expected error for nil HTTPRoute on SetHTTPRouteRules")
-	}
+	// All HTTPRoute functions now panic on nil receiver
+	assertPanics(t, func() { AddHTTPRouteHostname(nil, "example.com") })
+	assertPanics(t, func() { SetHTTPRouteHostnames(nil, nil) })
+	assertPanics(t, func() { AddHTTPRouteParentRef(nil, gwapiv1.ParentReference{}) })
+	assertPanics(t, func() { SetHTTPRouteParentRefs(nil, nil) })
+	assertPanics(t, func() { AddHTTPRouteRule(nil, gwapiv1.HTTPRouteRule{}) })
+	assertPanics(t, func() { SetHTTPRouteRules(nil, nil) })
 }
 
 func TestHTTPRouteFunctions(t *testing.T) {
 	route := CreateHTTPRoute("web", "ns")
 
-	if err := AddHTTPRouteHostname(route, "example.com"); err != nil {
-		t.Fatalf("AddHTTPRouteHostname returned error: %v", err)
-	}
+	AddHTTPRouteHostname(route, "example.com")
 	if len(route.Spec.Hostnames) != 1 || route.Spec.Hostnames[0] != "example.com" {
 		t.Errorf("hostname not added")
 	}
 
 	hostnames := []gwapiv1.Hostname{"a.example.com", "b.example.com"}
-	if err := SetHTTPRouteHostnames(route, hostnames); err != nil {
-		t.Fatalf("SetHTTPRouteHostnames returned error: %v", err)
-	}
+	SetHTTPRouteHostnames(route, hostnames)
 	if !reflect.DeepEqual(route.Spec.Hostnames, hostnames) {
 		t.Errorf("hostnames not set")
 	}
 
 	gwName := gwapiv1.ObjectName("my-gw")
 	ref := gwapiv1.ParentReference{Name: gwName}
-	if err := AddHTTPRouteParentRef(route, ref); err != nil {
-		t.Fatalf("AddHTTPRouteParentRef returned error: %v", err)
-	}
+	AddHTTPRouteParentRef(route, ref)
 	if len(route.Spec.ParentRefs) != 1 || route.Spec.ParentRefs[0].Name != gwName {
 		t.Errorf("parent ref not added")
 	}
 
 	refs := []gwapiv1.ParentReference{{Name: "gw-1"}, {Name: "gw-2"}}
-	if err := SetHTTPRouteParentRefs(route, refs); err != nil {
-		t.Fatalf("SetHTTPRouteParentRefs returned error: %v", err)
-	}
+	SetHTTPRouteParentRefs(route, refs)
 	if len(route.Spec.ParentRefs) != 2 {
 		t.Errorf("parent refs not set")
 	}
 
 	rule := gwapiv1.HTTPRouteRule{}
-	if err := AddHTTPRouteRule(route, rule); err != nil {
-		t.Fatalf("AddHTTPRouteRule returned error: %v", err)
-	}
+	AddHTTPRouteRule(route, rule)
 	if len(route.Spec.Rules) != 1 {
 		t.Errorf("rule not added")
 	}
 
 	rules := []gwapiv1.HTTPRouteRule{{}, {}}
-	if err := SetHTTPRouteRules(route, rules); err != nil {
-		t.Fatalf("SetHTTPRouteRules returned error: %v", err)
-	}
+	SetHTTPRouteRules(route, rules)
 	if len(route.Spec.Rules) != 2 {
 		t.Errorf("rules not set")
 	}

--- a/pkg/kubernetes/ingress.go
+++ b/pkg/kubernetes/ingress.go
@@ -1,8 +1,6 @@
 package kubernetes
 
 import (
-	"github.com/go-kure/kure/pkg/errors"
-
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -66,12 +64,11 @@ func CreateIngressPath(path string, pathType *netv1.PathType, servicename string
 }
 
 // AddIngressRule appends an IngressRule to the Ingress spec.
-func AddIngressRule(ingress *netv1.Ingress, rule *netv1.IngressRule) error {
+func AddIngressRule(ingress *netv1.Ingress, rule *netv1.IngressRule) {
 	if ingress == nil {
-		return errors.ErrNilIngress
+		panic("AddIngressRule: ingress must not be nil")
 	}
 	ingress.Spec.Rules = append(ingress.Spec.Rules, *rule)
-	return nil
 }
 
 // AddIngressRulePath appends a path to an IngressRule's HTTP paths.
@@ -83,28 +80,25 @@ func AddIngressRulePath(rule *netv1.IngressRule, path netv1.HTTPIngressPath) {
 }
 
 // AddIngressTLS appends a TLS configuration to the Ingress spec.
-func AddIngressTLS(ingress *netv1.Ingress, tls netv1.IngressTLS) error {
+func AddIngressTLS(ingress *netv1.Ingress, tls netv1.IngressTLS) {
 	if ingress == nil {
-		return errors.ErrNilIngress
+		panic("AddIngressTLS: ingress must not be nil")
 	}
 	ingress.Spec.TLS = append(ingress.Spec.TLS, tls)
-	return nil
 }
 
 // SetIngressDefaultBackend sets the default backend on the Ingress spec.
-func SetIngressDefaultBackend(ingress *netv1.Ingress, backend netv1.IngressBackend) error {
+func SetIngressDefaultBackend(ingress *netv1.Ingress, backend netv1.IngressBackend) {
 	if ingress == nil {
-		return errors.ErrNilIngress
+		panic("SetIngressDefaultBackend: ingress must not be nil")
 	}
 	ingress.Spec.DefaultBackend = &backend
-	return nil
 }
 
 // SetIngressClassName sets the ingress class name on the Ingress spec.
-func SetIngressClassName(ingress *netv1.Ingress, class string) error {
+func SetIngressClassName(ingress *netv1.Ingress, class string) {
 	if ingress == nil {
-		return errors.ErrNilIngress
+		panic("SetIngressClassName: ingress must not be nil")
 	}
 	ingress.Spec.IngressClassName = &class
-	return nil
 }

--- a/pkg/kubernetes/ingress_test.go
+++ b/pkg/kubernetes/ingress_test.go
@@ -24,18 +24,11 @@ func TestCreateIngress(t *testing.T) {
 
 func TestIngressNilErrors(t *testing.T) {
 	rule := CreateIngressRule("example.com")
-	if err := AddIngressRule(nil, rule); err == nil {
-		t.Error("expected error for nil Ingress on AddIngressRule")
-	}
-	if err := AddIngressTLS(nil, netv1.IngressTLS{}); err == nil {
-		t.Error("expected error for nil Ingress on AddIngressTLS")
-	}
-	if err := SetIngressDefaultBackend(nil, netv1.IngressBackend{}); err == nil {
-		t.Error("expected error for nil Ingress on SetIngressDefaultBackend")
-	}
-	if err := SetIngressClassName(nil, "nginx"); err == nil {
-		t.Error("expected error for nil Ingress on SetIngressClassName")
-	}
+	// All Ingress functions now panic on nil receiver
+	assertPanics(t, func() { AddIngressRule(nil, rule) })
+	assertPanics(t, func() { AddIngressTLS(nil, netv1.IngressTLS{}) })
+	assertPanics(t, func() { SetIngressDefaultBackend(nil, netv1.IngressBackend{}) })
+	assertPanics(t, func() { SetIngressClassName(nil, "nginx") })
 }
 
 func TestIngressFunctions(t *testing.T) {
@@ -66,32 +59,24 @@ func TestIngressFunctions(t *testing.T) {
 		t.Errorf("path not added")
 	}
 
-	if err := AddIngressRule(ing, rule); err != nil {
-		t.Fatalf("AddIngressRule returned error: %v", err)
-	}
+	AddIngressRule(ing, rule)
 	if len(ing.Spec.Rules) != 1 {
 		t.Errorf("rule not added")
 	}
 
 	tls := netv1.IngressTLS{Hosts: []string{"example.com"}}
-	if err := AddIngressTLS(ing, tls); err != nil {
-		t.Fatalf("AddIngressTLS returned error: %v", err)
-	}
+	AddIngressTLS(ing, tls)
 	if len(ing.Spec.TLS) != 1 || ing.Spec.TLS[0].Hosts[0] != "example.com" {
 		t.Errorf("tls not added")
 	}
 
 	backend := netv1.IngressBackend{Service: &netv1.IngressServiceBackend{Name: "svc", Port: netv1.ServiceBackendPort{Number: 80}}}
-	if err := SetIngressDefaultBackend(ing, backend); err != nil {
-		t.Fatalf("SetIngressDefaultBackend returned error: %v", err)
-	}
+	SetIngressDefaultBackend(ing, backend)
 	if ing.Spec.DefaultBackend == nil || ing.Spec.DefaultBackend.Service.Name != "svc" {
 		t.Errorf("default backend not set")
 	}
 
-	if err := SetIngressClassName(ing, "newclass"); err != nil {
-		t.Fatalf("SetIngressClassName returned error: %v", err)
-	}
+	SetIngressClassName(ing, "newclass")
 	if ing.Spec.IngressClassName == nil || *ing.Spec.IngressClassName != "newclass" {
 		t.Errorf("ingress class name not set")
 	}

--- a/pkg/kubernetes/job.go
+++ b/pkg/kubernetes/job.go
@@ -1,11 +1,11 @@
 package kubernetes
 
 import (
-	"github.com/go-kure/kure/pkg/errors"
-
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/go-kure/kure/pkg/errors"
 )
 
 func CreateJob(name, namespace string) *batchv1.Job {
@@ -92,71 +92,66 @@ func AddJobTopologySpreadConstraint(job *batchv1.Job, constraint *corev1.Topolog
 	return AddPodSpecTopologySpreadConstraints(&job.Spec.Template.Spec, constraint)
 }
 
-func SetJobServiceAccountName(job *batchv1.Job, name string) error {
+func SetJobServiceAccountName(job *batchv1.Job, name string) {
 	if job == nil {
-		return errors.ErrNilJob
+		panic("SetJobServiceAccountName: job must not be nil")
 	}
-	return SetPodSpecServiceAccountName(&job.Spec.Template.Spec, name)
+	SetPodSpecServiceAccountName(&job.Spec.Template.Spec, name)
 }
 
-func SetJobSecurityContext(job *batchv1.Job, sc *corev1.PodSecurityContext) error {
+func SetJobSecurityContext(job *batchv1.Job, sc *corev1.PodSecurityContext) {
 	if job == nil {
-		return errors.ErrNilJob
+		panic("SetJobSecurityContext: job must not be nil")
 	}
-	return SetPodSpecSecurityContext(&job.Spec.Template.Spec, sc)
+	SetPodSpecSecurityContext(&job.Spec.Template.Spec, sc)
 }
 
-func SetJobAffinity(job *batchv1.Job, aff *corev1.Affinity) error {
+func SetJobAffinity(job *batchv1.Job, aff *corev1.Affinity) {
 	if job == nil {
-		return errors.ErrNilJob
+		panic("SetJobAffinity: job must not be nil")
 	}
-	return SetPodSpecAffinity(&job.Spec.Template.Spec, aff)
+	SetPodSpecAffinity(&job.Spec.Template.Spec, aff)
 }
 
-func SetJobNodeSelector(job *batchv1.Job, selector map[string]string) error {
+func SetJobNodeSelector(job *batchv1.Job, selector map[string]string) {
 	if job == nil {
-		return errors.ErrNilJob
+		panic("SetJobNodeSelector: job must not be nil")
 	}
-	return SetPodSpecNodeSelector(&job.Spec.Template.Spec, selector)
+	SetPodSpecNodeSelector(&job.Spec.Template.Spec, selector)
 }
 
-func SetJobCompletions(job *batchv1.Job, completions int32) error {
+func SetJobCompletions(job *batchv1.Job, completions int32) {
 	if job == nil {
-		return errors.ErrNilJob
+		panic("SetJobCompletions: job must not be nil")
 	}
 	job.Spec.Completions = &completions
-	return nil
 }
 
-func SetJobParallelism(job *batchv1.Job, parallelism int32) error {
+func SetJobParallelism(job *batchv1.Job, parallelism int32) {
 	if job == nil {
-		return errors.ErrNilJob
+		panic("SetJobParallelism: job must not be nil")
 	}
 	job.Spec.Parallelism = &parallelism
-	return nil
 }
 
-func SetJobBackoffLimit(job *batchv1.Job, limit int32) error {
+func SetJobBackoffLimit(job *batchv1.Job, limit int32) {
 	if job == nil {
-		return errors.ErrNilJob
+		panic("SetJobBackoffLimit: job must not be nil")
 	}
 	job.Spec.BackoffLimit = &limit
-	return nil
 }
 
-func SetJobTTLSecondsAfterFinished(job *batchv1.Job, ttl int32) error {
+func SetJobTTLSecondsAfterFinished(job *batchv1.Job, ttl int32) {
 	if job == nil {
-		return errors.ErrNilJob
+		panic("SetJobTTLSecondsAfterFinished: job must not be nil")
 	}
 	job.Spec.TTLSecondsAfterFinished = &ttl
-	return nil
 }
 
 // SetJobActiveDeadlineSeconds sets the active deadline seconds for the job.
-func SetJobActiveDeadlineSeconds(job *batchv1.Job, secs *int64) error {
+func SetJobActiveDeadlineSeconds(job *batchv1.Job, secs *int64) {
 	if job == nil {
-		return errors.ErrNilJob
+		panic("SetJobActiveDeadlineSeconds: job must not be nil")
 	}
 	job.Spec.ActiveDeadlineSeconds = secs
-	return nil
 }

--- a/pkg/kubernetes/job_test.go
+++ b/pkg/kubernetes/job_test.go
@@ -75,69 +75,51 @@ func TestJobFunctions(t *testing.T) {
 		t.Errorf("topology constraint not added")
 	}
 
-	if err := SetJobServiceAccountName(job, "sa"); err != nil {
-		t.Fatalf("SetJobServiceAccountName returned error: %v", err)
-	}
+	SetJobServiceAccountName(job, "sa")
 	if job.Spec.Template.Spec.ServiceAccountName != "sa" {
 		t.Errorf("service account not set")
 	}
 
 	sc := &corev1.PodSecurityContext{}
-	if err := SetJobSecurityContext(job, sc); err != nil {
-		t.Fatalf("SetJobSecurityContext returned error: %v", err)
-	}
+	SetJobSecurityContext(job, sc)
 	if job.Spec.Template.Spec.SecurityContext != sc {
 		t.Errorf("security context not set")
 	}
 
 	aff := &corev1.Affinity{}
-	if err := SetJobAffinity(job, aff); err != nil {
-		t.Fatalf("SetJobAffinity returned error: %v", err)
-	}
+	SetJobAffinity(job, aff)
 	if job.Spec.Template.Spec.Affinity != aff {
 		t.Errorf("affinity not set")
 	}
 
 	sel := map[string]string{"role": "db"}
-	if err := SetJobNodeSelector(job, sel); err != nil {
-		t.Fatalf("SetJobNodeSelector returned error: %v", err)
-	}
+	SetJobNodeSelector(job, sel)
 	if !reflect.DeepEqual(job.Spec.Template.Spec.NodeSelector, sel) {
 		t.Errorf("node selector not set")
 	}
 
-	if err := SetJobCompletions(job, 2); err != nil {
-		t.Fatalf("SetJobCompletions returned error: %v", err)
-	}
+	SetJobCompletions(job, 2)
 	if job.Spec.Completions == nil || *job.Spec.Completions != 2 {
 		t.Errorf("completions not set")
 	}
 
-	if err := SetJobParallelism(job, 3); err != nil {
-		t.Fatalf("SetJobParallelism returned error: %v", err)
-	}
+	SetJobParallelism(job, 3)
 	if job.Spec.Parallelism == nil || *job.Spec.Parallelism != 3 {
 		t.Errorf("parallelism not set")
 	}
 
-	if err := SetJobBackoffLimit(job, 4); err != nil {
-		t.Fatalf("SetJobBackoffLimit returned error: %v", err)
-	}
+	SetJobBackoffLimit(job, 4)
 	if job.Spec.BackoffLimit == nil || *job.Spec.BackoffLimit != 4 {
 		t.Errorf("backoff limit not set")
 	}
 
-	if err := SetJobTTLSecondsAfterFinished(job, 30); err != nil {
-		t.Fatalf("SetJobTTLSecondsAfterFinished returned error: %v", err)
-	}
+	SetJobTTLSecondsAfterFinished(job, 30)
 	if job.Spec.TTLSecondsAfterFinished == nil || *job.Spec.TTLSecondsAfterFinished != 30 {
 		t.Errorf("ttl not set")
 	}
 
 	ad := int64(100)
-	if err := SetJobActiveDeadlineSeconds(job, &ad); err != nil {
-		t.Fatalf("SetJobActiveDeadlineSeconds returned error: %v", err)
-	}
+	SetJobActiveDeadlineSeconds(job, &ad)
 	if job.Spec.ActiveDeadlineSeconds == nil || *job.Spec.ActiveDeadlineSeconds != 100 {
 		t.Errorf("active deadline not set")
 	}
@@ -145,34 +127,38 @@ func TestJobFunctions(t *testing.T) {
 
 func TestJobNilGuards(t *testing.T) {
 	ad := int64(1)
-	tests := []struct {
-		name string
-		fn   func() error
-	}{
-		{"SetJobPodSpec", func() error { return SetJobPodSpec(nil, &corev1.PodSpec{}) }},
-		{"AddJobContainer", func() error { return AddJobContainer(nil, &corev1.Container{}) }},
-		{"AddJobInitContainer", func() error { return AddJobInitContainer(nil, &corev1.Container{}) }},
-		{"AddJobVolume", func() error { return AddJobVolume(nil, &corev1.Volume{}) }},
-		{"AddJobImagePullSecret", func() error { return AddJobImagePullSecret(nil, &corev1.LocalObjectReference{}) }},
-		{"AddJobToleration", func() error { return AddJobToleration(nil, &corev1.Toleration{}) }},
-		{"AddJobTopologySpreadConstraint", func() error {
-			return AddJobTopologySpreadConstraint(nil, &corev1.TopologySpreadConstraint{})
-		}},
-		{"SetJobServiceAccountName", func() error { return SetJobServiceAccountName(nil, "sa") }},
-		{"SetJobSecurityContext", func() error { return SetJobSecurityContext(nil, nil) }},
-		{"SetJobAffinity", func() error { return SetJobAffinity(nil, nil) }},
-		{"SetJobNodeSelector", func() error { return SetJobNodeSelector(nil, nil) }},
-		{"SetJobCompletions", func() error { return SetJobCompletions(nil, 1) }},
-		{"SetJobParallelism", func() error { return SetJobParallelism(nil, 1) }},
-		{"SetJobBackoffLimit", func() error { return SetJobBackoffLimit(nil, 1) }},
-		{"SetJobTTLSecondsAfterFinished", func() error { return SetJobTTLSecondsAfterFinished(nil, 1) }},
-		{"SetJobActiveDeadlineSeconds", func() error { return SetJobActiveDeadlineSeconds(nil, &ad) }},
+
+	// Functions with secondary nil checks — still return errors
+	if err := SetJobPodSpec(nil, &corev1.PodSpec{}); err == nil {
+		t.Error("SetJobPodSpec(nil) should return error")
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.fn(); err == nil {
-				t.Errorf("%s(nil) should return error", tt.name)
-			}
-		})
+	if err := AddJobContainer(nil, &corev1.Container{}); err == nil {
+		t.Error("AddJobContainer(nil) should return error")
 	}
+	if err := AddJobInitContainer(nil, &corev1.Container{}); err == nil {
+		t.Error("AddJobInitContainer(nil) should return error")
+	}
+	if err := AddJobVolume(nil, &corev1.Volume{}); err == nil {
+		t.Error("AddJobVolume(nil) should return error")
+	}
+	if err := AddJobImagePullSecret(nil, &corev1.LocalObjectReference{}); err == nil {
+		t.Error("AddJobImagePullSecret(nil) should return error")
+	}
+	if err := AddJobToleration(nil, &corev1.Toleration{}); err == nil {
+		t.Error("AddJobToleration(nil) should return error")
+	}
+	if err := AddJobTopologySpreadConstraint(nil, &corev1.TopologySpreadConstraint{}); err == nil {
+		t.Error("AddJobTopologySpreadConstraint(nil) should return error")
+	}
+
+	// Functions that now panic on nil receiver
+	assertPanics(t, func() { SetJobServiceAccountName(nil, "sa") })
+	assertPanics(t, func() { SetJobSecurityContext(nil, nil) })
+	assertPanics(t, func() { SetJobAffinity(nil, nil) })
+	assertPanics(t, func() { SetJobNodeSelector(nil, nil) })
+	assertPanics(t, func() { SetJobCompletions(nil, 1) })
+	assertPanics(t, func() { SetJobParallelism(nil, 1) })
+	assertPanics(t, func() { SetJobBackoffLimit(nil, 1) })
+	assertPanics(t, func() { SetJobTTLSecondsAfterFinished(nil, 1) })
+	assertPanics(t, func() { SetJobActiveDeadlineSeconds(nil, &ad) })
 }

--- a/pkg/kubernetes/networkpolicy.go
+++ b/pkg/kubernetes/networkpolicy.go
@@ -3,8 +3,6 @@ package kubernetes
 import (
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/go-kure/kure/pkg/errors"
 )
 
 // CreateNetworkPolicy returns a NetworkPolicy with default labels, annotations,
@@ -35,66 +33,59 @@ func CreateNetworkPolicy(name, namespace string) *netv1.NetworkPolicy {
 }
 
 // SetNetworkPolicyPodSelector sets the pod selector on the NetworkPolicy.
-func SetNetworkPolicyPodSelector(np *netv1.NetworkPolicy, selector metav1.LabelSelector) error {
+func SetNetworkPolicyPodSelector(np *netv1.NetworkPolicy, selector metav1.LabelSelector) {
 	if np == nil {
-		return errors.ErrNilNetworkPolicy
+		panic("SetNetworkPolicyPodSelector: np must not be nil")
 	}
 	np.Spec.PodSelector = selector
-	return nil
 }
 
 // AddNetworkPolicyPolicyType appends a policy type to the NetworkPolicy.
-func AddNetworkPolicyPolicyType(np *netv1.NetworkPolicy, t netv1.PolicyType) error {
+func AddNetworkPolicyPolicyType(np *netv1.NetworkPolicy, t netv1.PolicyType) {
 	if np == nil {
-		return errors.ErrNilNetworkPolicy
+		panic("AddNetworkPolicyPolicyType: np must not be nil")
 	}
 	np.Spec.PolicyTypes = append(np.Spec.PolicyTypes, t)
-	return nil
 }
 
 // SetNetworkPolicyPolicyTypes replaces the policy types on the NetworkPolicy.
-func SetNetworkPolicyPolicyTypes(np *netv1.NetworkPolicy, types []netv1.PolicyType) error {
+func SetNetworkPolicyPolicyTypes(np *netv1.NetworkPolicy, types []netv1.PolicyType) {
 	if np == nil {
-		return errors.ErrNilNetworkPolicy
+		panic("SetNetworkPolicyPolicyTypes: np must not be nil")
 	}
 	np.Spec.PolicyTypes = types
-	return nil
 }
 
 // AddNetworkPolicyIngressRule appends an ingress rule to the NetworkPolicy.
-func AddNetworkPolicyIngressRule(np *netv1.NetworkPolicy, rule netv1.NetworkPolicyIngressRule) error {
+func AddNetworkPolicyIngressRule(np *netv1.NetworkPolicy, rule netv1.NetworkPolicyIngressRule) {
 	if np == nil {
-		return errors.ErrNilNetworkPolicy
+		panic("AddNetworkPolicyIngressRule: np must not be nil")
 	}
 	np.Spec.Ingress = append(np.Spec.Ingress, rule)
-	return nil
 }
 
 // SetNetworkPolicyIngressRules replaces the ingress rules on the NetworkPolicy.
-func SetNetworkPolicyIngressRules(np *netv1.NetworkPolicy, rules []netv1.NetworkPolicyIngressRule) error {
+func SetNetworkPolicyIngressRules(np *netv1.NetworkPolicy, rules []netv1.NetworkPolicyIngressRule) {
 	if np == nil {
-		return errors.ErrNilNetworkPolicy
+		panic("SetNetworkPolicyIngressRules: np must not be nil")
 	}
 	np.Spec.Ingress = rules
-	return nil
 }
 
 // AddNetworkPolicyEgressRule appends an egress rule to the NetworkPolicy.
-func AddNetworkPolicyEgressRule(np *netv1.NetworkPolicy, rule netv1.NetworkPolicyEgressRule) error {
+func AddNetworkPolicyEgressRule(np *netv1.NetworkPolicy, rule netv1.NetworkPolicyEgressRule) {
 	if np == nil {
-		return errors.ErrNilNetworkPolicy
+		panic("AddNetworkPolicyEgressRule: np must not be nil")
 	}
 	np.Spec.Egress = append(np.Spec.Egress, rule)
-	return nil
 }
 
 // SetNetworkPolicyEgressRules replaces the egress rules on the NetworkPolicy.
-func SetNetworkPolicyEgressRules(np *netv1.NetworkPolicy, rules []netv1.NetworkPolicyEgressRule) error {
+func SetNetworkPolicyEgressRules(np *netv1.NetworkPolicy, rules []netv1.NetworkPolicyEgressRule) {
 	if np == nil {
-		return errors.ErrNilNetworkPolicy
+		panic("SetNetworkPolicyEgressRules: np must not be nil")
 	}
 	np.Spec.Egress = rules
-	return nil
 }
 
 // AddNetworkPolicyIngressPeer appends a peer to an ingress rule's From list.

--- a/pkg/kubernetes/networkpolicy_test.go
+++ b/pkg/kubernetes/networkpolicy_test.go
@@ -34,51 +34,32 @@ func TestCreateNetworkPolicy(t *testing.T) {
 }
 
 func TestNetworkPolicyNilErrors(t *testing.T) {
-	if err := SetNetworkPolicyPodSelector(nil, metav1.LabelSelector{}); err == nil {
-		t.Error("expected error for nil NetworkPolicy on SetNetworkPolicyPodSelector")
-	}
-	if err := AddNetworkPolicyPolicyType(nil, netv1.PolicyTypeIngress); err == nil {
-		t.Error("expected error for nil NetworkPolicy on AddNetworkPolicyPolicyType")
-	}
-	if err := SetNetworkPolicyPolicyTypes(nil, nil); err == nil {
-		t.Error("expected error for nil NetworkPolicy on SetNetworkPolicyPolicyTypes")
-	}
-	if err := AddNetworkPolicyIngressRule(nil, netv1.NetworkPolicyIngressRule{}); err == nil {
-		t.Error("expected error for nil NetworkPolicy on AddNetworkPolicyIngressRule")
-	}
-	if err := SetNetworkPolicyIngressRules(nil, nil); err == nil {
-		t.Error("expected error for nil NetworkPolicy on SetNetworkPolicyIngressRules")
-	}
-	if err := AddNetworkPolicyEgressRule(nil, netv1.NetworkPolicyEgressRule{}); err == nil {
-		t.Error("expected error for nil NetworkPolicy on AddNetworkPolicyEgressRule")
-	}
-	if err := SetNetworkPolicyEgressRules(nil, nil); err == nil {
-		t.Error("expected error for nil NetworkPolicy on SetNetworkPolicyEgressRules")
-	}
+	// All NetworkPolicy functions now panic on nil receiver
+	assertPanics(t, func() { SetNetworkPolicyPodSelector(nil, metav1.LabelSelector{}) })
+	assertPanics(t, func() { AddNetworkPolicyPolicyType(nil, netv1.PolicyTypeIngress) })
+	assertPanics(t, func() { SetNetworkPolicyPolicyTypes(nil, nil) })
+	assertPanics(t, func() { AddNetworkPolicyIngressRule(nil, netv1.NetworkPolicyIngressRule{}) })
+	assertPanics(t, func() { SetNetworkPolicyIngressRules(nil, nil) })
+	assertPanics(t, func() { AddNetworkPolicyEgressRule(nil, netv1.NetworkPolicyEgressRule{}) })
+	assertPanics(t, func() { SetNetworkPolicyEgressRules(nil, nil) })
 }
 
 func TestNetworkPolicyFunctions(t *testing.T) {
 	np := CreateNetworkPolicy("app", "ns")
 
 	sel := metav1.LabelSelector{MatchLabels: map[string]string{"tier": "frontend"}}
-	if err := SetNetworkPolicyPodSelector(np, sel); err != nil {
-		t.Fatalf("SetNetworkPolicyPodSelector returned error: %v", err)
-	}
+	SetNetworkPolicyPodSelector(np, sel)
 	if !reflect.DeepEqual(np.Spec.PodSelector, sel) {
 		t.Errorf("pod selector not set")
 	}
 
-	if err := AddNetworkPolicyPolicyType(np, netv1.PolicyTypeIngress); err != nil {
-		t.Fatalf("AddNetworkPolicyPolicyType returned error: %v", err)
-	}
+	AddNetworkPolicyPolicyType(np, netv1.PolicyTypeIngress)
 	if len(np.Spec.PolicyTypes) != 1 || np.Spec.PolicyTypes[0] != netv1.PolicyTypeIngress {
 		t.Errorf("policy type not added")
 	}
 
 	types := []netv1.PolicyType{netv1.PolicyTypeIngress, netv1.PolicyTypeEgress}
-	if err := SetNetworkPolicyPolicyTypes(np, types); err != nil {
-		t.Fatalf("SetNetworkPolicyPolicyTypes returned error: %v", err)
-	}
+	SetNetworkPolicyPolicyTypes(np, types)
 	if !reflect.DeepEqual(np.Spec.PolicyTypes, types) {
 		t.Errorf("policy types not set")
 	}
@@ -92,33 +73,25 @@ func TestNetworkPolicyFunctions(t *testing.T) {
 		t.Errorf("rule not populated correctly")
 	}
 
-	if err := AddNetworkPolicyIngressRule(np, rule); err != nil {
-		t.Fatalf("AddNetworkPolicyIngressRule returned error: %v", err)
-	}
+	AddNetworkPolicyIngressRule(np, rule)
 	if len(np.Spec.Ingress) != 1 {
 		t.Errorf("ingress rule not added")
 	}
 
 	ingressRules := []netv1.NetworkPolicyIngressRule{{}, {}}
-	if err := SetNetworkPolicyIngressRules(np, ingressRules); err != nil {
-		t.Fatalf("SetNetworkPolicyIngressRules returned error: %v", err)
-	}
+	SetNetworkPolicyIngressRules(np, ingressRules)
 	if len(np.Spec.Ingress) != 2 {
 		t.Errorf("ingress rules not set")
 	}
 
 	egressRule := netv1.NetworkPolicyEgressRule{}
-	if err := AddNetworkPolicyEgressRule(np, egressRule); err != nil {
-		t.Fatalf("AddNetworkPolicyEgressRule returned error: %v", err)
-	}
+	AddNetworkPolicyEgressRule(np, egressRule)
 	if len(np.Spec.Egress) != 1 {
 		t.Errorf("egress rule not added")
 	}
 
 	egressRules := []netv1.NetworkPolicyEgressRule{{}, {}}
-	if err := SetNetworkPolicyEgressRules(np, egressRules); err != nil {
-		t.Fatalf("SetNetworkPolicyEgressRules returned error: %v", err)
-	}
+	SetNetworkPolicyEgressRules(np, egressRules)
 	if len(np.Spec.Egress) != 2 {
 		t.Errorf("egress rules not set")
 	}

--- a/pkg/kubernetes/pdb.go
+++ b/pkg/kubernetes/pdb.go
@@ -4,8 +4,6 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-
-	"github.com/go-kure/kure/pkg/errors"
 )
 
 // CreatePodDisruptionBudget creates a new PodDisruptionBudget with the given name and namespace.
@@ -29,48 +27,43 @@ func CreatePodDisruptionBudget(name, namespace string) *policyv1.PodDisruptionBu
 }
 
 // SetPDBMinAvailable sets MinAvailable and clears MaxUnavailable (mutually exclusive).
-func SetPDBMinAvailable(pdb *policyv1.PodDisruptionBudget, val intstr.IntOrString) error {
+func SetPDBMinAvailable(pdb *policyv1.PodDisruptionBudget, val intstr.IntOrString) {
 	if pdb == nil {
-		return errors.ErrNilPodDisruptionBudget
+		panic("SetPDBMinAvailable: pdb must not be nil")
 	}
 	pdb.Spec.MinAvailable = &val
 	pdb.Spec.MaxUnavailable = nil
-	return nil
 }
 
 // SetPDBMaxUnavailable sets MaxUnavailable and clears MinAvailable (mutually exclusive).
-func SetPDBMaxUnavailable(pdb *policyv1.PodDisruptionBudget, val intstr.IntOrString) error {
+func SetPDBMaxUnavailable(pdb *policyv1.PodDisruptionBudget, val intstr.IntOrString) {
 	if pdb == nil {
-		return errors.ErrNilPodDisruptionBudget
+		panic("SetPDBMaxUnavailable: pdb must not be nil")
 	}
 	pdb.Spec.MaxUnavailable = &val
 	pdb.Spec.MinAvailable = nil
-	return nil
 }
 
 // SetPDBSelector sets the label selector for the PDB.
-func SetPDBSelector(pdb *policyv1.PodDisruptionBudget, selector *metav1.LabelSelector) error {
+func SetPDBSelector(pdb *policyv1.PodDisruptionBudget, selector *metav1.LabelSelector) {
 	if pdb == nil {
-		return errors.ErrNilPodDisruptionBudget
+		panic("SetPDBSelector: pdb must not be nil")
 	}
 	pdb.Spec.Selector = selector
-	return nil
 }
 
 // SetPDBLabels sets the labels on the PDB.
-func SetPDBLabels(pdb *policyv1.PodDisruptionBudget, labels map[string]string) error {
+func SetPDBLabels(pdb *policyv1.PodDisruptionBudget, labels map[string]string) {
 	if pdb == nil {
-		return errors.ErrNilPodDisruptionBudget
+		panic("SetPDBLabels: pdb must not be nil")
 	}
 	pdb.Labels = labels
-	return nil
 }
 
 // SetPDBAnnotations sets the annotations on the PDB.
-func SetPDBAnnotations(pdb *policyv1.PodDisruptionBudget, annotations map[string]string) error {
+func SetPDBAnnotations(pdb *policyv1.PodDisruptionBudget, annotations map[string]string) {
 	if pdb == nil {
-		return errors.ErrNilPodDisruptionBudget
+		panic("SetPDBAnnotations: pdb must not be nil")
 	}
 	pdb.Annotations = annotations
-	return nil
 }

--- a/pkg/kubernetes/pdb_test.go
+++ b/pkg/kubernetes/pdb_test.go
@@ -22,38 +22,25 @@ func TestCreatePodDisruptionBudget(t *testing.T) {
 
 func TestPDBNilErrors(t *testing.T) {
 	val := intstr.FromInt32(1)
-	if err := SetPDBMinAvailable(nil, val); err == nil {
-		t.Error("expected error for nil PDB on SetPDBMinAvailable")
-	}
-	if err := SetPDBMaxUnavailable(nil, val); err == nil {
-		t.Error("expected error for nil PDB on SetPDBMaxUnavailable")
-	}
-	if err := SetPDBSelector(nil, &metav1.LabelSelector{}); err == nil {
-		t.Error("expected error for nil PDB on SetPDBSelector")
-	}
-	if err := SetPDBLabels(nil, map[string]string{}); err == nil {
-		t.Error("expected error for nil PDB on SetPDBLabels")
-	}
-	if err := SetPDBAnnotations(nil, map[string]string{}); err == nil {
-		t.Error("expected error for nil PDB on SetPDBAnnotations")
-	}
+	// All PDB functions now panic on nil receiver
+	assertPanics(t, func() { SetPDBMinAvailable(nil, val) })
+	assertPanics(t, func() { SetPDBMaxUnavailable(nil, val) })
+	assertPanics(t, func() { SetPDBSelector(nil, &metav1.LabelSelector{}) })
+	assertPanics(t, func() { SetPDBLabels(nil, map[string]string{}) })
+	assertPanics(t, func() { SetPDBAnnotations(nil, map[string]string{}) })
 }
 
 func TestPDBMutualExclusivity(t *testing.T) {
 	pdb := CreatePodDisruptionBudget("test", "default")
 
 	minVal := intstr.FromInt32(2)
-	if err := SetPDBMinAvailable(pdb, minVal); err != nil {
-		t.Fatalf("SetPDBMinAvailable: %v", err)
-	}
+	SetPDBMinAvailable(pdb, minVal)
 	if pdb.Spec.MinAvailable == nil {
 		t.Fatal("expected MinAvailable to be set")
 	}
 
 	maxVal := intstr.FromInt32(1)
-	if err := SetPDBMaxUnavailable(pdb, maxVal); err != nil {
-		t.Fatalf("SetPDBMaxUnavailable: %v", err)
-	}
+	SetPDBMaxUnavailable(pdb, maxVal)
 	if pdb.Spec.MaxUnavailable == nil {
 		t.Fatal("expected MaxUnavailable to be set")
 	}
@@ -62,9 +49,7 @@ func TestPDBMutualExclusivity(t *testing.T) {
 	}
 
 	// Set MinAvailable again — should clear MaxUnavailable
-	if err := SetPDBMinAvailable(pdb, minVal); err != nil {
-		t.Fatalf("SetPDBMinAvailable: %v", err)
-	}
+	SetPDBMinAvailable(pdb, minVal)
 	if pdb.Spec.MaxUnavailable != nil {
 		t.Error("expected MaxUnavailable to be cleared after setting MinAvailable")
 	}
@@ -75,9 +60,7 @@ func TestPDBSelector(t *testing.T) {
 	selector := &metav1.LabelSelector{
 		MatchLabels: map[string]string{"app": "web"},
 	}
-	if err := SetPDBSelector(pdb, selector); err != nil {
-		t.Fatalf("SetPDBSelector: %v", err)
-	}
+	SetPDBSelector(pdb, selector)
 	if pdb.Spec.Selector == nil || pdb.Spec.Selector.MatchLabels["app"] != "web" {
 		t.Errorf("selector not set correctly")
 	}
@@ -87,17 +70,13 @@ func TestPDBLabelsAndAnnotations(t *testing.T) {
 	pdb := CreatePodDisruptionBudget("test", "default")
 
 	labels := map[string]string{"env": "prod"}
-	if err := SetPDBLabels(pdb, labels); err != nil {
-		t.Fatalf("SetPDBLabels: %v", err)
-	}
+	SetPDBLabels(pdb, labels)
 	if pdb.Labels["env"] != "prod" {
 		t.Errorf("labels not set correctly")
 	}
 
 	annotations := map[string]string{"note": "test"}
-	if err := SetPDBAnnotations(pdb, annotations); err != nil {
-		t.Fatalf("SetPDBAnnotations: %v", err)
-	}
+	SetPDBAnnotations(pdb, annotations)
 	if pdb.Annotations["note"] != "test" {
 		t.Errorf("annotations not set correctly")
 	}

--- a/pkg/kubernetes/podspec.go
+++ b/pkg/kubernetes/podspec.go
@@ -109,139 +109,124 @@ func AddPodSpecTopologySpreadConstraints(spec *corev1.PodSpec, constraint *corev
 }
 
 // SetPodSpecServiceAccountName sets the service account name.
-func SetPodSpecServiceAccountName(spec *corev1.PodSpec, name string) error {
+func SetPodSpecServiceAccountName(spec *corev1.PodSpec, name string) {
 	if spec == nil {
-		return errors.ErrNilPodSpec
+		panic("SetPodSpecServiceAccountName: spec must not be nil")
 	}
 	spec.ServiceAccountName = name
-	return nil
 }
 
 // SetPodSpecSecurityContext sets the security context for the PodSpec.
-func SetPodSpecSecurityContext(spec *corev1.PodSpec, sc *corev1.PodSecurityContext) error {
+func SetPodSpecSecurityContext(spec *corev1.PodSpec, sc *corev1.PodSecurityContext) {
 	if spec == nil {
-		return errors.ErrNilPodSpec
+		panic("SetPodSpecSecurityContext: spec must not be nil")
 	}
 	spec.SecurityContext = sc
-	return nil
 }
 
 // SetPodSpecAffinity assigns affinity rules to the PodSpec.
-func SetPodSpecAffinity(spec *corev1.PodSpec, aff *corev1.Affinity) error {
+func SetPodSpecAffinity(spec *corev1.PodSpec, aff *corev1.Affinity) {
 	if spec == nil {
-		return errors.ErrNilPodSpec
+		panic("SetPodSpecAffinity: spec must not be nil")
 	}
 	spec.Affinity = aff
-	return nil
 }
 
 // SetPodSpecNodeSelector sets the node selector map.
-func SetPodSpecNodeSelector(spec *corev1.PodSpec, selector map[string]string) error {
+func SetPodSpecNodeSelector(spec *corev1.PodSpec, selector map[string]string) {
 	if spec == nil {
-		return errors.ErrNilPodSpec
+		panic("SetPodSpecNodeSelector: spec must not be nil")
 	}
 	spec.NodeSelector = selector
-	return nil
 }
 
 // SetPodSpecPriorityClassName sets the priority class name.
-func SetPodSpecPriorityClassName(spec *corev1.PodSpec, class string) error {
+func SetPodSpecPriorityClassName(spec *corev1.PodSpec, class string) {
 	if spec == nil {
-		return errors.ErrNilPodSpec
+		panic("SetPodSpecPriorityClassName: spec must not be nil")
 	}
 	spec.PriorityClassName = class
-	return nil
 }
 
 // SetPodSpecHostNetwork configures host networking.
-func SetPodSpecHostNetwork(spec *corev1.PodSpec, hostNetwork bool) error {
+func SetPodSpecHostNetwork(spec *corev1.PodSpec, hostNetwork bool) {
 	if spec == nil {
-		return errors.ErrNilPodSpec
+		panic("SetPodSpecHostNetwork: spec must not be nil")
 	}
 	spec.HostNetwork = hostNetwork
-	return nil
 }
 
 // SetPodSpecHostPID configures host PID namespace usage.
-func SetPodSpecHostPID(spec *corev1.PodSpec, hostPID bool) error {
+func SetPodSpecHostPID(spec *corev1.PodSpec, hostPID bool) {
 	if spec == nil {
-		return errors.ErrNilPodSpec
+		panic("SetPodSpecHostPID: spec must not be nil")
 	}
 	spec.HostPID = hostPID
-	return nil
 }
 
 // SetPodSpecHostIPC configures host IPC namespace usage.
-func SetPodSpecHostIPC(spec *corev1.PodSpec, hostIPC bool) error {
+func SetPodSpecHostIPC(spec *corev1.PodSpec, hostIPC bool) {
 	if spec == nil {
-		return errors.ErrNilPodSpec
+		panic("SetPodSpecHostIPC: spec must not be nil")
 	}
 	spec.HostIPC = hostIPC
-	return nil
 }
 
 // SetPodSpecDNSPolicy sets the DNS policy.
-func SetPodSpecDNSPolicy(spec *corev1.PodSpec, policy corev1.DNSPolicy) error {
+func SetPodSpecDNSPolicy(spec *corev1.PodSpec, policy corev1.DNSPolicy) {
 	if spec == nil {
-		return errors.ErrNilPodSpec
+		panic("SetPodSpecDNSPolicy: spec must not be nil")
 	}
 	spec.DNSPolicy = policy
-	return nil
 }
 
 // SetPodSpecDNSConfig sets the DNS config.
-func SetPodSpecDNSConfig(spec *corev1.PodSpec, cfg *corev1.PodDNSConfig) error {
+func SetPodSpecDNSConfig(spec *corev1.PodSpec, cfg *corev1.PodDNSConfig) {
 	if spec == nil {
-		return errors.ErrNilPodSpec
+		panic("SetPodSpecDNSConfig: spec must not be nil")
 	}
 	spec.DNSConfig = cfg
-	return nil
 }
 
 // SetPodSpecHostname sets the hostname.
-func SetPodSpecHostname(spec *corev1.PodSpec, hostname string) error {
+func SetPodSpecHostname(spec *corev1.PodSpec, hostname string) {
 	if spec == nil {
-		return errors.ErrNilPodSpec
+		panic("SetPodSpecHostname: spec must not be nil")
 	}
 	spec.Hostname = hostname
-	return nil
 }
 
 // SetPodSpecSubdomain sets the subdomain.
-func SetPodSpecSubdomain(spec *corev1.PodSpec, subdomain string) error {
+func SetPodSpecSubdomain(spec *corev1.PodSpec, subdomain string) {
 	if spec == nil {
-		return errors.ErrNilPodSpec
+		panic("SetPodSpecSubdomain: spec must not be nil")
 	}
 	spec.Subdomain = subdomain
-	return nil
 }
 
 // SetPodSpecRestartPolicy sets the restart policy.
-func SetPodSpecRestartPolicy(spec *corev1.PodSpec, policy corev1.RestartPolicy) error {
+func SetPodSpecRestartPolicy(spec *corev1.PodSpec, policy corev1.RestartPolicy) {
 	if spec == nil {
-		return errors.ErrNilPodSpec
+		panic("SetPodSpecRestartPolicy: spec must not be nil")
 	}
 	spec.RestartPolicy = policy
-	return nil
 }
 
 // SetPodSpecTerminationGracePeriod sets the termination grace period seconds.
-func SetPodSpecTerminationGracePeriod(spec *corev1.PodSpec, secs int64) error {
+func SetPodSpecTerminationGracePeriod(spec *corev1.PodSpec, secs int64) {
 	if spec == nil {
-		return errors.ErrNilPodSpec
+		panic("SetPodSpecTerminationGracePeriod: spec must not be nil")
 	}
 	if spec.TerminationGracePeriodSeconds == nil {
 		spec.TerminationGracePeriodSeconds = new(int64)
 	}
 	*spec.TerminationGracePeriodSeconds = secs
-	return nil
 }
 
 // SetPodSpecSchedulerName sets the scheduler name.
-func SetPodSpecSchedulerName(spec *corev1.PodSpec, scheduler string) error {
+func SetPodSpecSchedulerName(spec *corev1.PodSpec, scheduler string) {
 	if spec == nil {
-		return errors.ErrNilPodSpec
+		panic("SetPodSpecSchedulerName: spec must not be nil")
 	}
 	spec.SchedulerName = scheduler
-	return nil
 }

--- a/pkg/kubernetes/podspec_test.go
+++ b/pkg/kubernetes/podspec_test.go
@@ -81,153 +81,138 @@ func TestPodSpecFunctions(t *testing.T) {
 		t.Errorf("topology constraint not added")
 	}
 
-	if err := SetPodSpecServiceAccountName(spec, "sa"); err != nil {
-		t.Fatalf("SetPodSpecServiceAccountName returned error: %v", err)
-	}
+	SetPodSpecServiceAccountName(spec, "sa")
 	if spec.ServiceAccountName != "sa" {
 		t.Errorf("service account not set")
 	}
 
 	sc := &corev1.PodSecurityContext{}
-	if err := SetPodSpecSecurityContext(spec, sc); err != nil {
-		t.Fatalf("SetPodSpecSecurityContext returned error: %v", err)
-	}
+	SetPodSpecSecurityContext(spec, sc)
 	if spec.SecurityContext != sc {
 		t.Errorf("security context not set")
 	}
 
 	aff := &corev1.Affinity{}
-	if err := SetPodSpecAffinity(spec, aff); err != nil {
-		t.Fatalf("SetPodSpecAffinity returned error: %v", err)
-	}
+	SetPodSpecAffinity(spec, aff)
 	if spec.Affinity != aff {
 		t.Errorf("affinity not set")
 	}
 
 	sel := map[string]string{"role": "db"}
-	if err := SetPodSpecNodeSelector(spec, sel); err != nil {
-		t.Fatalf("SetPodSpecNodeSelector returned error: %v", err)
-	}
+	SetPodSpecNodeSelector(spec, sel)
 	if !reflect.DeepEqual(spec.NodeSelector, sel) {
 		t.Errorf("node selector not set")
 	}
 
-	if err := SetPodSpecPriorityClassName(spec, "high"); err != nil {
-		t.Fatalf("SetPodSpecPriorityClassName returned error: %v", err)
-	}
+	SetPodSpecPriorityClassName(spec, "high")
 	if spec.PriorityClassName != "high" {
 		t.Errorf("priority class name not set")
 	}
 
-	if err := SetPodSpecHostNetwork(spec, true); err != nil {
-		t.Fatalf("SetPodSpecHostNetwork returned error: %v", err)
-	}
+	SetPodSpecHostNetwork(spec, true)
 	if !spec.HostNetwork {
 		t.Errorf("host network not set")
 	}
 
-	if err := SetPodSpecHostPID(spec, true); err != nil {
-		t.Fatalf("SetPodSpecHostPID returned error: %v", err)
-	}
+	SetPodSpecHostPID(spec, true)
 	if !spec.HostPID {
 		t.Errorf("host pid not set")
 	}
 
-	if err := SetPodSpecHostIPC(spec, true); err != nil {
-		t.Fatalf("SetPodSpecHostIPC returned error: %v", err)
-	}
+	SetPodSpecHostIPC(spec, true)
 	if !spec.HostIPC {
 		t.Errorf("host ipc not set")
 	}
 
-	if err := SetPodSpecDNSPolicy(spec, corev1.DNSClusterFirstWithHostNet); err != nil {
-		t.Fatalf("SetPodSpecDNSPolicy returned error: %v", err)
-	}
+	SetPodSpecDNSPolicy(spec, corev1.DNSClusterFirstWithHostNet)
 	if spec.DNSPolicy != corev1.DNSClusterFirstWithHostNet {
 		t.Errorf("dns policy not set")
 	}
 
 	dnsCfg := &corev1.PodDNSConfig{Nameservers: []string{"8.8.8.8"}}
-	if err := SetPodSpecDNSConfig(spec, dnsCfg); err != nil {
-		t.Fatalf("SetPodSpecDNSConfig returned error: %v", err)
-	}
+	SetPodSpecDNSConfig(spec, dnsCfg)
 	if spec.DNSConfig != dnsCfg {
 		t.Errorf("dns config not set")
 	}
 
-	if err := SetPodSpecHostname(spec, "myhost"); err != nil {
-		t.Fatalf("SetPodSpecHostname returned error: %v", err)
-	}
+	SetPodSpecHostname(spec, "myhost")
 	if spec.Hostname != "myhost" {
 		t.Errorf("hostname not set")
 	}
 
-	if err := SetPodSpecSubdomain(spec, "sub"); err != nil {
-		t.Fatalf("SetPodSpecSubdomain returned error: %v", err)
-	}
+	SetPodSpecSubdomain(spec, "sub")
 	if spec.Subdomain != "sub" {
 		t.Errorf("subdomain not set")
 	}
 
-	if err := SetPodSpecRestartPolicy(spec, corev1.RestartPolicyOnFailure); err != nil {
-		t.Fatalf("SetPodSpecRestartPolicy returned error: %v", err)
-	}
+	SetPodSpecRestartPolicy(spec, corev1.RestartPolicyOnFailure)
 	if spec.RestartPolicy != corev1.RestartPolicyOnFailure {
 		t.Errorf("restart policy not set")
 	}
 
-	if err := SetPodSpecTerminationGracePeriod(spec, 15); err != nil {
-		t.Fatalf("SetPodSpecTerminationGracePeriod returned error: %v", err)
-	}
+	SetPodSpecTerminationGracePeriod(spec, 15)
 	if spec.TerminationGracePeriodSeconds == nil || *spec.TerminationGracePeriodSeconds != 15 {
 		t.Errorf("termination grace period not set")
 	}
 
-	if err := SetPodSpecSchedulerName(spec, "sched"); err != nil {
-		t.Fatalf("SetPodSpecSchedulerName returned error: %v", err)
-	}
+	SetPodSpecSchedulerName(spec, "sched")
 	if spec.SchedulerName != "sched" {
 		t.Errorf("scheduler name not set")
 	}
 }
 
 func TestPodSpecNilGuards(t *testing.T) {
-	tests := []struct {
-		name string
-		fn   func() error
-	}{
-		{"AddPodSpecContainer", func() error { return AddPodSpecContainer(nil, &corev1.Container{Name: "c"}) }},
-		{"AddPodSpecInitContainer", func() error { return AddPodSpecInitContainer(nil, &corev1.Container{Name: "c"}) }},
-		{"AddPodSpecEphemeralContainer", func() error {
-			return AddPodSpecEphemeralContainer(nil, &corev1.EphemeralContainer{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "e"}})
-		}},
-		{"AddPodSpecVolume", func() error { return AddPodSpecVolume(nil, &corev1.Volume{Name: "v"}) }},
-		{"AddPodSpecImagePullSecret", func() error { return AddPodSpecImagePullSecret(nil, &corev1.LocalObjectReference{Name: "s"}) }},
-		{"AddPodSpecToleration", func() error { return AddPodSpecToleration(nil, &corev1.Toleration{Key: "k"}) }},
-		{"AddPodSpecTopologySpreadConstraints", func() error {
-			return AddPodSpecTopologySpreadConstraints(nil, &corev1.TopologySpreadConstraint{MaxSkew: 1, TopologyKey: "zone", WhenUnsatisfiable: corev1.DoNotSchedule, LabelSelector: &metav1.LabelSelector{}})
-		}},
-		{"SetPodSpecServiceAccountName", func() error { return SetPodSpecServiceAccountName(nil, "sa") }},
-		{"SetPodSpecSecurityContext", func() error { return SetPodSpecSecurityContext(nil, &corev1.PodSecurityContext{}) }},
-		{"SetPodSpecAffinity", func() error { return SetPodSpecAffinity(nil, &corev1.Affinity{}) }},
-		{"SetPodSpecNodeSelector", func() error { return SetPodSpecNodeSelector(nil, map[string]string{"k": "v"}) }},
-		{"SetPodSpecPriorityClassName", func() error { return SetPodSpecPriorityClassName(nil, "high") }},
-		{"SetPodSpecHostNetwork", func() error { return SetPodSpecHostNetwork(nil, true) }},
-		{"SetPodSpecHostPID", func() error { return SetPodSpecHostPID(nil, true) }},
-		{"SetPodSpecHostIPC", func() error { return SetPodSpecHostIPC(nil, true) }},
-		{"SetPodSpecDNSPolicy", func() error { return SetPodSpecDNSPolicy(nil, corev1.DNSClusterFirst) }},
-		{"SetPodSpecDNSConfig", func() error { return SetPodSpecDNSConfig(nil, &corev1.PodDNSConfig{}) }},
-		{"SetPodSpecHostname", func() error { return SetPodSpecHostname(nil, "host") }},
-		{"SetPodSpecSubdomain", func() error { return SetPodSpecSubdomain(nil, "sub") }},
-		{"SetPodSpecRestartPolicy", func() error { return SetPodSpecRestartPolicy(nil, corev1.RestartPolicyAlways) }},
-		{"SetPodSpecTerminationGracePeriod", func() error { return SetPodSpecTerminationGracePeriod(nil, 30) }},
-		{"SetPodSpecSchedulerName", func() error { return SetPodSpecSchedulerName(nil, "sched") }},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.fn(); err == nil {
-				t.Errorf("%s(nil) should return error", tt.name)
-			}
-		})
-	}
+	// Functions that still return error (secondary nil checks) — keep error-based tests
+	t.Run("AddPodSpecContainer nil spec", func(t *testing.T) {
+		if err := AddPodSpecContainer(nil, &corev1.Container{Name: "c"}); err == nil {
+			t.Error("AddPodSpecContainer(nil) should return error")
+		}
+	})
+	t.Run("AddPodSpecInitContainer nil spec", func(t *testing.T) {
+		if err := AddPodSpecInitContainer(nil, &corev1.Container{Name: "c"}); err == nil {
+			t.Error("AddPodSpecInitContainer(nil) should return error")
+		}
+	})
+	t.Run("AddPodSpecEphemeralContainer nil spec", func(t *testing.T) {
+		if err := AddPodSpecEphemeralContainer(nil, &corev1.EphemeralContainer{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "e"}}); err == nil {
+			t.Error("AddPodSpecEphemeralContainer(nil) should return error")
+		}
+	})
+	t.Run("AddPodSpecVolume nil spec", func(t *testing.T) {
+		if err := AddPodSpecVolume(nil, &corev1.Volume{Name: "v"}); err == nil {
+			t.Error("AddPodSpecVolume(nil) should return error")
+		}
+	})
+	t.Run("AddPodSpecImagePullSecret nil spec", func(t *testing.T) {
+		if err := AddPodSpecImagePullSecret(nil, &corev1.LocalObjectReference{Name: "s"}); err == nil {
+			t.Error("AddPodSpecImagePullSecret(nil) should return error")
+		}
+	})
+	t.Run("AddPodSpecToleration nil spec", func(t *testing.T) {
+		if err := AddPodSpecToleration(nil, &corev1.Toleration{Key: "k"}); err == nil {
+			t.Error("AddPodSpecToleration(nil) should return error")
+		}
+	})
+	t.Run("AddPodSpecTopologySpreadConstraints nil spec", func(t *testing.T) {
+		if err := AddPodSpecTopologySpreadConstraints(nil, &corev1.TopologySpreadConstraint{MaxSkew: 1, TopologyKey: "zone", WhenUnsatisfiable: corev1.DoNotSchedule, LabelSelector: &metav1.LabelSelector{}}); err == nil {
+			t.Error("AddPodSpecTopologySpreadConstraints(nil) should return error")
+		}
+	})
+
+	// Functions now panic on nil receiver
+	assertPanics(t, func() { SetPodSpecServiceAccountName(nil, "sa") })
+	assertPanics(t, func() { SetPodSpecSecurityContext(nil, &corev1.PodSecurityContext{}) })
+	assertPanics(t, func() { SetPodSpecAffinity(nil, &corev1.Affinity{}) })
+	assertPanics(t, func() { SetPodSpecNodeSelector(nil, map[string]string{"k": "v"}) })
+	assertPanics(t, func() { SetPodSpecPriorityClassName(nil, "high") })
+	assertPanics(t, func() { SetPodSpecHostNetwork(nil, true) })
+	assertPanics(t, func() { SetPodSpecHostPID(nil, true) })
+	assertPanics(t, func() { SetPodSpecHostIPC(nil, true) })
+	assertPanics(t, func() { SetPodSpecDNSPolicy(nil, corev1.DNSClusterFirst) })
+	assertPanics(t, func() { SetPodSpecDNSConfig(nil, &corev1.PodDNSConfig{}) })
+	assertPanics(t, func() { SetPodSpecHostname(nil, "host") })
+	assertPanics(t, func() { SetPodSpecSubdomain(nil, "sub") })
+	assertPanics(t, func() { SetPodSpecRestartPolicy(nil, corev1.RestartPolicyAlways) })
+	assertPanics(t, func() { SetPodSpecTerminationGracePeriod(nil, 30) })
+	assertPanics(t, func() { SetPodSpecSchedulerName(nil, "sched") })
 }

--- a/pkg/kubernetes/rbac.go
+++ b/pkg/kubernetes/rbac.go
@@ -3,8 +3,6 @@ package kubernetes
 import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/go-kure/kure/pkg/errors"
 )
 
 func CreateRole(name, namespace string) *rbacv1.Role {
@@ -20,12 +18,11 @@ func CreateRole(name, namespace string) *rbacv1.Role {
 	}
 }
 
-func AddRoleRule(role *rbacv1.Role, rule rbacv1.PolicyRule) error {
+func AddRoleRule(role *rbacv1.Role, rule rbacv1.PolicyRule) {
 	if role == nil {
-		return errors.ErrNilRole
+		panic("AddRoleRule: role must not be nil")
 	}
 	role.Rules = append(role.Rules, rule)
-	return nil
 }
 
 func CreateRoleBinding(name, namespace string) *rbacv1.RoleBinding {
@@ -41,20 +38,18 @@ func CreateRoleBinding(name, namespace string) *rbacv1.RoleBinding {
 	}
 }
 
-func SetRoleBindingRoleRef(rb *rbacv1.RoleBinding, roleRef rbacv1.RoleRef) error {
+func SetRoleBindingRoleRef(rb *rbacv1.RoleBinding, roleRef rbacv1.RoleRef) {
 	if rb == nil {
-		return errors.ErrNilRoleBinding
+		panic("SetRoleBindingRoleRef: rb must not be nil")
 	}
 	rb.RoleRef = roleRef
-	return nil
 }
 
-func AddRoleBindingSubject(rb *rbacv1.RoleBinding, subject rbacv1.Subject) error {
+func AddRoleBindingSubject(rb *rbacv1.RoleBinding, subject rbacv1.Subject) {
 	if rb == nil {
-		return errors.ErrNilRoleBinding
+		panic("AddRoleBindingSubject: rb must not be nil")
 	}
 	rb.Subjects = append(rb.Subjects, subject)
-	return nil
 }
 
 func CreateClusterRole(name string) *rbacv1.ClusterRole {
@@ -69,12 +64,11 @@ func CreateClusterRole(name string) *rbacv1.ClusterRole {
 	}
 }
 
-func AddClusterRoleRule(cr *rbacv1.ClusterRole, rule rbacv1.PolicyRule) error {
+func AddClusterRoleRule(cr *rbacv1.ClusterRole, rule rbacv1.PolicyRule) {
 	if cr == nil {
-		return errors.ErrNilClusterRole
+		panic("AddClusterRoleRule: cr must not be nil")
 	}
 	cr.Rules = append(cr.Rules, rule)
-	return nil
 }
 
 func CreateClusterRoleBinding(name string) *rbacv1.ClusterRoleBinding {
@@ -89,18 +83,16 @@ func CreateClusterRoleBinding(name string) *rbacv1.ClusterRoleBinding {
 	}
 }
 
-func SetClusterRoleBindingRoleRef(crb *rbacv1.ClusterRoleBinding, roleRef rbacv1.RoleRef) error {
+func SetClusterRoleBindingRoleRef(crb *rbacv1.ClusterRoleBinding, roleRef rbacv1.RoleRef) {
 	if crb == nil {
-		return errors.ErrNilClusterRoleBinding
+		panic("SetClusterRoleBindingRoleRef: crb must not be nil")
 	}
 	crb.RoleRef = roleRef
-	return nil
 }
 
-func AddClusterRoleBindingSubject(crb *rbacv1.ClusterRoleBinding, subject rbacv1.Subject) error {
+func AddClusterRoleBindingSubject(crb *rbacv1.ClusterRoleBinding, subject rbacv1.Subject) {
 	if crb == nil {
-		return errors.ErrNilClusterRoleBinding
+		panic("AddClusterRoleBindingSubject: crb must not be nil")
 	}
 	crb.Subjects = append(crb.Subjects, subject)
-	return nil
 }

--- a/pkg/kubernetes/rbac_test.go
+++ b/pkg/kubernetes/rbac_test.go
@@ -29,9 +29,7 @@ func TestAddRoleRule(t *testing.T) {
 		Resources: []string{"pods"},
 		Verbs:     []string{"get", "list"},
 	}
-	if err := AddRoleRule(r, rule); err != nil {
-		t.Fatalf("AddRoleRule returned error: %v", err)
-	}
+	AddRoleRule(r, rule)
 	if len(r.Rules) != 1 {
 		t.Fatalf("expected 1 rule, got %d", len(r.Rules))
 	}
@@ -60,9 +58,7 @@ func TestSetRoleBindingRoleRef(t *testing.T) {
 		Kind:     "Role",
 		Name:     "my-role",
 	}
-	if err := SetRoleBindingRoleRef(rb, ref); err != nil {
-		t.Fatalf("SetRoleBindingRoleRef returned error: %v", err)
-	}
+	SetRoleBindingRoleRef(rb, ref)
 	if rb.RoleRef != ref {
 		t.Errorf("role ref not set correctly")
 	}
@@ -75,9 +71,7 @@ func TestAddRoleBindingSubject(t *testing.T) {
 		Name:      "my-sa",
 		Namespace: "ns",
 	}
-	if err := AddRoleBindingSubject(rb, subj); err != nil {
-		t.Fatalf("AddRoleBindingSubject returned error: %v", err)
-	}
+	AddRoleBindingSubject(rb, subj)
 	if len(rb.Subjects) != 1 || rb.Subjects[0] != subj {
 		t.Errorf("subject not added correctly")
 	}
@@ -103,9 +97,7 @@ func TestAddClusterRoleRule(t *testing.T) {
 		Resources: []string{"deployments"},
 		Verbs:     []string{"get", "list", "watch"},
 	}
-	if err := AddClusterRoleRule(cr, rule); err != nil {
-		t.Fatalf("AddClusterRoleRule returned error: %v", err)
-	}
+	AddClusterRoleRule(cr, rule)
 	if len(cr.Rules) != 1 {
 		t.Fatalf("expected 1 rule, got %d", len(cr.Rules))
 	}
@@ -134,9 +126,7 @@ func TestSetClusterRoleBindingRoleRef(t *testing.T) {
 		Kind:     "ClusterRole",
 		Name:     "my-cr",
 	}
-	if err := SetClusterRoleBindingRoleRef(crb, ref); err != nil {
-		t.Fatalf("SetClusterRoleBindingRoleRef returned error: %v", err)
-	}
+	SetClusterRoleBindingRoleRef(crb, ref)
 	if crb.RoleRef != ref {
 		t.Errorf("role ref not set correctly")
 	}
@@ -149,9 +139,7 @@ func TestAddClusterRoleBindingSubject(t *testing.T) {
 		Name:      "my-sa",
 		Namespace: "ns",
 	}
-	if err := AddClusterRoleBindingSubject(crb, subj); err != nil {
-		t.Fatalf("AddClusterRoleBindingSubject returned error: %v", err)
-	}
+	AddClusterRoleBindingSubject(crb, subj)
 	if len(crb.Subjects) != 1 || crb.Subjects[0] != subj {
 		t.Errorf("subject not added correctly")
 	}
@@ -162,22 +150,11 @@ func TestRBACNilGuards(t *testing.T) {
 	ref := rbacv1.RoleRef{}
 	subj := rbacv1.Subject{}
 
-	tests := []struct {
-		name string
-		fn   func() error
-	}{
-		{"AddRoleRule", func() error { return AddRoleRule(nil, rule) }},
-		{"SetRoleBindingRoleRef", func() error { return SetRoleBindingRoleRef(nil, ref) }},
-		{"AddRoleBindingSubject", func() error { return AddRoleBindingSubject(nil, subj) }},
-		{"AddClusterRoleRule", func() error { return AddClusterRoleRule(nil, rule) }},
-		{"SetClusterRoleBindingRoleRef", func() error { return SetClusterRoleBindingRoleRef(nil, ref) }},
-		{"AddClusterRoleBindingSubject", func() error { return AddClusterRoleBindingSubject(nil, subj) }},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.fn(); err == nil {
-				t.Errorf("%s(nil) should return error", tt.name)
-			}
-		})
-	}
+	// All RBAC functions now panic on nil receiver
+	assertPanics(t, func() { AddRoleRule(nil, rule) })
+	assertPanics(t, func() { SetRoleBindingRoleRef(nil, ref) })
+	assertPanics(t, func() { AddRoleBindingSubject(nil, subj) })
+	assertPanics(t, func() { AddClusterRoleRule(nil, rule) })
+	assertPanics(t, func() { SetClusterRoleBindingRoleRef(nil, ref) })
+	assertPanics(t, func() { AddClusterRoleBindingSubject(nil, subj) })
 }

--- a/pkg/kubernetes/resourcerequirements.go
+++ b/pkg/kubernetes/resourcerequirements.go
@@ -59,12 +59,11 @@ func SetResourceLimit(rr *corev1.ResourceRequirements, name corev1.ResourceName,
 }
 
 // AddResourceClaim appends a ResourceClaim to the ResourceRequirements.
-func AddResourceClaim(rr *corev1.ResourceRequirements, claim corev1.ResourceClaim) error {
+func AddResourceClaim(rr *corev1.ResourceRequirements, claim corev1.ResourceClaim) {
 	if rr == nil {
-		return errors.ErrNilResourceRequirements
+		panic("AddResourceClaim: rr must not be nil")
 	}
 	rr.Claims = append(rr.Claims, claim)
-	return nil
 }
 
 func setResourceQuantity(rr *corev1.ResourceRequirements, name corev1.ResourceName, value string, isRequest bool) error {

--- a/pkg/kubernetes/resourcerequirements_test.go
+++ b/pkg/kubernetes/resourcerequirements_test.go
@@ -115,9 +115,7 @@ func TestSetResourceLimit(t *testing.T) {
 func TestAddResourceClaim(t *testing.T) {
 	rr := CreateResourceRequirements()
 	claim := corev1.ResourceClaim{Name: "my-gpu-claim"}
-	if err := AddResourceClaim(rr, claim); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	AddResourceClaim(rr, claim)
 	if len(rr.Claims) != 1 {
 		t.Fatalf("expected 1 claim, got %d", len(rr.Claims))
 	}
@@ -127,15 +125,15 @@ func TestAddResourceClaim(t *testing.T) {
 }
 
 func TestResourceRequirementsNilErrors(t *testing.T) {
+	// SetResource* functions still return error (can fail on quantity parse)
 	if err := SetResourceRequestCPU(nil, "100m"); err == nil {
 		t.Error("expected error for nil ResourceRequirements")
 	}
 	if err := SetResourceLimitMemory(nil, "256Mi"); err == nil {
 		t.Error("expected error for nil ResourceRequirements")
 	}
-	if err := AddResourceClaim(nil, corev1.ResourceClaim{Name: "test"}); err == nil {
-		t.Error("expected error for nil ResourceRequirements")
-	}
+	// AddResourceClaim now panics on nil receiver
+	assertPanics(t, func() { AddResourceClaim(nil, corev1.ResourceClaim{Name: "test"}) })
 }
 
 func TestResourceRequirementsInvalidQuantity(t *testing.T) {

--- a/pkg/kubernetes/service.go
+++ b/pkg/kubernetes/service.go
@@ -3,8 +3,6 @@ package kubernetes
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/go-kure/kure/pkg/errors"
 )
 
 // CreateService creates a new v1 Service with the given name and namespace.
@@ -34,213 +32,191 @@ func CreateService(name string, namespace string) *corev1.Service {
 }
 
 // AddServicePort appends a port to the Service spec.
-func AddServicePort(service *corev1.Service, port corev1.ServicePort) error {
+func AddServicePort(service *corev1.Service, port corev1.ServicePort) {
 	if service == nil {
-		return errors.ErrNilService
+		panic("AddServicePort: service must not be nil")
 	}
 	service.Spec.Ports = append(service.Spec.Ports, port)
-	return nil
 }
 
 // SetServiceSelector sets the selector map on the Service spec.
-func SetServiceSelector(service *corev1.Service, selector map[string]string) error {
+func SetServiceSelector(service *corev1.Service, selector map[string]string) {
 	if service == nil {
-		return errors.ErrNilService
+		panic("SetServiceSelector: service must not be nil")
 	}
 	service.Spec.Selector = selector
-	return nil
 }
 
 // SetServiceType sets the service type (ClusterIP, NodePort, LoadBalancer, etc.).
-func SetServiceType(service *corev1.Service, type_ corev1.ServiceType) error {
+func SetServiceType(service *corev1.Service, type_ corev1.ServiceType) {
 	if service == nil {
-		return errors.ErrNilService
+		panic("SetServiceType: service must not be nil")
 	}
 	service.Spec.Type = type_
-	return nil
 }
 
 // SetServiceClusterIP sets the clusterIP on the Service spec.
-func SetServiceClusterIP(service *corev1.Service, ip string) error {
+func SetServiceClusterIP(service *corev1.Service, ip string) {
 	if service == nil {
-		return errors.ErrNilService
+		panic("SetServiceClusterIP: service must not be nil")
 	}
 	service.Spec.ClusterIP = ip
-	return nil
 }
 
 // AddServiceExternalIP appends an external IP address to the Service spec.
-func AddServiceExternalIP(service *corev1.Service, ip string) error {
+func AddServiceExternalIP(service *corev1.Service, ip string) {
 	if service == nil {
-		return errors.ErrNilService
+		panic("AddServiceExternalIP: service must not be nil")
 	}
 	service.Spec.ExternalIPs = append(service.Spec.ExternalIPs, ip)
-	return nil
 }
 
 // SetServiceExternalTrafficPolicy sets the external traffic policy on the
 // Service spec.
-func SetServiceExternalTrafficPolicy(service *corev1.Service, trafficPolicy corev1.ServiceExternalTrafficPolicy) error {
+func SetServiceExternalTrafficPolicy(service *corev1.Service, trafficPolicy corev1.ServiceExternalTrafficPolicy) {
 	if service == nil {
-		return errors.ErrNilService
+		panic("SetServiceExternalTrafficPolicy: service must not be nil")
 	}
 	service.Spec.ExternalTrafficPolicy = trafficPolicy
-	return nil
 }
 
 // SetServiceSessionAffinity sets the session affinity on the Service spec.
-func SetServiceSessionAffinity(service *corev1.Service, affinity corev1.ServiceAffinity) error {
+func SetServiceSessionAffinity(service *corev1.Service, affinity corev1.ServiceAffinity) {
 	if service == nil {
-		return errors.ErrNilService
+		panic("SetServiceSessionAffinity: service must not be nil")
 	}
 	service.Spec.SessionAffinity = affinity
-	return nil
 }
 
 // SetServiceLoadBalancerClass sets the load balancer class on the Service spec.
-func SetServiceLoadBalancerClass(service *corev1.Service, class string) error {
+func SetServiceLoadBalancerClass(service *corev1.Service, class string) {
 	if service == nil {
-		return errors.ErrNilService
+		panic("SetServiceLoadBalancerClass: service must not be nil")
 	}
 	service.Spec.LoadBalancerClass = &class
-	return nil
 }
 
 // AddServiceLabel adds a single label to the Service metadata.
-func AddServiceLabel(svc *corev1.Service, key, value string) error {
+func AddServiceLabel(svc *corev1.Service, key, value string) {
 	if svc == nil {
-		return errors.ErrNilService
+		panic("AddServiceLabel: svc must not be nil")
 	}
 	if svc.Labels == nil {
 		svc.Labels = make(map[string]string)
 	}
 	svc.Labels[key] = value
-	return nil
 }
 
 // AddServiceAnnotation adds a single annotation to the Service metadata.
-func AddServiceAnnotation(svc *corev1.Service, key, value string) error {
+func AddServiceAnnotation(svc *corev1.Service, key, value string) {
 	if svc == nil {
-		return errors.ErrNilService
+		panic("AddServiceAnnotation: svc must not be nil")
 	}
 	if svc.Annotations == nil {
 		svc.Annotations = make(map[string]string)
 	}
 	svc.Annotations[key] = value
-	return nil
 }
 
 // SetServiceLabels replaces the labels on the Service with the provided map.
-func SetServiceLabels(svc *corev1.Service, labels map[string]string) error {
+func SetServiceLabels(svc *corev1.Service, labels map[string]string) {
 	if svc == nil {
-		return errors.ErrNilService
+		panic("SetServiceLabels: svc must not be nil")
 	}
 	svc.Labels = labels
-	return nil
 }
 
 // SetServiceAnnotations replaces the annotations on the Service with the
 // provided map.
-func SetServiceAnnotations(svc *corev1.Service, anns map[string]string) error {
+func SetServiceAnnotations(svc *corev1.Service, anns map[string]string) {
 	if svc == nil {
-		return errors.ErrNilService
+		panic("SetServiceAnnotations: svc must not be nil")
 	}
 	svc.Annotations = anns
-	return nil
 }
 
 // SetServicePublishNotReadyAddresses sets whether endpoints for not-ready pods
 // are published.
-func SetServicePublishNotReadyAddresses(svc *corev1.Service, publish bool) error {
+func SetServicePublishNotReadyAddresses(svc *corev1.Service, publish bool) {
 	if svc == nil {
-		return errors.ErrNilService
+		panic("SetServicePublishNotReadyAddresses: svc must not be nil")
 	}
 	svc.Spec.PublishNotReadyAddresses = publish
-	return nil
 }
 
 // AddServiceLoadBalancerSourceRange appends a CIDR to the allowed source ranges
 // for a load balancer Service.
-func AddServiceLoadBalancerSourceRange(svc *corev1.Service, cidr string) error {
+func AddServiceLoadBalancerSourceRange(svc *corev1.Service, cidr string) {
 	if svc == nil {
-		return errors.ErrNilService
+		panic("AddServiceLoadBalancerSourceRange: svc must not be nil")
 	}
 	svc.Spec.LoadBalancerSourceRanges = append(svc.Spec.LoadBalancerSourceRanges, cidr)
-	return nil
 }
 
 // SetServiceLoadBalancerSourceRanges replaces the load balancer source ranges
 // on the Service spec.
-func SetServiceLoadBalancerSourceRanges(svc *corev1.Service, ranges []string) error {
+func SetServiceLoadBalancerSourceRanges(svc *corev1.Service, ranges []string) {
 	if svc == nil {
-		return errors.ErrNilService
+		panic("SetServiceLoadBalancerSourceRanges: svc must not be nil")
 	}
 	svc.Spec.LoadBalancerSourceRanges = ranges
-	return nil
 }
 
 // SetServiceIPFamilies sets the IP families on the Service spec.
-func SetServiceIPFamilies(svc *corev1.Service, fams []corev1.IPFamily) error {
+func SetServiceIPFamilies(svc *corev1.Service, fams []corev1.IPFamily) {
 	if svc == nil {
-		return errors.ErrNilService
+		panic("SetServiceIPFamilies: svc must not be nil")
 	}
 	svc.Spec.IPFamilies = fams
-	return nil
 }
 
 // SetServiceIPFamilyPolicy sets the IP family policy on the Service spec.
-func SetServiceIPFamilyPolicy(svc *corev1.Service, policy *corev1.IPFamilyPolicy) error {
+func SetServiceIPFamilyPolicy(svc *corev1.Service, policy *corev1.IPFamilyPolicy) {
 	if svc == nil {
-		return errors.ErrNilService
+		panic("SetServiceIPFamilyPolicy: svc must not be nil")
 	}
 	svc.Spec.IPFamilyPolicy = policy
-	return nil
 }
 
 // SetServiceInternalTrafficPolicy sets the internal traffic policy on the
 // Service spec.
-func SetServiceInternalTrafficPolicy(svc *corev1.Service, policy *corev1.ServiceInternalTrafficPolicy) error {
+func SetServiceInternalTrafficPolicy(svc *corev1.Service, policy *corev1.ServiceInternalTrafficPolicy) {
 	if svc == nil {
-		return errors.ErrNilService
+		panic("SetServiceInternalTrafficPolicy: svc must not be nil")
 	}
 	svc.Spec.InternalTrafficPolicy = policy
-	return nil
 }
 
 // SetServiceAllocateLoadBalancerNodePorts controls whether node ports are
 // allocated for a LoadBalancer Service.
-func SetServiceAllocateLoadBalancerNodePorts(svc *corev1.Service, allocate bool) error {
+func SetServiceAllocateLoadBalancerNodePorts(svc *corev1.Service, allocate bool) {
 	if svc == nil {
-		return errors.ErrNilService
+		panic("SetServiceAllocateLoadBalancerNodePorts: svc must not be nil")
 	}
 	svc.Spec.AllocateLoadBalancerNodePorts = &allocate
-	return nil
 }
 
 // SetServiceExternalName sets the externalName field for ExternalName services.
-func SetServiceExternalName(svc *corev1.Service, name string) error {
+func SetServiceExternalName(svc *corev1.Service, name string) {
 	if svc == nil {
-		return errors.ErrNilService
+		panic("SetServiceExternalName: svc must not be nil")
 	}
 	svc.Spec.ExternalName = name
-	return nil
 }
 
 // SetServiceHealthCheckNodePort sets the healthCheckNodePort field for
 // LoadBalancer services.
-func SetServiceHealthCheckNodePort(svc *corev1.Service, port int32) error {
+func SetServiceHealthCheckNodePort(svc *corev1.Service, port int32) {
 	if svc == nil {
-		return errors.ErrNilService
+		panic("SetServiceHealthCheckNodePort: svc must not be nil")
 	}
 	svc.Spec.HealthCheckNodePort = port
-	return nil
 }
 
 // SetServiceSessionAffinityConfig configures the session affinity options.
-func SetServiceSessionAffinityConfig(svc *corev1.Service, cfg *corev1.SessionAffinityConfig) error {
+func SetServiceSessionAffinityConfig(svc *corev1.Service, cfg *corev1.SessionAffinityConfig) {
 	if svc == nil {
-		return errors.ErrNilService
+		panic("SetServiceSessionAffinityConfig: svc must not be nil")
 	}
 	svc.Spec.SessionAffinityConfig = cfg
-	return nil
 }

--- a/pkg/kubernetes/service_test.go
+++ b/pkg/kubernetes/service_test.go
@@ -25,72 +25,29 @@ func TestCreateService(t *testing.T) {
 }
 
 func TestServiceNilErrors(t *testing.T) {
-	if err := AddServicePort(nil, corev1.ServicePort{}); err == nil {
-		t.Error("expected error for nil Service on AddServicePort")
-	}
-	if err := SetServiceSelector(nil, map[string]string{}); err == nil {
-		t.Error("expected error for nil Service on SetServiceSelector")
-	}
-	if err := SetServiceType(nil, corev1.ServiceTypeClusterIP); err == nil {
-		t.Error("expected error for nil Service on SetServiceType")
-	}
-	if err := SetServiceClusterIP(nil, "10.0.0.1"); err == nil {
-		t.Error("expected error for nil Service on SetServiceClusterIP")
-	}
-	if err := AddServiceExternalIP(nil, "1.2.3.4"); err == nil {
-		t.Error("expected error for nil Service on AddServiceExternalIP")
-	}
-	if err := SetServiceExternalTrafficPolicy(nil, corev1.ServiceExternalTrafficPolicyLocal); err == nil {
-		t.Error("expected error for nil Service on SetServiceExternalTrafficPolicy")
-	}
-	if err := SetServiceSessionAffinity(nil, corev1.ServiceAffinityClientIP); err == nil {
-		t.Error("expected error for nil Service on SetServiceSessionAffinity")
-	}
-	if err := SetServiceLoadBalancerClass(nil, "x"); err == nil {
-		t.Error("expected error for nil Service on SetServiceLoadBalancerClass")
-	}
-	if err := AddServiceLabel(nil, "k", "v"); err == nil {
-		t.Error("expected error for nil Service on AddServiceLabel")
-	}
-	if err := AddServiceAnnotation(nil, "k", "v"); err == nil {
-		t.Error("expected error for nil Service on AddServiceAnnotation")
-	}
-	if err := SetServiceLabels(nil, nil); err == nil {
-		t.Error("expected error for nil Service on SetServiceLabels")
-	}
-	if err := SetServiceAnnotations(nil, nil); err == nil {
-		t.Error("expected error for nil Service on SetServiceAnnotations")
-	}
-	if err := SetServicePublishNotReadyAddresses(nil, true); err == nil {
-		t.Error("expected error for nil Service on SetServicePublishNotReadyAddresses")
-	}
-	if err := AddServiceLoadBalancerSourceRange(nil, "10.0.0.0/24"); err == nil {
-		t.Error("expected error for nil Service on AddServiceLoadBalancerSourceRange")
-	}
-	if err := SetServiceLoadBalancerSourceRanges(nil, nil); err == nil {
-		t.Error("expected error for nil Service on SetServiceLoadBalancerSourceRanges")
-	}
-	if err := SetServiceIPFamilies(nil, nil); err == nil {
-		t.Error("expected error for nil Service on SetServiceIPFamilies")
-	}
-	if err := SetServiceIPFamilyPolicy(nil, nil); err == nil {
-		t.Error("expected error for nil Service on SetServiceIPFamilyPolicy")
-	}
-	if err := SetServiceInternalTrafficPolicy(nil, nil); err == nil {
-		t.Error("expected error for nil Service on SetServiceInternalTrafficPolicy")
-	}
-	if err := SetServiceAllocateLoadBalancerNodePorts(nil, false); err == nil {
-		t.Error("expected error for nil Service on SetServiceAllocateLoadBalancerNodePorts")
-	}
-	if err := SetServiceExternalName(nil, "example.com"); err == nil {
-		t.Error("expected error for nil Service on SetServiceExternalName")
-	}
-	if err := SetServiceHealthCheckNodePort(nil, 30000); err == nil {
-		t.Error("expected error for nil Service on SetServiceHealthCheckNodePort")
-	}
-	if err := SetServiceSessionAffinityConfig(nil, nil); err == nil {
-		t.Error("expected error for nil Service on SetServiceSessionAffinityConfig")
-	}
+	// All Service functions now panic on nil receiver
+	assertPanics(t, func() { AddServicePort(nil, corev1.ServicePort{}) })
+	assertPanics(t, func() { SetServiceSelector(nil, map[string]string{}) })
+	assertPanics(t, func() { SetServiceType(nil, corev1.ServiceTypeClusterIP) })
+	assertPanics(t, func() { SetServiceClusterIP(nil, "10.0.0.1") })
+	assertPanics(t, func() { AddServiceExternalIP(nil, "1.2.3.4") })
+	assertPanics(t, func() { SetServiceExternalTrafficPolicy(nil, corev1.ServiceExternalTrafficPolicyLocal) })
+	assertPanics(t, func() { SetServiceSessionAffinity(nil, corev1.ServiceAffinityClientIP) })
+	assertPanics(t, func() { SetServiceLoadBalancerClass(nil, "x") })
+	assertPanics(t, func() { AddServiceLabel(nil, "k", "v") })
+	assertPanics(t, func() { AddServiceAnnotation(nil, "k", "v") })
+	assertPanics(t, func() { SetServiceLabels(nil, nil) })
+	assertPanics(t, func() { SetServiceAnnotations(nil, nil) })
+	assertPanics(t, func() { SetServicePublishNotReadyAddresses(nil, true) })
+	assertPanics(t, func() { AddServiceLoadBalancerSourceRange(nil, "10.0.0.0/24") })
+	assertPanics(t, func() { SetServiceLoadBalancerSourceRanges(nil, nil) })
+	assertPanics(t, func() { SetServiceIPFamilies(nil, nil) })
+	assertPanics(t, func() { SetServiceIPFamilyPolicy(nil, nil) })
+	assertPanics(t, func() { SetServiceInternalTrafficPolicy(nil, nil) })
+	assertPanics(t, func() { SetServiceAllocateLoadBalancerNodePorts(nil, false) })
+	assertPanics(t, func() { SetServiceExternalName(nil, "example.com") })
+	assertPanics(t, func() { SetServiceHealthCheckNodePort(nil, 30000) })
+	assertPanics(t, func() { SetServiceSessionAffinityConfig(nil, nil) })
 }
 
 func TestServiceFunctions(t *testing.T) {
@@ -100,133 +57,97 @@ func TestServiceFunctions(t *testing.T) {
 	}
 
 	port := corev1.ServicePort{Name: "http", Port: 80}
-	if err := AddServicePort(svc, port); err != nil {
-		t.Fatalf("AddServicePort returned error: %v", err)
-	}
+	AddServicePort(svc, port)
 	if len(svc.Spec.Ports) != 1 || svc.Spec.Ports[0] != port {
 		t.Errorf("port not added correctly: %+v", svc.Spec.Ports)
 	}
 
 	selector := map[string]string{"app": "svc"}
-	if err := SetServiceSelector(svc, selector); err != nil {
-		t.Fatalf("SetServiceSelector returned error: %v", err)
-	}
+	SetServiceSelector(svc, selector)
 	if !reflect.DeepEqual(svc.Spec.Selector, selector) {
 		t.Errorf("selector not set: %+v", svc.Spec.Selector)
 	}
 
-	if err := SetServiceType(svc, corev1.ServiceTypeNodePort); err != nil {
-		t.Fatalf("SetServiceType returned error: %v", err)
-	}
+	SetServiceType(svc, corev1.ServiceTypeNodePort)
 	if svc.Spec.Type != corev1.ServiceTypeNodePort {
 		t.Errorf("service type not set")
 	}
 
-	if err := SetServiceExternalTrafficPolicy(svc, corev1.ServiceExternalTrafficPolicyLocal); err != nil {
-		t.Fatalf("SetServiceExternalTrafficPolicy returned error: %v", err)
-	}
+	SetServiceExternalTrafficPolicy(svc, corev1.ServiceExternalTrafficPolicyLocal)
 	if svc.Spec.ExternalTrafficPolicy != corev1.ServiceExternalTrafficPolicyLocal {
 		t.Errorf("external traffic policy not set")
 	}
 
-	if err := SetServiceSessionAffinity(svc, corev1.ServiceAffinityClientIP); err != nil {
-		t.Fatalf("SetServiceSessionAffinity returned error: %v", err)
-	}
+	SetServiceSessionAffinity(svc, corev1.ServiceAffinityClientIP)
 	if svc.Spec.SessionAffinity != corev1.ServiceAffinityClientIP {
 		t.Errorf("session affinity not set")
 	}
 
-	if err := SetServiceLoadBalancerClass(svc, "lb-class"); err != nil {
-		t.Fatalf("SetServiceLoadBalancerClass returned error: %v", err)
-	}
+	SetServiceLoadBalancerClass(svc, "lb-class")
 	if svc.Spec.LoadBalancerClass == nil || *svc.Spec.LoadBalancerClass != "lb-class" {
 		t.Errorf("load balancer class not set")
 	}
 
-	if err := SetServiceClusterIP(svc, "10.0.0.1"); err != nil {
-		t.Fatalf("SetServiceClusterIP returned error: %v", err)
-	}
+	SetServiceClusterIP(svc, "10.0.0.1")
 	if svc.Spec.ClusterIP != "10.0.0.1" {
 		t.Errorf("clusterIP not set")
 	}
 
-	if err := AddServiceExternalIP(svc, "192.168.1.2"); err != nil {
-		t.Fatalf("AddServiceExternalIP returned error: %v", err)
-	}
+	AddServiceExternalIP(svc, "192.168.1.2")
 	if len(svc.Spec.ExternalIPs) != 1 || svc.Spec.ExternalIPs[0] != "192.168.1.2" {
 		t.Errorf("external IP not added")
 	}
 
-	if err := SetServicePublishNotReadyAddresses(svc, true); err != nil {
-		t.Fatalf("SetServicePublishNotReadyAddresses returned error: %v", err)
-	}
+	SetServicePublishNotReadyAddresses(svc, true)
 	if !svc.Spec.PublishNotReadyAddresses {
 		t.Errorf("publish not ready addresses not set")
 	}
 
-	if err := AddServiceLoadBalancerSourceRange(svc, "10.0.0.0/24"); err != nil {
-		t.Fatalf("AddServiceLoadBalancerSourceRange returned error: %v", err)
-	}
+	AddServiceLoadBalancerSourceRange(svc, "10.0.0.0/24")
 	if len(svc.Spec.LoadBalancerSourceRanges) != 1 || svc.Spec.LoadBalancerSourceRanges[0] != "10.0.0.0/24" {
 		t.Errorf("source range not added")
 	}
 
 	ranges := []string{"10.0.1.0/24", "10.0.2.0/24"}
-	if err := SetServiceLoadBalancerSourceRanges(svc, ranges); err != nil {
-		t.Fatalf("SetServiceLoadBalancerSourceRanges returned error: %v", err)
-	}
+	SetServiceLoadBalancerSourceRanges(svc, ranges)
 	if !reflect.DeepEqual(svc.Spec.LoadBalancerSourceRanges, ranges) {
 		t.Errorf("source ranges not set")
 	}
 
-	if err := SetServiceIPFamilies(svc, []corev1.IPFamily{corev1.IPv4Protocol}); err != nil {
-		t.Fatalf("SetServiceIPFamilies returned error: %v", err)
-	}
+	SetServiceIPFamilies(svc, []corev1.IPFamily{corev1.IPv4Protocol})
 	if len(svc.Spec.IPFamilies) != 1 || svc.Spec.IPFamilies[0] != corev1.IPv4Protocol {
 		t.Errorf("ip families not set")
 	}
 
 	policy := corev1.IPFamilyPolicyPreferDualStack
-	if err := SetServiceIPFamilyPolicy(svc, &policy); err != nil {
-		t.Fatalf("SetServiceIPFamilyPolicy returned error: %v", err)
-	}
+	SetServiceIPFamilyPolicy(svc, &policy)
 	if svc.Spec.IPFamilyPolicy == nil || *svc.Spec.IPFamilyPolicy != policy {
 		t.Errorf("ip family policy not set")
 	}
 
 	itp := corev1.ServiceInternalTrafficPolicyLocal
-	if err := SetServiceInternalTrafficPolicy(svc, &itp); err != nil {
-		t.Fatalf("SetServiceInternalTrafficPolicy returned error: %v", err)
-	}
+	SetServiceInternalTrafficPolicy(svc, &itp)
 	if svc.Spec.InternalTrafficPolicy == nil || *svc.Spec.InternalTrafficPolicy != itp {
 		t.Errorf("internal traffic policy not set")
 	}
 
-	if err := SetServiceAllocateLoadBalancerNodePorts(svc, false); err != nil {
-		t.Fatalf("SetServiceAllocateLoadBalancerNodePorts returned error: %v", err)
-	}
+	SetServiceAllocateLoadBalancerNodePorts(svc, false)
 	if svc.Spec.AllocateLoadBalancerNodePorts == nil || *svc.Spec.AllocateLoadBalancerNodePorts {
 		t.Errorf("allocate LB node ports not set")
 	}
 
-	if err := SetServiceExternalName(svc, "example.com"); err != nil {
-		t.Fatalf("SetServiceExternalName returned error: %v", err)
-	}
+	SetServiceExternalName(svc, "example.com")
 	if svc.Spec.ExternalName != "example.com" {
 		t.Errorf("external name not set")
 	}
 
-	if err := SetServiceHealthCheckNodePort(svc, 30000); err != nil {
-		t.Fatalf("SetServiceHealthCheckNodePort returned error: %v", err)
-	}
+	SetServiceHealthCheckNodePort(svc, 30000)
 	if svc.Spec.HealthCheckNodePort != 30000 {
 		t.Errorf("health check node port not set")
 	}
 
 	cfg := &corev1.SessionAffinityConfig{ClientIP: &corev1.ClientIPConfig{TimeoutSeconds: new(int32)}}
-	if err := SetServiceSessionAffinityConfig(svc, cfg); err != nil {
-		t.Fatalf("SetServiceSessionAffinityConfig returned error: %v", err)
-	}
+	SetServiceSessionAffinityConfig(svc, cfg)
 	if svc.Spec.SessionAffinityConfig != cfg {
 		t.Errorf("session affinity config not set")
 	}
@@ -235,32 +156,24 @@ func TestServiceFunctions(t *testing.T) {
 func TestServiceMetadataFunctions(t *testing.T) {
 	svc := CreateService("svc", "ns")
 
-	if err := AddServiceLabel(svc, "k", "v"); err != nil {
-		t.Fatalf("AddServiceLabel returned error: %v", err)
-	}
+	AddServiceLabel(svc, "k", "v")
 	if svc.Labels["k"] != "v" {
 		t.Errorf("label not added")
 	}
 
-	if err := AddServiceAnnotation(svc, "a", "b"); err != nil {
-		t.Fatalf("AddServiceAnnotation returned error: %v", err)
-	}
+	AddServiceAnnotation(svc, "a", "b")
 	if svc.Annotations["a"] != "b" {
 		t.Errorf("annotation not added")
 	}
 
 	labels := map[string]string{"x": "y"}
-	if err := SetServiceLabels(svc, labels); err != nil {
-		t.Fatalf("SetServiceLabels returned error: %v", err)
-	}
+	SetServiceLabels(svc, labels)
 	if !reflect.DeepEqual(svc.Labels, labels) {
 		t.Errorf("labels not set")
 	}
 
 	anns := map[string]string{"c": "d"}
-	if err := SetServiceAnnotations(svc, anns); err != nil {
-		t.Fatalf("SetServiceAnnotations returned error: %v", err)
-	}
+	SetServiceAnnotations(svc, anns)
 	if !reflect.DeepEqual(svc.Annotations, anns) {
 		t.Errorf("annotations not set")
 	}
@@ -273,9 +186,7 @@ func TestAddServicePort_Success(t *testing.T) {
 		Port:       80,
 		TargetPort: intstr.FromInt(8080),
 	}
-	if err := AddServicePort(svc, port); err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	AddServicePort(svc, port)
 	if len(svc.Spec.Ports) != 1 {
 		t.Fatal("expected Port to be added")
 	}

--- a/pkg/kubernetes/serviceaccount.go
+++ b/pkg/kubernetes/serviceaccount.go
@@ -1,8 +1,6 @@
 package kubernetes
 
 import (
-	"github.com/go-kure/kure/pkg/errors"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -30,47 +28,42 @@ func CreateServiceAccount(name, namespace string) *corev1.ServiceAccount {
 	return obj
 }
 
-func AddServiceAccountSecret(sa *corev1.ServiceAccount, secret corev1.ObjectReference) error {
+func AddServiceAccountSecret(sa *corev1.ServiceAccount, secret corev1.ObjectReference) {
 	if sa == nil {
-		return errors.ErrNilServiceAccount
+		panic("AddServiceAccountSecret: sa must not be nil")
 	}
 	sa.Secrets = append(sa.Secrets, secret)
-	return nil
 }
 
-func AddServiceAccountImagePullSecret(sa *corev1.ServiceAccount, secret corev1.LocalObjectReference) error {
+func AddServiceAccountImagePullSecret(sa *corev1.ServiceAccount, secret corev1.LocalObjectReference) {
 	if sa == nil {
-		return errors.ErrNilServiceAccount
+		panic("AddServiceAccountImagePullSecret: sa must not be nil")
 	}
 	sa.ImagePullSecrets = append(sa.ImagePullSecrets, secret)
-	return nil
 }
 
-func SetServiceAccountSecrets(sa *corev1.ServiceAccount, secrets []corev1.ObjectReference) error {
+func SetServiceAccountSecrets(sa *corev1.ServiceAccount, secrets []corev1.ObjectReference) {
 	if sa == nil {
-		return errors.ErrNilServiceAccount
+		panic("SetServiceAccountSecrets: sa must not be nil")
 	}
 	sa.Secrets = secrets
-	return nil
 }
 
-func SetServiceAccountImagePullSecrets(sa *corev1.ServiceAccount, secrets []corev1.LocalObjectReference) error {
+func SetServiceAccountImagePullSecrets(sa *corev1.ServiceAccount, secrets []corev1.LocalObjectReference) {
 	if sa == nil {
-		return errors.ErrNilServiceAccount
+		panic("SetServiceAccountImagePullSecrets: sa must not be nil")
 	}
 	sa.ImagePullSecrets = secrets
-	return nil
 }
 
-func SetServiceAccountAutomountToken(sa *corev1.ServiceAccount, automount bool) error {
+func SetServiceAccountAutomountToken(sa *corev1.ServiceAccount, automount bool) {
 	if sa == nil {
-		return errors.ErrNilServiceAccount
+		panic("SetServiceAccountAutomountToken: sa must not be nil")
 	}
 	if sa.AutomountServiceAccountToken == nil {
 		sa.AutomountServiceAccountToken = new(bool)
 	}
 	*sa.AutomountServiceAccountToken = automount
-	return nil
 }
 
 func AddServiceAccountLabel(sa *corev1.ServiceAccount, key, value string) {

--- a/pkg/kubernetes/serviceaccount_test.go
+++ b/pkg/kubernetes/serviceaccount_test.go
@@ -32,9 +32,7 @@ func TestCreateServiceAccount(t *testing.T) {
 func TestAddServiceAccountSecret(t *testing.T) {
 	sa := CreateServiceAccount("sa", "ns")
 	ref := corev1.ObjectReference{Name: "secret"}
-	if err := AddServiceAccountSecret(sa, ref); err != nil {
-		t.Fatalf("AddServiceAccountSecret returned error: %v", err)
-	}
+	AddServiceAccountSecret(sa, ref)
 	if len(sa.Secrets) != 1 || sa.Secrets[0] != ref {
 		t.Errorf("secret not added")
 	}
@@ -43,9 +41,7 @@ func TestAddServiceAccountSecret(t *testing.T) {
 func TestAddServiceAccountImagePullSecret(t *testing.T) {
 	sa := CreateServiceAccount("sa", "ns")
 	ref := corev1.LocalObjectReference{Name: "pullsecret"}
-	if err := AddServiceAccountImagePullSecret(sa, ref); err != nil {
-		t.Fatalf("AddServiceAccountImagePullSecret returned error: %v", err)
-	}
+	AddServiceAccountImagePullSecret(sa, ref)
 	if len(sa.ImagePullSecrets) != 1 || sa.ImagePullSecrets[0] != ref {
 		t.Errorf("image pull secret not added")
 	}
@@ -54,9 +50,7 @@ func TestAddServiceAccountImagePullSecret(t *testing.T) {
 func TestSetServiceAccountSecrets(t *testing.T) {
 	sa := CreateServiceAccount("sa", "ns")
 	secrets := []corev1.ObjectReference{{Name: "a"}, {Name: "b"}}
-	if err := SetServiceAccountSecrets(sa, secrets); err != nil {
-		t.Fatalf("SetServiceAccountSecrets returned error: %v", err)
-	}
+	SetServiceAccountSecrets(sa, secrets)
 	if !reflect.DeepEqual(sa.Secrets, secrets) {
 		t.Errorf("secrets not set")
 	}
@@ -65,9 +59,7 @@ func TestSetServiceAccountSecrets(t *testing.T) {
 func TestSetServiceAccountImagePullSecrets(t *testing.T) {
 	sa := CreateServiceAccount("sa", "ns")
 	pulls := []corev1.LocalObjectReference{{Name: "x"}, {Name: "y"}}
-	if err := SetServiceAccountImagePullSecrets(sa, pulls); err != nil {
-		t.Fatalf("SetServiceAccountImagePullSecrets returned error: %v", err)
-	}
+	SetServiceAccountImagePullSecrets(sa, pulls)
 	if !reflect.DeepEqual(sa.ImagePullSecrets, pulls) {
 		t.Errorf("image pull secrets not set")
 	}
@@ -75,15 +67,11 @@ func TestSetServiceAccountImagePullSecrets(t *testing.T) {
 
 func TestSetServiceAccountAutomountToken(t *testing.T) {
 	sa := CreateServiceAccount("sa", "ns")
-	if err := SetServiceAccountAutomountToken(sa, true); err != nil {
-		t.Fatalf("SetServiceAccountAutomountToken returned error: %v", err)
-	}
+	SetServiceAccountAutomountToken(sa, true)
 	if sa.AutomountServiceAccountToken == nil || !*sa.AutomountServiceAccountToken {
 		t.Errorf("automount token not set to true")
 	}
-	if err := SetServiceAccountAutomountToken(sa, false); err != nil {
-		t.Fatalf("SetServiceAccountAutomountToken returned error: %v", err)
-	}
+	SetServiceAccountAutomountToken(sa, false)
 	if sa.AutomountServiceAccountToken == nil || *sa.AutomountServiceAccountToken {
 		t.Errorf("automount token not updated to false")
 	}
@@ -114,23 +102,9 @@ func TestServiceAccountMetadataFunctions(t *testing.T) {
 }
 
 func TestServiceAccountNilGuards(t *testing.T) {
-	tests := []struct {
-		name string
-		fn   func() error
-	}{
-		{"AddServiceAccountSecret", func() error { return AddServiceAccountSecret(nil, corev1.ObjectReference{}) }},
-		{"AddServiceAccountImagePullSecret", func() error {
-			return AddServiceAccountImagePullSecret(nil, corev1.LocalObjectReference{})
-		}},
-		{"SetServiceAccountSecrets", func() error { return SetServiceAccountSecrets(nil, nil) }},
-		{"SetServiceAccountImagePullSecrets", func() error { return SetServiceAccountImagePullSecrets(nil, nil) }},
-		{"SetServiceAccountAutomountToken", func() error { return SetServiceAccountAutomountToken(nil, true) }},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.fn(); err == nil {
-				t.Errorf("%s(nil) should return error", tt.name)
-			}
-		})
-	}
+	assertPanics(t, func() { AddServiceAccountSecret(nil, corev1.ObjectReference{}) })
+	assertPanics(t, func() { AddServiceAccountImagePullSecret(nil, corev1.LocalObjectReference{}) })
+	assertPanics(t, func() { SetServiceAccountSecrets(nil, nil) })
+	assertPanics(t, func() { SetServiceAccountImagePullSecrets(nil, nil) })
+	assertPanics(t, func() { SetServiceAccountAutomountToken(nil, true) })
 }

--- a/pkg/kubernetes/setters_test.go
+++ b/pkg/kubernetes/setters_test.go
@@ -12,10 +12,7 @@ import (
 func TestAddContainerPort_Success(t *testing.T) {
 	container := CreateContainer("test", "nginx", nil, nil)
 	port := corev1.ContainerPort{ContainerPort: 8080}
-	err := AddContainerPort(container, port)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	AddContainerPort(container, port)
 	if len(container.Ports) != 1 {
 		t.Fatal("expected Port to be added")
 	}
@@ -24,10 +21,7 @@ func TestAddContainerPort_Success(t *testing.T) {
 func TestAddContainerEnv_Success(t *testing.T) {
 	container := CreateContainer("test", "nginx", nil, nil)
 	env := corev1.EnvVar{Name: "KEY", Value: "value"}
-	err := AddContainerEnv(container, env)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	AddContainerEnv(container, env)
 	if len(container.Env) != 1 {
 		t.Fatal("expected Env to be added")
 	}
@@ -36,10 +30,7 @@ func TestAddContainerEnv_Success(t *testing.T) {
 func TestAddContainerEnvFrom_Success(t *testing.T) {
 	container := CreateContainer("test", "nginx", nil, nil)
 	envFrom := corev1.EnvFromSource{}
-	err := AddContainerEnvFrom(container, envFrom)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	AddContainerEnvFrom(container, envFrom)
 	if len(container.EnvFrom) != 1 {
 		t.Fatal("expected EnvFrom to be added")
 	}
@@ -48,10 +39,7 @@ func TestAddContainerEnvFrom_Success(t *testing.T) {
 func TestAddContainerVolumeMount_Success(t *testing.T) {
 	container := CreateContainer("test", "nginx", nil, nil)
 	mount := corev1.VolumeMount{Name: "vol", MountPath: "/data"}
-	err := AddContainerVolumeMount(container, mount)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	AddContainerVolumeMount(container, mount)
 	if len(container.VolumeMounts) != 1 {
 		t.Fatal("expected VolumeMount to be added")
 	}
@@ -60,10 +48,7 @@ func TestAddContainerVolumeMount_Success(t *testing.T) {
 func TestAddContainerVolumeDevice_Success(t *testing.T) {
 	container := CreateContainer("test", "nginx", nil, nil)
 	device := corev1.VolumeDevice{Name: "dev", DevicePath: "/dev/sda"}
-	err := AddContainerVolumeDevice(container, device)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	AddContainerVolumeDevice(container, device)
 	if len(container.VolumeDevices) != 1 {
 		t.Fatal("expected VolumeDevice to be added")
 	}
@@ -72,10 +57,7 @@ func TestAddContainerVolumeDevice_Success(t *testing.T) {
 func TestSetContainerLivenessProbe_Success(t *testing.T) {
 	container := CreateContainer("test", "nginx", nil, nil)
 	probe := corev1.Probe{}
-	err := SetContainerLivenessProbe(container, probe)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetContainerLivenessProbe(container, probe)
 	if container.LivenessProbe == nil {
 		t.Fatal("expected LivenessProbe to be set")
 	}
@@ -84,10 +66,7 @@ func TestSetContainerLivenessProbe_Success(t *testing.T) {
 func TestSetContainerReadinessProbe_Success(t *testing.T) {
 	container := CreateContainer("test", "nginx", nil, nil)
 	probe := corev1.Probe{}
-	err := SetContainerReadinessProbe(container, probe)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetContainerReadinessProbe(container, probe)
 	if container.ReadinessProbe == nil {
 		t.Fatal("expected ReadinessProbe to be set")
 	}
@@ -96,10 +75,7 @@ func TestSetContainerReadinessProbe_Success(t *testing.T) {
 func TestSetContainerStartupProbe_Success(t *testing.T) {
 	container := CreateContainer("test", "nginx", nil, nil)
 	probe := corev1.Probe{}
-	err := SetContainerStartupProbe(container, probe)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetContainerStartupProbe(container, probe)
 	if container.StartupProbe == nil {
 		t.Fatal("expected StartupProbe to be set")
 	}
@@ -112,18 +88,12 @@ func TestSetContainerResources_Success(t *testing.T) {
 			"cpu": resource.MustParse("1"),
 		},
 	}
-	err := SetContainerResources(container, resources)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetContainerResources(container, resources)
 }
 
 func TestSetContainerImagePullPolicy_Success(t *testing.T) {
 	container := CreateContainer("test", "nginx", nil, nil)
-	err := SetContainerImagePullPolicy(container, corev1.PullAlways)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetContainerImagePullPolicy(container, corev1.PullAlways)
 	if container.ImagePullPolicy != corev1.PullAlways {
 		t.Fatal("expected ImagePullPolicy to be set")
 	}
@@ -132,10 +102,7 @@ func TestSetContainerImagePullPolicy_Success(t *testing.T) {
 func TestSetContainerSecurityContext_Success(t *testing.T) {
 	container := CreateContainer("test", "nginx", nil, nil)
 	sc := corev1.SecurityContext{}
-	err := SetContainerSecurityContext(container, sc)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetContainerSecurityContext(container, sc)
 	if container.SecurityContext == nil {
 		t.Fatal("expected SecurityContext to be set")
 	}
@@ -215,55 +182,37 @@ func TestAddDaemonSetTopologySpreadConstraints_Success(t *testing.T) {
 
 func TestSetDaemonSetServiceAccountName_Success(t *testing.T) {
 	ds := CreateDaemonSet("test", "default")
-	err := SetDaemonSetServiceAccountName(ds, "test-sa")
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetDaemonSetServiceAccountName(ds, "test-sa")
 }
 
 func TestSetDaemonSetSecurityContext_Success(t *testing.T) {
 	ds := CreateDaemonSet("test", "default")
 	sc := &corev1.PodSecurityContext{}
-	err := SetDaemonSetSecurityContext(ds, sc)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetDaemonSetSecurityContext(ds, sc)
 }
 
 func TestSetDaemonSetAffinity_Success(t *testing.T) {
 	ds := CreateDaemonSet("test", "default")
 	affinity := &corev1.Affinity{}
-	err := SetDaemonSetAffinity(ds, affinity)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetDaemonSetAffinity(ds, affinity)
 }
 
 func TestSetDaemonSetNodeSelector_Success(t *testing.T) {
 	ds := CreateDaemonSet("test", "default")
 	selector := map[string]string{"key": "value"}
-	err := SetDaemonSetNodeSelector(ds, selector)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetDaemonSetNodeSelector(ds, selector)
 }
 
 func TestSetDaemonSetUpdateStrategy_Success(t *testing.T) {
 	ds := CreateDaemonSet("test", "default")
 	strategy := appsv1.DaemonSetUpdateStrategy{}
-	err := SetDaemonSetUpdateStrategy(ds, strategy)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetDaemonSetUpdateStrategy(ds, strategy)
 }
 
 func TestSetDaemonSetRevisionHistoryLimit_Success(t *testing.T) {
 	ds := CreateDaemonSet("test", "default")
 	limit := int32(5)
-	err := SetDaemonSetRevisionHistoryLimit(ds, &limit)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetDaemonSetRevisionHistoryLimit(ds, &limit)
 	if ds.Spec.RevisionHistoryLimit == nil || *ds.Spec.RevisionHistoryLimit != 5 {
 		t.Fatal("expected RevisionHistoryLimit to be 5")
 	}
@@ -343,45 +292,30 @@ func TestAddJobTopologySpreadConstraint_Success(t *testing.T) {
 
 func TestSetJobServiceAccountName_Success(t *testing.T) {
 	job := CreateJob("test", "default")
-	err := SetJobServiceAccountName(job, "test-sa")
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetJobServiceAccountName(job, "test-sa")
 }
 
 func TestSetJobSecurityContext_Success(t *testing.T) {
 	job := CreateJob("test", "default")
 	sc := &corev1.PodSecurityContext{}
-	err := SetJobSecurityContext(job, sc)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetJobSecurityContext(job, sc)
 }
 
 func TestSetJobAffinity_Success(t *testing.T) {
 	job := CreateJob("test", "default")
 	affinity := &corev1.Affinity{}
-	err := SetJobAffinity(job, affinity)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetJobAffinity(job, affinity)
 }
 
 func TestSetJobNodeSelector_Success(t *testing.T) {
 	job := CreateJob("test", "default")
 	selector := map[string]string{"key": "value"}
-	err := SetJobNodeSelector(job, selector)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetJobNodeSelector(job, selector)
 }
 
 func TestSetJobCompletions_Success(t *testing.T) {
 	job := CreateJob("test", "default")
-	err := SetJobCompletions(job, 1)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetJobCompletions(job, 1)
 	if job.Spec.Completions == nil || *job.Spec.Completions != 1 {
 		t.Fatal("expected Completions to be 1")
 	}
@@ -389,10 +323,7 @@ func TestSetJobCompletions_Success(t *testing.T) {
 
 func TestSetJobParallelism_Success(t *testing.T) {
 	job := CreateJob("test", "default")
-	err := SetJobParallelism(job, 2)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetJobParallelism(job, 2)
 	if job.Spec.Parallelism == nil || *job.Spec.Parallelism != 2 {
 		t.Fatal("expected Parallelism to be 2")
 	}
@@ -400,10 +331,7 @@ func TestSetJobParallelism_Success(t *testing.T) {
 
 func TestSetJobBackoffLimit_Success(t *testing.T) {
 	job := CreateJob("test", "default")
-	err := SetJobBackoffLimit(job, 3)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetJobBackoffLimit(job, 3)
 	if job.Spec.BackoffLimit == nil || *job.Spec.BackoffLimit != 3 {
 		t.Fatal("expected BackoffLimit to be 3")
 	}
@@ -411,10 +339,7 @@ func TestSetJobBackoffLimit_Success(t *testing.T) {
 
 func TestSetJobTTLSecondsAfterFinished_Success(t *testing.T) {
 	job := CreateJob("test", "default")
-	err := SetJobTTLSecondsAfterFinished(job, 100)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetJobTTLSecondsAfterFinished(job, 100)
 	if job.Spec.TTLSecondsAfterFinished == nil || *job.Spec.TTLSecondsAfterFinished != 100 {
 		t.Fatal("expected TTLSecondsAfterFinished to be 100")
 	}
@@ -423,10 +348,7 @@ func TestSetJobTTLSecondsAfterFinished_Success(t *testing.T) {
 func TestSetJobActiveDeadlineSeconds_Success(t *testing.T) {
 	job := CreateJob("test", "default")
 	secs := int64(600)
-	err := SetJobActiveDeadlineSeconds(job, &secs)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetJobActiveDeadlineSeconds(job, &secs)
 	if job.Spec.ActiveDeadlineSeconds == nil || *job.Spec.ActiveDeadlineSeconds != 600 {
 		t.Fatal("expected ActiveDeadlineSeconds to be 600")
 	}
@@ -435,10 +357,7 @@ func TestSetJobActiveDeadlineSeconds_Success(t *testing.T) {
 // StatefulSet setter tests
 func TestSetStatefulSetReplicas_Success(t *testing.T) {
 	ss := CreateStatefulSet("test", "default")
-	err := SetStatefulSetReplicas(ss, 3)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetStatefulSetReplicas(ss, 3)
 	if ss.Spec.Replicas == nil || *ss.Spec.Replicas != 3 {
 		t.Fatal("expected Replicas to be 3")
 	}
@@ -446,10 +365,7 @@ func TestSetStatefulSetReplicas_Success(t *testing.T) {
 
 func TestSetStatefulSetServiceName_Success(t *testing.T) {
 	ss := CreateStatefulSet("test", "default")
-	err := SetStatefulSetServiceName(ss, "headless")
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetStatefulSetServiceName(ss, "headless")
 	if ss.Spec.ServiceName != "headless" {
 		t.Fatal("expected ServiceName to be set")
 	}
@@ -458,19 +374,13 @@ func TestSetStatefulSetServiceName_Success(t *testing.T) {
 func TestSetStatefulSetUpdateStrategy_Success(t *testing.T) {
 	ss := CreateStatefulSet("test", "default")
 	strategy := appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType}
-	err := SetStatefulSetUpdateStrategy(ss, strategy)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetStatefulSetUpdateStrategy(ss, strategy)
 }
 
 func TestSetStatefulSetRevisionHistoryLimit_Success(t *testing.T) {
 	ss := CreateStatefulSet("test", "default")
 	limit := int32(5)
-	err := SetStatefulSetRevisionHistoryLimit(ss, &limit)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetStatefulSetRevisionHistoryLimit(ss, &limit)
 	if ss.Spec.RevisionHistoryLimit == nil || *ss.Spec.RevisionHistoryLimit != 5 {
 		t.Fatal("expected RevisionHistoryLimit to be 5")
 	}
@@ -478,10 +388,7 @@ func TestSetStatefulSetRevisionHistoryLimit_Success(t *testing.T) {
 
 func TestSetStatefulSetPodManagementPolicy_Success(t *testing.T) {
 	ss := CreateStatefulSet("test", "default")
-	err := SetStatefulSetPodManagementPolicy(ss, appsv1.ParallelPodManagement)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	SetStatefulSetPodManagementPolicy(ss, appsv1.ParallelPodManagement)
 	if ss.Spec.PodManagementPolicy != appsv1.ParallelPodManagement {
 		t.Fatal("expected PodManagementPolicy to be set")
 	}

--- a/pkg/kubernetes/statefulset.go
+++ b/pkg/kubernetes/statefulset.go
@@ -1,11 +1,11 @@
 package kubernetes
 
 import (
-	"github.com/go-kure/kure/pkg/errors"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/go-kure/kure/pkg/errors"
 )
 
 // CreateStatefulSet returns a StatefulSet with sensible defaults set.
@@ -102,99 +102,92 @@ func AddStatefulSetTopologySpreadConstraints(sts *appsv1.StatefulSet, c *corev1.
 }
 
 // AddStatefulSetVolumeClaimTemplate appends a PVC template to the StatefulSet.
-func AddStatefulSetVolumeClaimTemplate(sts *appsv1.StatefulSet, pvc corev1.PersistentVolumeClaim) error {
+func AddStatefulSetVolumeClaimTemplate(sts *appsv1.StatefulSet, pvc corev1.PersistentVolumeClaim) {
 	if sts == nil {
-		return errors.ErrNilStatefulSet
+		panic("AddStatefulSetVolumeClaimTemplate: sts must not be nil")
 	}
 	sts.Spec.VolumeClaimTemplates = append(sts.Spec.VolumeClaimTemplates, pvc)
-	return nil
 }
 
 // SetStatefulSetServiceAccountName sets the service account name for the pod template.
-func SetStatefulSetServiceAccountName(sts *appsv1.StatefulSet, name string) error {
+func SetStatefulSetServiceAccountName(sts *appsv1.StatefulSet, name string) {
 	if sts == nil {
-		return errors.ErrNilStatefulSet
+		panic("SetStatefulSetServiceAccountName: sts must not be nil")
 	}
-	return SetPodSpecServiceAccountName(&sts.Spec.Template.Spec, name)
+	SetPodSpecServiceAccountName(&sts.Spec.Template.Spec, name)
 }
 
 // SetStatefulSetSecurityContext sets the pod security context.
-func SetStatefulSetSecurityContext(sts *appsv1.StatefulSet, sc *corev1.PodSecurityContext) error {
+func SetStatefulSetSecurityContext(sts *appsv1.StatefulSet, sc *corev1.PodSecurityContext) {
 	if sts == nil {
-		return errors.ErrNilStatefulSet
+		panic("SetStatefulSetSecurityContext: sts must not be nil")
 	}
-	return SetPodSpecSecurityContext(&sts.Spec.Template.Spec, sc)
+	SetPodSpecSecurityContext(&sts.Spec.Template.Spec, sc)
 }
 
 // SetStatefulSetAffinity sets the pod affinity rules.
-func SetStatefulSetAffinity(sts *appsv1.StatefulSet, aff *corev1.Affinity) error {
+func SetStatefulSetAffinity(sts *appsv1.StatefulSet, aff *corev1.Affinity) {
 	if sts == nil {
-		return errors.ErrNilStatefulSet
+		panic("SetStatefulSetAffinity: sts must not be nil")
 	}
-	return SetPodSpecAffinity(&sts.Spec.Template.Spec, aff)
+	SetPodSpecAffinity(&sts.Spec.Template.Spec, aff)
 }
 
 // SetStatefulSetNodeSelector sets the node selector.
-func SetStatefulSetNodeSelector(sts *appsv1.StatefulSet, ns map[string]string) error {
+func SetStatefulSetNodeSelector(sts *appsv1.StatefulSet, ns map[string]string) {
 	if sts == nil {
-		return errors.ErrNilStatefulSet
+		panic("SetStatefulSetNodeSelector: sts must not be nil")
 	}
-	return SetPodSpecNodeSelector(&sts.Spec.Template.Spec, ns)
+	SetPodSpecNodeSelector(&sts.Spec.Template.Spec, ns)
 }
 
 // SetStatefulSetUpdateStrategy sets the update strategy for the StatefulSet.
-func SetStatefulSetUpdateStrategy(sts *appsv1.StatefulSet, strategy appsv1.StatefulSetUpdateStrategy) error {
+func SetStatefulSetUpdateStrategy(sts *appsv1.StatefulSet, strategy appsv1.StatefulSetUpdateStrategy) {
 	if sts == nil {
-		return errors.ErrNilStatefulSet
+		panic("SetStatefulSetUpdateStrategy: sts must not be nil")
 	}
 	sts.Spec.UpdateStrategy = strategy
-	return nil
 }
 
 // SetStatefulSetReplicas sets the replica count.
-func SetStatefulSetReplicas(sts *appsv1.StatefulSet, replicas int32) error {
+func SetStatefulSetReplicas(sts *appsv1.StatefulSet, replicas int32) {
 	if sts == nil {
-		return errors.ErrNilStatefulSet
+		panic("SetStatefulSetReplicas: sts must not be nil")
 	}
 	if sts.Spec.Replicas == nil {
 		sts.Spec.Replicas = new(int32)
 	}
 	*sts.Spec.Replicas = replicas
-	return nil
 }
 
 // SetStatefulSetServiceName sets the service name used by the StatefulSet.
-func SetStatefulSetServiceName(sts *appsv1.StatefulSet, svc string) error {
+func SetStatefulSetServiceName(sts *appsv1.StatefulSet, svc string) {
 	if sts == nil {
-		return errors.ErrNilStatefulSet
+		panic("SetStatefulSetServiceName: sts must not be nil")
 	}
 	sts.Spec.ServiceName = svc
-	return nil
 }
 
 // SetStatefulSetPodManagementPolicy sets the pod management policy.
-func SetStatefulSetPodManagementPolicy(sts *appsv1.StatefulSet, policy appsv1.PodManagementPolicyType) error {
+func SetStatefulSetPodManagementPolicy(sts *appsv1.StatefulSet, policy appsv1.PodManagementPolicyType) {
 	if sts == nil {
-		return errors.ErrNilStatefulSet
+		panic("SetStatefulSetPodManagementPolicy: sts must not be nil")
 	}
 	sts.Spec.PodManagementPolicy = policy
-	return nil
 }
 
 // SetStatefulSetRevisionHistoryLimit sets the revision history limit.
-func SetStatefulSetRevisionHistoryLimit(sts *appsv1.StatefulSet, limit *int32) error {
+func SetStatefulSetRevisionHistoryLimit(sts *appsv1.StatefulSet, limit *int32) {
 	if sts == nil {
-		return errors.ErrNilStatefulSet
+		panic("SetStatefulSetRevisionHistoryLimit: sts must not be nil")
 	}
 	sts.Spec.RevisionHistoryLimit = limit
-	return nil
 }
 
 // SetStatefulSetMinReadySeconds sets the minimum ready seconds.
-func SetStatefulSetMinReadySeconds(sts *appsv1.StatefulSet, secs int32) error {
+func SetStatefulSetMinReadySeconds(sts *appsv1.StatefulSet, secs int32) {
 	if sts == nil {
-		return errors.ErrNilStatefulSet
+		panic("SetStatefulSetMinReadySeconds: sts must not be nil")
 	}
 	sts.Spec.MinReadySeconds = secs
-	return nil
 }

--- a/pkg/kubernetes/statefulset_test.go
+++ b/pkg/kubernetes/statefulset_test.go
@@ -129,84 +129,62 @@ func TestStatefulSetFunctions(t *testing.T) {
 	}
 
 	pvc := corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "data"}}
-	if err := AddStatefulSetVolumeClaimTemplate(sts, pvc); err != nil {
-		t.Fatalf("AddStatefulSetVolumeClaimTemplate returned error: %v", err)
-	}
+	AddStatefulSetVolumeClaimTemplate(sts, pvc)
 	if len(sts.Spec.VolumeClaimTemplates) != 1 {
 		t.Errorf("volume claim template not added")
 	}
 
-	if err := SetStatefulSetServiceAccountName(sts, "sa"); err != nil {
-		t.Fatalf("SetStatefulSetServiceAccountName returned error: %v", err)
-	}
+	SetStatefulSetServiceAccountName(sts, "sa")
 	if sts.Spec.Template.Spec.ServiceAccountName != "sa" {
 		t.Errorf("service account name not set")
 	}
 
 	sc := &corev1.PodSecurityContext{}
-	if err := SetStatefulSetSecurityContext(sts, sc); err != nil {
-		t.Fatalf("SetStatefulSetSecurityContext returned error: %v", err)
-	}
+	SetStatefulSetSecurityContext(sts, sc)
 	if sts.Spec.Template.Spec.SecurityContext != sc {
 		t.Errorf("security context not set")
 	}
 
 	aff := &corev1.Affinity{}
-	if err := SetStatefulSetAffinity(sts, aff); err != nil {
-		t.Fatalf("SetStatefulSetAffinity returned error: %v", err)
-	}
+	SetStatefulSetAffinity(sts, aff)
 	if sts.Spec.Template.Spec.Affinity != aff {
 		t.Errorf("affinity not set")
 	}
 
 	ns := map[string]string{"role": "db"}
-	if err := SetStatefulSetNodeSelector(sts, ns); err != nil {
-		t.Fatalf("SetStatefulSetNodeSelector returned error: %v", err)
-	}
+	SetStatefulSetNodeSelector(sts, ns)
 	if !reflect.DeepEqual(sts.Spec.Template.Spec.NodeSelector, ns) {
 		t.Errorf("node selector not set")
 	}
 
 	strategy := appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType}
-	if err := SetStatefulSetUpdateStrategy(sts, strategy); err != nil {
-		t.Fatalf("SetStatefulSetUpdateStrategy returned error: %v", err)
-	}
+	SetStatefulSetUpdateStrategy(sts, strategy)
 	if sts.Spec.UpdateStrategy.Type != appsv1.RollingUpdateStatefulSetStrategyType {
 		t.Errorf("update strategy not set")
 	}
 
-	if err := SetStatefulSetReplicas(sts, 3); err != nil {
-		t.Fatalf("SetStatefulSetReplicas returned error: %v", err)
-	}
+	SetStatefulSetReplicas(sts, 3)
 	if sts.Spec.Replicas == nil || *sts.Spec.Replicas != 3 {
 		t.Errorf("replicas not set")
 	}
 
-	if err := SetStatefulSetServiceName(sts, "svc"); err != nil {
-		t.Fatalf("SetStatefulSetServiceName returned error: %v", err)
-	}
+	SetStatefulSetServiceName(sts, "svc")
 	if sts.Spec.ServiceName != "svc" {
 		t.Errorf("service name not set")
 	}
 
-	if err := SetStatefulSetPodManagementPolicy(sts, appsv1.ParallelPodManagement); err != nil {
-		t.Fatalf("SetStatefulSetPodManagementPolicy returned error: %v", err)
-	}
+	SetStatefulSetPodManagementPolicy(sts, appsv1.ParallelPodManagement)
 	if sts.Spec.PodManagementPolicy != appsv1.ParallelPodManagement {
 		t.Errorf("pod management policy not set")
 	}
 
 	rhl := int32(4)
-	if err := SetStatefulSetRevisionHistoryLimit(sts, &rhl); err != nil {
-		t.Fatalf("SetStatefulSetRevisionHistoryLimit returned error: %v", err)
-	}
+	SetStatefulSetRevisionHistoryLimit(sts, &rhl)
 	if sts.Spec.RevisionHistoryLimit == nil || *sts.Spec.RevisionHistoryLimit != 4 {
 		t.Errorf("revision history limit not set")
 	}
 
-	if err := SetStatefulSetMinReadySeconds(sts, 5); err != nil {
-		t.Fatalf("SetStatefulSetMinReadySeconds returned error: %v", err)
-	}
+	SetStatefulSetMinReadySeconds(sts, 5)
 	if sts.Spec.MinReadySeconds != 5 {
 		t.Errorf("min ready seconds not set")
 	}
@@ -214,44 +192,40 @@ func TestStatefulSetFunctions(t *testing.T) {
 
 func TestStatefulSetNilGuards(t *testing.T) {
 	rhl := int32(1)
-	tests := []struct {
-		name string
-		fn   func() error
-	}{
-		{"SetStatefulSetPodSpec", func() error { return SetStatefulSetPodSpec(nil, &corev1.PodSpec{}) }},
-		{"AddStatefulSetContainer", func() error { return AddStatefulSetContainer(nil, &corev1.Container{}) }},
-		{"AddStatefulSetInitContainer", func() error { return AddStatefulSetInitContainer(nil, &corev1.Container{}) }},
-		{"AddStatefulSetVolume", func() error { return AddStatefulSetVolume(nil, &corev1.Volume{}) }},
-		{"AddStatefulSetImagePullSecret", func() error {
-			return AddStatefulSetImagePullSecret(nil, &corev1.LocalObjectReference{})
-		}},
-		{"AddStatefulSetToleration", func() error { return AddStatefulSetToleration(nil, &corev1.Toleration{}) }},
-		{"AddStatefulSetTopologySpreadConstraints", func() error {
-			return AddStatefulSetTopologySpreadConstraints(nil, &corev1.TopologySpreadConstraint{})
-		}},
-		{"AddStatefulSetVolumeClaimTemplate", func() error {
-			return AddStatefulSetVolumeClaimTemplate(nil, corev1.PersistentVolumeClaim{})
-		}},
-		{"SetStatefulSetServiceAccountName", func() error { return SetStatefulSetServiceAccountName(nil, "sa") }},
-		{"SetStatefulSetSecurityContext", func() error { return SetStatefulSetSecurityContext(nil, nil) }},
-		{"SetStatefulSetAffinity", func() error { return SetStatefulSetAffinity(nil, nil) }},
-		{"SetStatefulSetNodeSelector", func() error { return SetStatefulSetNodeSelector(nil, nil) }},
-		{"SetStatefulSetUpdateStrategy", func() error {
-			return SetStatefulSetUpdateStrategy(nil, appsv1.StatefulSetUpdateStrategy{})
-		}},
-		{"SetStatefulSetReplicas", func() error { return SetStatefulSetReplicas(nil, 1) }},
-		{"SetStatefulSetServiceName", func() error { return SetStatefulSetServiceName(nil, "svc") }},
-		{"SetStatefulSetPodManagementPolicy", func() error {
-			return SetStatefulSetPodManagementPolicy(nil, appsv1.OrderedReadyPodManagement)
-		}},
-		{"SetStatefulSetRevisionHistoryLimit", func() error { return SetStatefulSetRevisionHistoryLimit(nil, &rhl) }},
-		{"SetStatefulSetMinReadySeconds", func() error { return SetStatefulSetMinReadySeconds(nil, 1) }},
+
+	// Functions with secondary nil checks — still return errors
+	if err := SetStatefulSetPodSpec(nil, &corev1.PodSpec{}); err == nil {
+		t.Error("SetStatefulSetPodSpec(nil) should return error")
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.fn(); err == nil {
-				t.Errorf("%s(nil) should return error", tt.name)
-			}
-		})
+	if err := AddStatefulSetContainer(nil, &corev1.Container{}); err == nil {
+		t.Error("AddStatefulSetContainer(nil) should return error")
 	}
+	if err := AddStatefulSetInitContainer(nil, &corev1.Container{}); err == nil {
+		t.Error("AddStatefulSetInitContainer(nil) should return error")
+	}
+	if err := AddStatefulSetVolume(nil, &corev1.Volume{}); err == nil {
+		t.Error("AddStatefulSetVolume(nil) should return error")
+	}
+	if err := AddStatefulSetImagePullSecret(nil, &corev1.LocalObjectReference{}); err == nil {
+		t.Error("AddStatefulSetImagePullSecret(nil) should return error")
+	}
+	if err := AddStatefulSetToleration(nil, &corev1.Toleration{}); err == nil {
+		t.Error("AddStatefulSetToleration(nil) should return error")
+	}
+	if err := AddStatefulSetTopologySpreadConstraints(nil, &corev1.TopologySpreadConstraint{}); err == nil {
+		t.Error("AddStatefulSetTopologySpreadConstraints(nil) should return error")
+	}
+
+	// Functions that now panic on nil receiver
+	assertPanics(t, func() { AddStatefulSetVolumeClaimTemplate(nil, corev1.PersistentVolumeClaim{}) })
+	assertPanics(t, func() { SetStatefulSetServiceAccountName(nil, "sa") })
+	assertPanics(t, func() { SetStatefulSetSecurityContext(nil, nil) })
+	assertPanics(t, func() { SetStatefulSetAffinity(nil, nil) })
+	assertPanics(t, func() { SetStatefulSetNodeSelector(nil, nil) })
+	assertPanics(t, func() { SetStatefulSetUpdateStrategy(nil, appsv1.StatefulSetUpdateStrategy{}) })
+	assertPanics(t, func() { SetStatefulSetReplicas(nil, 1) })
+	assertPanics(t, func() { SetStatefulSetServiceName(nil, "svc") })
+	assertPanics(t, func() { SetStatefulSetPodManagementPolicy(nil, appsv1.OrderedReadyPodManagement) })
+	assertPanics(t, func() { SetStatefulSetRevisionHistoryLimit(nil, &rhl) })
+	assertPanics(t, func() { SetStatefulSetMinReadySeconds(nil, 1) })
 }

--- a/pkg/kubernetes/utilities_test.go
+++ b/pkg/kubernetes/utilities_test.go
@@ -15,6 +15,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// assertPanics asserts that f() panics. Used to test nil-receiver panic guards.
+func assertPanics(t *testing.T, f func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic, got none")
+		}
+	}()
+	f()
+}
+
 func TestGetGroupVersionKind_Success(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/stack/generators/appworkload/internal/appworkload.go
+++ b/pkg/stack/generators/appworkload/internal/appworkload.go
@@ -401,11 +401,9 @@ func GenerateResources(cfg *Config, app *stack.Application) ([]*client.Object, e
 			if err != nil {
 				return nil, err
 			}
-			if err := kubernetes.AddStatefulSetVolumeClaimTemplate(sts, *k8sPVC); err != nil {
-				return nil, err
-			}
+			kubernetes.AddStatefulSetVolumeClaimTemplate(sts, *k8sPVC)
 		}
-		_ = kubernetes.SetStatefulSetReplicas(sts, cfg.Replicas)
+		kubernetes.SetStatefulSetReplicas(sts, cfg.Replicas)
 		objs = append(objs, kubernetes.ToClientObject(sts))
 	case DaemonSetWorkload:
 		ds := kubernetes.CreateDaemonSet(app.Name, app.Namespace)
@@ -434,7 +432,7 @@ func GenerateResources(cfg *Config, app *stack.Application) ([]*client.Object, e
 				return nil, err
 			}
 		}
-		_ = kubernetes.SetDeploymentReplicas(dep, cfg.Replicas)
+		kubernetes.SetDeploymentReplicas(dep, cfg.Replicas)
 		objs = append(objs, kubernetes.ToClientObject(dep))
 	default:
 		return nil, errors.NewValidationError("workload", string(cfg.Workload), "AppWorkloadConfig", []string{"Deployment", "StatefulSet", "DaemonSet"})
@@ -444,9 +442,9 @@ func GenerateResources(cfg *Config, app *stack.Application) ([]*client.Object, e
 	var svc *corev1.Service
 	if len(allports) > 0 {
 		svc = kubernetes.CreateService(app.Name, app.Namespace)
-		_ = kubernetes.SetServiceSelector(svc, map[string]string{"app": app.Name})
+		kubernetes.SetServiceSelector(svc, map[string]string{"app": app.Name})
 		for _, p := range allports {
-			_ = kubernetes.AddServicePort(svc, corev1.ServicePort{
+			kubernetes.AddServicePort(svc, corev1.ServicePort{
 				Name:       p.Name,
 				Port:       p.ContainerPort,
 				TargetPort: intstr.FromInt32(p.ContainerPort),
@@ -465,8 +463,8 @@ func GenerateResources(cfg *Config, app *stack.Application) ([]*client.Object, e
 		}
 		port := cfg.Ingress.ServicePortName
 		kubernetes.AddIngressRulePath(rule, kubernetes.CreateIngressPath(path, &pt, svc.Name, port))
-		_ = kubernetes.AddIngressRule(ing, rule)
-		_ = kubernetes.AddIngressTLS(ing, netv1.IngressTLS{Hosts: []string{cfg.Ingress.Host}, SecretName: fmt.Sprintf("%s-tls", app.Name)})
+		kubernetes.AddIngressRule(ing, rule)
+		kubernetes.AddIngressTLS(ing, netv1.IngressTLS{Hosts: []string{cfg.Ingress.Host}, SecretName: fmt.Sprintf("%s-tls", app.Name)})
 		objs = append(objs, kubernetes.ToClientObject(ing))
 	}
 
@@ -480,20 +478,20 @@ func (cfg ContainerConfig) Generate() (*corev1.Container, []corev1.ContainerPort
 	// Add ports
 	for _, p := range cfg.Ports {
 		k8sPort := p.ToKubernetesPort()
-		_ = kubernetes.AddContainerPort(container, k8sPort)
+		kubernetes.AddContainerPort(container, k8sPort)
 		ports = append(ports, k8sPort)
 	}
 
 	// Add environment variables
 	for _, env := range cfg.Env {
 		k8sEnv := env.ToKubernetesEnvVar()
-		_ = kubernetes.AddContainerEnv(container, k8sEnv)
+		kubernetes.AddContainerEnv(container, k8sEnv)
 	}
 
 	// Add volume mounts
 	for _, vm := range cfg.VolumeMounts {
 		k8sMount := vm.ToKubernetesVolumeMount()
-		_ = kubernetes.AddContainerVolumeMount(container, k8sMount)
+		kubernetes.AddContainerVolumeMount(container, k8sMount)
 	}
 
 	// Set resources if provided
@@ -503,7 +501,7 @@ func (cfg ContainerConfig) Generate() (*corev1.Container, []corev1.ContainerPort
 			return nil, nil, err
 		}
 		if k8sResources != nil {
-			_ = kubernetes.SetContainerResources(container, *k8sResources)
+			kubernetes.SetContainerResources(container, *k8sResources)
 		}
 	}
 
@@ -511,19 +509,19 @@ func (cfg ContainerConfig) Generate() (*corev1.Container, []corev1.ContainerPort
 	if cfg.LivenessProbe != nil {
 		k8sProbe := cfg.LivenessProbe.ToKubernetesProbe()
 		if k8sProbe != nil {
-			_ = kubernetes.SetContainerLivenessProbe(container, *k8sProbe)
+			kubernetes.SetContainerLivenessProbe(container, *k8sProbe)
 		}
 	}
 	if cfg.ReadinessProbe != nil {
 		k8sProbe := cfg.ReadinessProbe.ToKubernetesProbe()
 		if k8sProbe != nil {
-			_ = kubernetes.SetContainerReadinessProbe(container, *k8sProbe)
+			kubernetes.SetContainerReadinessProbe(container, *k8sProbe)
 		}
 	}
 	if cfg.StartupProbe != nil {
 		k8sProbe := cfg.StartupProbe.ToKubernetesProbe()
 		if k8sProbe != nil {
-			_ = kubernetes.SetContainerStartupProbe(container, *k8sProbe)
+			kubernetes.SetContainerStartupProbe(container, *k8sProbe)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Functions in `pkg/kubernetes/` where the **only** error condition was a nil receiver now `panic` instead of returning `error`. Passing a nil receiver is a programmer error, not a recoverable runtime condition.
- Functions that also validate secondary pointer parameters (`*corev1.PodSpec`, `*corev1.Container`, etc.) retain their `error` returns.
- All callers updated (`cmd/demo/main.go`, `pkg/stack/generators/appworkload/internal/appworkload.go`).
- Test nil-guard cases changed from `if err := f(nil); err == nil` to `assertPanics(t, func() { f(nil) })`, with a new `assertPanics` helper in `utilities_test.go`.

Closes #520

## Affected packages

`container`, `cronjob`, `daemonset`, `deployment`, `hpa`, `httproute`, `ingress`, `job`, `networkpolicy`, `pdb`, `podspec`, `rbac`, `resourcerequirements` (`AddResourceClaim` only), `service`, `serviceaccount`, `statefulset`

## Test plan

- [ ] `go build ./...` — clean
- [ ] `go test ./...` — all pass
- [ ] `make lint` — 0 issues
- [ ] Nil-receiver paths verified to panic via `assertPanics` in test suite
- [ ] Functions with secondary nil checks still return errors (verified in `TestDeploymentNilArgErrors`, `TestCronJobNilArgErrors`, etc.)