### PR TITLE
ci: increase test job timeout from 10 min to 20 min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
   test:
     name: test
     runs-on: autops-kube-kure
-    timeout-minutes: 10
+    timeout-minutes: 20
     needs: [changes]
     if: |
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
@@ -253,7 +253,7 @@ jobs:
       run: |
         set -euo pipefail
         mkdir -p coverage
-        go test -v -race -coverprofile=coverage/coverage.out -covermode=atomic -timeout 5m ./... 2>&1 | tee /tmp/gotest.log
+        go test -v -race -coverprofile=coverage/coverage.out -covermode=atomic -timeout 15m ./... 2>&1 | tee /tmp/gotest.log
 
     - name: Upload test log
       uses: actions/upload-artifact@v7

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -89,7 +89,7 @@ PR-only jobs (parallel, no blocking):
 | Job | Check Name | Timeout | Dependencies | Purpose |
 |-----|------------|---------|--------------|---------|
 | `validate` | `lint` | 15 min | changes | Go fmt, tidy, vet, lint; caches goimports + yq binaries |
-| `test` | `test` | 10 min | changes | Unit tests with race detection and coverage |
+| `test` | `test` | 20 min | changes | Unit tests with race detection and coverage; `-race` compilation takes ~5 min on the in-cluster runner, so 20 min allows compilation + 15 min for test execution |
 | `security` | `Security` | 5 min | changes | govulncheck (`-scan package`, v1.1.4, informational — findings warn but do not fail), outdated deps, sensitive file check |
 | `coverage-check` | `Coverage Check` | 5 min | test | 85% threshold, Codecov upload, PR comment |
 | `build-binaries` | `Build kure/demo` | 10 min | changes, test | Build kure and demo binaries (matrix) |


### PR DESCRIPTION
## Summary

- Race-instrumented compilation takes ~5 min on the in-cluster runner, consuming most of the previous 10-minute job ceiling before tests even start
- Increase `timeout-minutes` for the `test` job from 10 → 20 minutes
- Increase `go test -timeout` from 5 min → 15 min to match the larger window

## Test plan
- [ ] CI `test` job completes without timeout on this PR
- [ ] After merge, open PRs (#525 #526 #527 #528) auto-rebase and CI passes