### PR TITLE
docs: mark generators deprecated; note pkg/patch moved to launcher

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,7 +13,7 @@ Kure is a Go library for programmatically building Kubernetes resources used by 
 - **Interface Segregation**: Split monolithic workflow interfaces into focused components
 - **Type Safety**: Strong typing throughout with comprehensive validation
 - **GitOps Agnostic**: Support for multiple GitOps tools through pluggable workflows
-- **Declarative Patching**: JSONPath-based patching system with structure preservation
+- **Declarative Patching**: JSONPath-based patching system with structure preservation *(moved to go-kure/launcher)*
 
 The architecture supports complex Kubernetes cluster configurations while maintaining simplicity and extensibility through clean separation of concerns and well-defined interfaces.
 
@@ -81,7 +81,26 @@ The system is organized around four primary architectural layers:
 1. **Domain Model** (`pkg/stack/`): Hierarchical abstractions for cluster configuration
 2. **Workflow Engines** (`pkg/stack/workflow.go`, `pkg/stack/fluxcd/`, `pkg/stack/argocd/`): GitOps-specific implementations
 3. **Resource Builders** (`internal/`): Strongly-typed Kubernetes resource factories
-4. **Support Systems**: Error handling, patching, layout, and I/O utilities
+4. **Support Systems**: Error handling, layout, and I/O utilities
+
+### What kure does NOT provide
+
+kure is an unopinionated foundation. It provides building blocks — it does not compose them into
+named application patterns or OAM abstractions.
+
+| Not in kure | Reason |
+|-------------|--------|
+| Application-level components (webservice, worker, helmrelease) | Downstream consumers have different opinions on what each means |
+| Trait logic (ingress, certificate, external-secret) | Trait implementation depends on platform capabilities |
+| OAM model (Application, Component, Trait, Policy) | This belongs in the OAM runtime layer (launcher) |
+| Policy enforcement | Enforcement rules are organizational — not a library concern |
+| GitOps delivery layout decisions | Each consumer defines its own OCI artifact hierarchy |
+
+**Why this matters for library design.** If kure defined a `WebserviceConfig`, it would need to
+decide: does it include a `ServiceAccount`? Topology spread constraints? Sidecars? Each downstream
+consumer has different answers. Putting the composed abstraction in the library couples all
+consumers to kure's version of that answer. kure avoids this by providing composable primitives and
+leaving composition to consumers.
 
 ### Key Design Principles
 
@@ -104,6 +123,33 @@ The system is organized around four primary architectural layers:
 - Strong typing for all Kubernetes resources
 - Compile-time validation of resource construction
 - Custom error types with contextual information
+
+### Relationship to Launcher
+
+[launcher](https://github.com/go-kure/launcher) is an OAM-native package manager built on kure.
+The dependency is strictly one-directional: launcher imports kure; kure has no dependency on
+launcher.
+
+```
+downstream consumers
+        │
+        ▼
+   launcher (OAM runtime)
+        │
+        ▼
+    kure (library)
+```
+
+kure provides the building blocks — `ApplicationConfig` interface, K8s resource builders, FluxCD
+workflow primitives. Launcher uses these to implement an OAM-to-manifest pipeline with component
+handlers, trait handlers, and a Policy extension point for downstream enforcement.
+
+Downstream consumers that need capabilities beyond launcher's built-in handlers can register
+additional handlers and implement the `launcher.Policy` interface, while still using kure's
+resource builders directly.
+
+For the full layering model see
+[kure-launcher-architecture](https://github.com/go-kure/.github/blob/main/docs/design/kure-launcher-architecture.md).
 
 ---
 
@@ -513,6 +559,9 @@ This is the kure idiom for one-of: setting two variants is a compile error (sing
 
 ## Patch System Architecture
 
+> **Note (2026-05-15)**: `pkg/patch` moved to `go-kure/launcher`. The section below describes the
+> historical implementation that lived in kure before the launcher extraction (ADR-018).
+
 ### Design Philosophy
 
 The patch system implements declarative, JSONPath-based patching with structure preservation:
@@ -737,7 +786,7 @@ pkg/                          # Public APIs and interfaces
 │   └── layout/             # Layout generation utilities
 ├── stack/workflow.go       # Workflow interfaces (public)
 ├── errors/                 # Error handling utilities (public)
-└── patch/                  # Patch system (public)
+└── patch/                  # Patch system (public) — moved to go-kure/launcher (ADR-018)
 
 internal/                    # Implementation packages (private)
 ├── kubernetes/             # Core Kubernetes builders

--- a/site/content/api-reference/_index.md
+++ b/site/content/api-reference/_index.md
@@ -15,7 +15,7 @@ For full Go API documentation, see [pkg.go.dev/github.com/go-kure/kure](https://
 |---------|-------------|-----------|
 | [Stack](stack) | Cluster, Node, Bundle, Application domain model | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/stack) |
 | [Flux Engine](flux-engine) | FluxCD workflow implementation | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/stack/fluxcd) |
-| [Generators](generators) | Application generator system (GVK) | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/stack/generators) |
+| [Generators](generators) | Application generator system (GVK) — **deprecated**, removal tracked in [#539](https://github.com/go-kure/kure/issues/539) | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/stack/generators) |
 | [Layout Engine](layout) | Manifest directory organization | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/stack/layout) |
 
 ## Resource Operations

--- a/site/content/concepts/design-philosophy.md
+++ b/site/content/concepts/design-philosophy.md
@@ -50,6 +50,10 @@ This allows new application types and GitOps tools to be added without modifying
 
 The kurel package system follows a simple principle: it takes base manifests, applies patches, resolves variables, and writes YAML files. It's not a runtime system, not a controller, not an orchestrator.
 
+> **Note (2026-05-15)**: This describes the historical kurel prototype. The current kurel is an
+> OAM-native package manager in [go-kure/launcher](https://github.com/go-kure/launcher) — it uses
+> OAM Application/Component/Trait semantics rather than the patch-and-variables model above.
+
 This constraint keeps the system simple and auditable. You can always inspect exactly what will be deployed by looking at the generated output.
 
 ## Composition Over Configuration

--- a/site/content/guides/generators.md
+++ b/site/content/guides/generators.md
@@ -5,6 +5,11 @@ weight = 30
 
 # Working with Generators
 
+> **Deprecated (2026-05-15)**: The generator system (`pkg/stack/generators/`) is being removed from
+> kure. It is unused by all known runtime consumers. Removal is tracked in
+> [kure#539](https://github.com/go-kure/kure/issues/539). Application-level component patterns live
+> in [go-kure/launcher](https://github.com/go-kure/launcher).
+
 Generators provide a type-safe way to create application workloads from configuration. They implement the `ApplicationConfig` interface and are identified by GroupVersionKind (GVK) strings.
 
 ## Getting Started

--- a/site/content/guides/kurel-packages.md
+++ b/site/content/guides/kurel-packages.md
@@ -5,6 +5,12 @@ weight = 50
 
 # Building Kurel Packages
 
+> **Note (2026-05-15)**: This page describes the historical kurel prototype — a patch-based package
+> system that lived in kure. The current kurel is an OAM-native package manager that lives in
+> [go-kure/launcher](https://github.com/go-kure/launcher). The design described below is superseded.
+> See [launcher/docs/design.md](https://github.com/go-kure/launcher/blob/main/docs/design.md) for
+> the current design.
+
 Kurel is the package system for creating reusable Kubernetes applications. A kurel package bundles base manifests, patches, and parameters into a self-contained unit that can be customized per deployment.
 
 ## Package Structure
@@ -108,6 +114,6 @@ my-app.local.kurel/
 
 ## Further Reading
 
-- [Launcher reference](https://pkg.go.dev/github.com/go-kure/launcher/pkg/launcher) for the package system API
+- [Launcher reference](https://github.com/go-kure/launcher) for the package system API
 - [Kurel Frigate example](/examples/kurel-frigate) for a complete package
 - [Patching guide](/guides/patching/) for the patch format


### PR DESCRIPTION
## Summary

- `docs/ARCHITECTURE.md` — add "What kure does NOT provide" subsection and "Relationship to launcher" section; add `*(moved to go-kure/launcher)*` notes to Declarative Patching bullet and `pkg/patch` row in package org table; historical note at top of §6 (patch engine)
- `site/content/guides/generators.md` — add deprecation notice at top; removal tracked in #539
- `site/content/api-reference/_index.md` — mark Generators row as deprecated with #539 link
- `site/content/guides/kurel-packages.md` — add historical notice at top (current kurel is OAM-native in go-kure/launcher); fix stale `pkg.go.dev/…/pkg/launcher` link
- `site/content/concepts/design-philosophy.md` — add inline note that the kurel patch-system description is the historical prototype

## Related

- Closes #539 preparation (deprecation notices in place before removal)