### PR TITLE
ci: stable gobuild cache key and expand workflow path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
             - 'go.mod'
             - 'go.sum'
             - 'Makefile'
-            - '.github/workflows/ci.yml'
+            - '.github/workflows/**'
           docs:
             - 'site/**'
             - 'docs/**'
@@ -124,7 +124,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.cache/go-build
-        key: ${{ runner.os }}-gobuild-${{ github.sha }}
+        key: ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-gobuild-
 
@@ -241,7 +241,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.cache/go-build
-        key: ${{ runner.os }}-gobuild-${{ github.sha }}
+        key: ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-gobuild-
 
@@ -462,7 +462,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.cache/go-build
-        key: ${{ runner.os }}-gobuild-${{ github.sha }}
+        key: ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-gobuild-
 
@@ -547,7 +547,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.cache/go-build
-        key: ${{ runner.os }}-gobuild-${{ matrix.os }}-${{ matrix.arch }}-${{ github.sha }}
+        key: ${{ runner.os }}-gobuild-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-gobuild-${{ matrix.os }}-${{ matrix.arch }}-
           ${{ runner.os }}-gobuild-
@@ -650,7 +650,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.cache/go-build
-        key: ${{ runner.os }}-gobuild-${{ github.sha }}
+        key: ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-gobuild-
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -2,7 +2,7 @@
 
 This document provides an overview of all GitHub Actions workflows used in the kure project.
 
-**Last Updated:** 2026-05-08
+**Last Updated:** 2026-05-10
 
 ---
 
@@ -34,14 +34,12 @@ This document provides an overview of all GitHub Actions workflows used in the k
 
 ### Concurrency
 
-Uses `github.sha` to avoid duplicate runs:
-- Same commit won't run CI twice (e.g., PR merge → push to main)
-- Different commits run independently
+Uses `github.ref` to cancel superseded runs on the same branch or PR:
 
 ```yaml
 concurrency:
-  group: ci-${{ github.sha }}
-  cancel-in-progress: false
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 ```
 
 ### Job Dependency Graph
@@ -449,12 +447,12 @@ control cache keys precisely. Two separate Go caches are maintained:
     restore-keys: |
       ${{ runner.os }}-gomod-
 
-# Build cache: per-commit, partial restore from previous commits
+# Build cache: invalidates when go.sum changes, shared across commits with same deps
 - name: Cache Go build cache
   uses: actions/cache@v5
   with:
     path: ~/.cache/go-build
-    key: ${{ runner.os }}-gobuild-${{ github.sha }}
+    key: ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}
     restore-keys: |
       ${{ runner.os }}-gobuild-
 ```
@@ -487,6 +485,16 @@ The `docs-build` job uses three separate caches:
 - `gomod` — for `make docs-cli` CLI reference generation
 - `gobuild` — for Go compilation during CLI reference generation
 - `hugo` — Hugo module cache (`$HUGO_CACHEDIR` only, **not** `~/go/pkg/mod`)
+
+### Path Filters
+
+The `changes` job uses `dorny/paths-filter` to skip jobs when unrelated files change:
+
+- `go:` filter — triggers lint/test/security/build jobs. Includes `**.go`, `go.mod`, `go.sum`,
+  `Makefile`, and **`.github/workflows/**`** so that workflow-only PRs are also validated.
+- `docs:` filter — triggers docs-build/docs-check jobs. Includes `site/**`, `docs/**`, `*.md`,
+  `scripts/**`, and `.github/workflows/ci.yml` (only ci.yml, since other workflows don't affect
+  the docs build).
 
 ### Branch Patterns
 


### PR DESCRIPTION
## Summary

- Replace per-commit gobuild cache keys (`github.sha`) with `go.sum`-based keys so the build cache is actually reused across commits with the same dependencies
- Expand the `go:` path filter from `ci.yml` only to `.github/workflows/**` so workflow-only PRs (like this one) also run CI validation

## Test plan

- [ ] CI runs on this PR (path filter change is self-testing)
- [ ] Next CI run after this merges hits the gobuild cache instead of cold-starting