### PR TITLE
docs: remove stale pkg/patch references from ARCHITECTURE.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1209,10 +1209,6 @@ pkg/
 │   ├── application_test.go
 │   ├── bundle_test.go
 │   └── ...
-├── patch/
-│   ├── apply_test.go
-│   ├── set_test.go
-│   └── ...
 └── ...
 ```
 
@@ -1432,9 +1428,6 @@ func assertError(t *testing.T, err error, expectedType errors.ErrorType) {
 
 Additional design documentation available in the repository:
 
-- `pkg/patch/DESIGN.md`: Detailed patch system specification
-- `pkg/patch/PATCH_ENGINE_DESIGN.md`: Patch engine implementation details
-- `pkg/patch/PATH_RESOLUTION.md`: JSONPath resolution algorithms
 - `pkg/stack/layout/README.md`: Layout system overview
 - `pkg/stack/workflow.go`: Workflow interface definitions
 


### PR DESCRIPTION
## Summary

Closes #540 — removes two stale `pkg/patch` references that remained after the extraction to go-kure/launcher (#539 now complete):

- **Naming Conventions test tree**: remove `pkg/patch/` entry (files no longer exist in kure)
- **Appendix C**: remove three `pkg/patch/*.md` design doc links (`DESIGN.md`, `PATCH_ENGINE_DESIGN.md`, `PATH_RESOLUTION.md`) — these moved to go-kure/launcher with the package (ADR-018)

The §6 patch engine section and public package tree were already annotated in PR #541.