### PR TITLE
feat: add NamedDependsOn to stack.Bundle for name-based kustomization chaining

### DIFF
--- a/pkg/stack/README.md
+++ b/pkg/stack/README.md
@@ -45,17 +45,20 @@ A tree structure for organizing bundles into logical groups. Nodes can have chil
 node := &stack.Node{
     Name:     "infrastructure",
     Children: []*stack.Node{childNode},
-    Bundle:   []*stack.Bundle{monitoringBundle},
+    Bundle:   monitoringBundle,
 }
 ```
 
 ### Bundle
 
-A deployment unit corresponding to a single GitOps resource (e.g., a Flux Kustomization). Bundles support dependency ordering via `DependsOn`.
+A deployment unit corresponding to a single GitOps resource (e.g., a Flux Kustomization). Bundles support dependency ordering via `DependsOn` (pointer-based) or `NamedDependsOn` (name-based, for cross-scope references).
 
 ```go
 bundle, err := stack.NewBundle("monitoring", apps, labels)
-bundle.DependsOn = []string{"cert-manager"}
+// Pointer-based — when you hold the bundle object:
+bundle.DependsOn = []*stack.Bundle{certManagerBundle}
+// Name-based — when you only know the name (e.g. a hook-phase bundle):
+bundle.NamedDependsOn = []string{"cert-manager"}
 bundle.Interval = "10m"
 ```
 

--- a/pkg/stack/builders.go
+++ b/pkg/stack/builders.go
@@ -149,6 +149,10 @@ func deepCopyBundle(b *Bundle) *Bundle {
 		newBundle.DependsOn = make([]*Bundle, len(b.DependsOn))
 		copy(newBundle.DependsOn, b.DependsOn)
 	}
+	if b.NamedDependsOn != nil {
+		newBundle.NamedDependsOn = make([]string, len(b.NamedDependsOn))
+		copy(newBundle.NamedDependsOn, b.NamedDependsOn)
+	}
 	// Same shallow-copy strategy for Children (umbrella) bundle references.
 	if b.Children != nil {
 		newBundle.Children = make([]*Bundle, len(b.Children))

--- a/pkg/stack/bundle.go
+++ b/pkg/stack/bundle.go
@@ -28,6 +28,10 @@ type Bundle struct {
 	ParentPath string
 	// DependsOn lists other bundles this bundle depends on
 	DependsOn []*Bundle
+	// NamedDependsOn lists names of kustomizations this bundle depends on, by name.
+	// Unlike DependsOn, names need not resolve to in-scope Bundle objects.
+	// Both fields are merged into Kustomization.Spec.DependsOn.
+	NamedDependsOn []string
 	// Children holds bundles whose Flux Kustomization CRs are rendered into
 	// this bundle's tar path and whose readiness is aggregated into this
 	// bundle's HealthChecks. When non-empty, this bundle acts as an umbrella:
@@ -199,6 +203,23 @@ func (a *Bundle) validateChildren(visited map[*Bundle]bool) error {
 			depNames[dep.Name] = true
 		}
 	}
+	// Validate NamedDependsOn: empty names, duplicates, cross-field duplicates.
+	namedDepNames := make(map[string]bool, len(a.NamedDependsOn))
+	for _, name := range a.NamedDependsOn {
+		if name == "" {
+			return errors.ResourceValidationError("Bundle", a.Name, "namedDependsOn",
+				"named dependency has empty name", nil)
+		}
+		if namedDepNames[name] {
+			return errors.ResourceValidationError("Bundle", a.Name, "namedDependsOn",
+				fmt.Sprintf("duplicate named dependency %q", name), nil)
+		}
+		if depNames[name] {
+			return errors.ResourceValidationError("Bundle", a.Name, "namedDependsOn",
+				fmt.Sprintf("dependency %q appears in both DependsOn and NamedDependsOn", name), nil)
+		}
+		namedDepNames[name] = true
+	}
 	childNames := make(map[string]bool, len(a.Children))
 	for i, c := range a.Children {
 		if c == nil {
@@ -226,9 +247,17 @@ func (a *Bundle) validateChildren(visited map[*Bundle]bool) error {
 			return errors.ResourceValidationError("Bundle", a.Name, "children",
 				fmt.Sprintf("child %q also appears in dependsOn", c.Name), nil)
 		}
+		if namedDepNames[c.Name] {
+			return errors.ResourceValidationError("Bundle", a.Name, "children",
+				fmt.Sprintf("child %q also appears in namedDependsOn", c.Name), nil)
+		}
 		if slices.Contains(c.DependsOn, a) {
 			return errors.ResourceValidationError("Bundle", a.Name, "children",
 				fmt.Sprintf("child %q depends on parent %q", c.Name, a.Name), nil)
+		}
+		if slices.Contains(c.NamedDependsOn, a.Name) {
+			return errors.ResourceValidationError("Bundle", a.Name, "children",
+				fmt.Sprintf("child %q has parent %q in namedDependsOn", c.Name, a.Name), nil)
 		}
 		if err := c.validateChildren(visited); err != nil {
 			return err

--- a/pkg/stack/bundle_test.go
+++ b/pkg/stack/bundle_test.go
@@ -640,6 +640,41 @@ func TestBundleValidateUmbrellaChildren(t *testing.T) {
 			t.Fatal("expected empty grandchild name to fail")
 		}
 	})
+
+	t.Run("NamedDependsOn empty name rejected", func(t *testing.T) {
+		b := &Bundle{Name: "b", NamedDependsOn: []string{""}}
+		if err := b.Validate(); err == nil {
+			t.Fatal("expected empty NamedDependsOn name to fail")
+		}
+	})
+	t.Run("NamedDependsOn duplicate rejected", func(t *testing.T) {
+		b := &Bundle{Name: "b", NamedDependsOn: []string{"x", "x"}}
+		if err := b.Validate(); err == nil {
+			t.Fatal("expected duplicate NamedDependsOn to fail")
+		}
+	})
+	t.Run("NamedDependsOn/DependsOn cross-field duplicate rejected", func(t *testing.T) {
+		dep := &Bundle{Name: "shared"}
+		b := &Bundle{Name: "b", DependsOn: []*Bundle{dep}, NamedDependsOn: []string{"shared"}}
+		if err := b.Validate(); err == nil {
+			t.Fatal("expected cross-field duplicate to fail")
+		}
+	})
+	t.Run("NamedDependsOn/Children overlap rejected", func(t *testing.T) {
+		child := &Bundle{Name: "c"}
+		b := &Bundle{Name: "b", NamedDependsOn: []string{"c"}, Children: []*Bundle{child}}
+		if err := b.Validate(); err == nil {
+			t.Fatal("expected child in NamedDependsOn to fail")
+		}
+	})
+	t.Run("child NamedDependsOn containing parent rejected", func(t *testing.T) {
+		parent := &Bundle{Name: "p"}
+		child := &Bundle{Name: "c", NamedDependsOn: []string{"p"}}
+		parent.Children = []*Bundle{child}
+		if err := parent.Validate(); err == nil {
+			t.Fatal("expected child->parent NamedDependsOn to fail")
+		}
+	})
 }
 
 func TestBundleIsUmbrella(t *testing.T) {

--- a/pkg/stack/fluxcd/fluxcd_test.go
+++ b/pkg/stack/fluxcd/fluxcd_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"slices"
 	"strings"
 	"testing"
 
@@ -871,6 +872,39 @@ func TestEndToEndUmbrellaFromCluster_Separate(t *testing.T) {
 		if !kustNames[want] {
 			t.Errorf("flux-system missing Kustomization %q, got %v", want, kustNames)
 		}
+	}
+}
+
+func TestGenerateFromBundle_NamedDependsOn(t *testing.T) {
+	b := &stack.Bundle{
+		Name: "app-post",
+		SourceRef: &stack.SourceRef{
+			Kind:      "GitRepository",
+			Name:      "demo",
+			Namespace: "flux-system",
+		},
+		NamedDependsOn: []string{"app-main", "app-pre"},
+	}
+	objs, err := fluxstack.Engine().GenerateFromBundle(b)
+	if err != nil {
+		t.Fatalf("GenerateFromBundle: %v", err)
+	}
+	var kust *kustv1.Kustomization
+	for _, o := range objs {
+		if k, ok := o.(*kustv1.Kustomization); ok {
+			kust = k
+			break
+		}
+	}
+	if kust == nil {
+		t.Fatal("no Kustomization in output")
+	}
+	got := make([]string, len(kust.Spec.DependsOn))
+	for i, d := range kust.Spec.DependsOn {
+		got[i] = d.Name
+	}
+	if !slices.Contains(got, "app-main") || !slices.Contains(got, "app-pre") {
+		t.Errorf("unexpected DependsOn: %v", got)
 	}
 }
 

--- a/pkg/stack/fluxcd/resource_generator.go
+++ b/pkg/stack/fluxcd/resource_generator.go
@@ -300,6 +300,11 @@ func (g *ResourceGenerator) createKustomization(b *stack.Bundle) client.Object {
 			Name: dep.Name,
 		})
 	}
+	for _, name := range b.NamedDependsOn {
+		kust.Spec.DependsOn = append(kust.Spec.DependsOn, kustv1.DependencyReference{
+			Name: name,
+		})
+	}
 
 	return kust
 }

--- a/site/content/concepts/domain-model.md
+++ b/site/content/concepts/domain-model.md
@@ -30,7 +30,7 @@ Nodes map to **directory structures** in the GitOps repository. Each node can al
 
 A deployment unit corresponding to a single GitOps reconciliation resource (e.g., a Flux Kustomization or ArgoCD Application). Bundles contain applications and support:
 
-- **Dependency ordering** via `DependsOn` (e.g., "deploy cert-manager before my app")
+- **Dependency ordering** via `DependsOn` (pointer-based, in-scope bundles) or `NamedDependsOn` (name-based, for cross-scope or hook-phase chains)
 - **Umbrella composition** via `Children` (see below)
 - **Reconciliation settings**: interval, pruning, timeouts
 - **Labels and annotations** for metadata


### PR DESCRIPTION
Closes #551

## Summary

- Adds `NamedDependsOn []string` to `stack.Bundle` for pointer-free, name-based Kustomization dependency chaining
- Both `DependsOn` and `NamedDependsOn` merge into `kust.Spec.DependsOn` in the resource generator
- Full validation: empty names, duplicates, cross-field duplicates (DependsOn/NamedDependsOn), Children overlap, child→parent cycles
- Deep-copies the new field in `builders.go`
- Fixes stale `Node.Bundle` slice error in `pkg/stack/README.md`
- Updates `site/content/concepts/domain-model.md` to mention both dependency forms

## Test plan

- [ ] `go test ./pkg/stack/...` — 5 new validation test cases in `TestBundleValidateUmbrellaChildren`
- [ ] `go test ./pkg/stack/fluxcd/...` — `TestGenerateFromBundle_NamedDependsOn` verifies both names appear in `kust.Spec.DependsOn`
- [ ] `mise run check` passes