### PR TITLE
feat: add SplitByHookWeight utility for helm hook-phase ordering

### DIFF
--- a/pkg/stack/helm/README.md
+++ b/pkg/stack/helm/README.md
@@ -1,14 +1,19 @@
 # pkg/stack/helm
 
-Client-side Helm chart rendering from OCI registries.
+Client-side Helm chart rendering and hook-phase splitting for GitOps deployment.
 
 ## Overview
 
-This package provides `RenderChart`, which pulls a Helm chart from an OCI
-registry and renders its templates locally — equivalent to `helm template` —
-returning multi-document YAML. No Kubernetes cluster connection is required.
+This package provides two utilities:
 
-## Usage
+- **`RenderChart`** — pulls a Helm chart from an OCI registry and renders its
+  templates locally (equivalent to `helm template`), returning multi-document YAML.
+- **`SplitByHookWeight`** — groups rendered Helm manifests by hook phase and weight
+  for ordered FluxCD Kustomization generation.
+
+No Kubernetes cluster connection is required.
+
+## RenderChart
 
 ```go
 import "github.com/go-kure/kure/pkg/stack/helm"
@@ -29,8 +34,6 @@ if err != nil {
 // manifests is multi-doc YAML suitable for kubectl apply -f -
 ```
 
-## API
-
 ```go
 // RenderChart pulls a Helm chart from an OCI registry and renders it
 // client-side, returning multi-doc YAML.
@@ -39,6 +42,49 @@ if err != nil {
 // version is the chart version tag (e.g. "1.16.5").
 // values are merged on top of the chart's default values.
 func RenderChart(chartURL, version string, values map[string]any) ([]byte, error)
+```
+
+## SplitByHookWeight
+
+Groups a slice of rendered Helm objects by `helm.sh/hook` phase and
+`helm.sh/hook-weight` for ordered FluxCD Kustomization generation.
+
+```go
+objects, _ := helm.RenderChart("oci://example.com/chart", "1.0.0", nil)
+parsed := parseYAML(objects) // []client.Object
+
+groups := helm.SplitByHookWeight(parsed)
+for _, g := range groups {
+    // each group becomes one FluxCD Kustomization, deployed in order
+    fmt.Printf("phase=%q weight=%d resources=%d\n", g.Phase, g.Weight, len(g.Resources))
+}
+```
+
+**Phase ordering policy:**
+
+| Phase | Order | Notes |
+|---|---|---|
+| `pre-install` | 0 | before main resources, on install |
+| `pre-upgrade` | 1 | before main resources, on upgrade |
+| `""` (non-hook) | 2 | main resources |
+| `post-install` | 3 | after main resources, on install |
+| `post-upgrade` | 4 | after main resources, on upgrade |
+| unknown | 5+ alphabetical | unrecognised phases, included conservatively |
+| `pre-delete`, `post-delete`, `pre-rollback`, `post-rollback`, `test` | — | **excluded**: no FluxCD lifecycle equivalent |
+
+Comma-separated annotations (e.g. `"pre-install,post-install"`) are treated as
+a single opaque phase string and placed in the unknown group to avoid SSA
+ownership conflicts between multiple Kustomizations.
+
+```go
+// HookGroup is a set of Helm manifests sharing the same hook phase and weight.
+type HookGroup struct {
+    Phase     string
+    Weight    int
+    Resources []client.Object
+}
+
+func SplitByHookWeight(objects []client.Object) []HookGroup
 ```
 
 ## Notes

--- a/pkg/stack/helm/hooks.go
+++ b/pkg/stack/helm/hooks.go
@@ -1,0 +1,97 @@
+package helm
+
+import (
+	"sort"
+	"strconv"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// HookGroup is a set of Helm manifests sharing the same hook phase and weight.
+// Resources with no helm.sh/hook annotation have Phase="" and Weight=0 (main group).
+type HookGroup struct {
+	Phase     string
+	Weight    int
+	Resources []client.Object
+}
+
+// excludedHookPhases lists Helm hook phases that have no equivalent in a FluxCD
+// GitOps lifecycle. Objects with these phases are dropped from SplitByHookWeight output.
+var excludedHookPhases = map[string]bool{
+	"pre-delete":    true,
+	"post-delete":   true,
+	"pre-rollback":  true,
+	"post-rollback": true,
+	"test":          true,
+}
+
+// SplitByHookWeight groups rendered Helm manifests by hook phase and weight for
+// ordered FluxCD Kustomization generation. Groups are returned in execution order:
+// pre-install, pre-upgrade, main (non-hook), post-install, post-upgrade, then any
+// remaining unknown hook phases alphabetically.
+//
+// Objects whose helm.sh/hook phase has no FluxCD lifecycle equivalent
+// (pre-delete, post-delete, pre-rollback, post-rollback, test) are excluded.
+// Comma-separated hook annotations (e.g. "pre-install,post-install") are treated
+// as a single opaque phase string and placed in the unknown group.
+func SplitByHookWeight(objects []client.Object) []HookGroup {
+	if len(objects) == 0 {
+		return nil
+	}
+	type key struct {
+		phase  string
+		weight int
+	}
+	groupMap := map[key][]client.Object{}
+	for _, obj := range objects {
+		ann := obj.GetAnnotations()
+		phase := ann["helm.sh/hook"]
+		if excludedHookPhases[phase] {
+			continue
+		}
+		weight := 0
+		if w, err := strconv.Atoi(ann["helm.sh/hook-weight"]); err == nil {
+			weight = w
+		}
+		k := key{phase, weight}
+		groupMap[k] = append(groupMap[k], obj)
+	}
+
+	phaseOrder := func(phase string) int {
+		switch phase {
+		case "pre-install":
+			return 0
+		case "pre-upgrade":
+			return 1
+		case "":
+			return 2
+		case "post-install":
+			return 3
+		case "post-upgrade":
+			return 4
+		default:
+			return 5
+		}
+	}
+
+	keys := make([]key, 0, len(groupMap))
+	for k := range groupMap {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		oi, oj := phaseOrder(keys[i].phase), phaseOrder(keys[j].phase)
+		if oi != oj {
+			return oi < oj
+		}
+		if keys[i].phase != keys[j].phase {
+			return keys[i].phase < keys[j].phase
+		}
+		return keys[i].weight < keys[j].weight
+	})
+
+	groups := make([]HookGroup, 0, len(keys))
+	for _, k := range keys {
+		groups = append(groups, HookGroup{Phase: k.phase, Weight: k.weight, Resources: groupMap[k]})
+	}
+	return groups
+}

--- a/pkg/stack/helm/hooks_test.go
+++ b/pkg/stack/helm/hooks_test.go
@@ -1,0 +1,167 @@
+package helm_test
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/kure/pkg/stack/helm"
+)
+
+func hookObj(name, hookAnno, weightAnno string) client.Object {
+	u := &unstructured.Unstructured{}
+	u.SetName(name)
+	ann := map[string]string{}
+	if hookAnno != "" {
+		ann["helm.sh/hook"] = hookAnno
+	}
+	if weightAnno != "" {
+		ann["helm.sh/hook-weight"] = weightAnno
+	}
+	u.SetAnnotations(ann)
+	return u
+}
+
+func TestSplitByHookWeight_NoHooks(t *testing.T) {
+	groups := helm.SplitByHookWeight([]client.Object{hookObj("a", "", ""), hookObj("b", "", "")})
+	if len(groups) != 1 {
+		t.Fatalf("want 1, got %d", len(groups))
+	}
+	if groups[0].Phase != "" {
+		t.Errorf("want main phase, got %q", groups[0].Phase)
+	}
+	if len(groups[0].Resources) != 2 {
+		t.Errorf("want 2 resources, got %d", len(groups[0].Resources))
+	}
+}
+
+func TestSplitByHookWeight_PreMainPost(t *testing.T) {
+	objs := []client.Object{
+		hookObj("pre", "pre-install", "0"),
+		hookObj("main", "", ""),
+		hookObj("post", "post-install", "0"),
+	}
+	groups := helm.SplitByHookWeight(objs)
+	if len(groups) != 3 {
+		t.Fatalf("want 3, got %d", len(groups))
+	}
+	if groups[0].Phase != "pre-install" {
+		t.Errorf("[0]: %q", groups[0].Phase)
+	}
+	if groups[1].Phase != "" {
+		t.Errorf("[1]: %q", groups[1].Phase)
+	}
+	if groups[2].Phase != "post-install" {
+		t.Errorf("[2]: %q", groups[2].Phase)
+	}
+}
+
+func TestSplitByHookWeight_UpgradePhases_OrderedAroundMain(t *testing.T) {
+	// pre-upgrade and post-upgrade are included; FluxCD reconciliations are equivalent to upgrades.
+	objs := []client.Object{
+		hookObj("pi", "pre-install", "0"),
+		hookObj("pu", "pre-upgrade", "0"),
+		hookObj("main", "", ""),
+		hookObj("po", "post-install", "0"),
+		hookObj("pou", "post-upgrade", "0"),
+	}
+	groups := helm.SplitByHookWeight(objs)
+	if len(groups) != 5 {
+		t.Fatalf("want 5, got %d", len(groups))
+	}
+	want := []string{"pre-install", "pre-upgrade", "", "post-install", "post-upgrade"}
+	for i, w := range want {
+		if groups[i].Phase != w {
+			t.Errorf("[%d]: want %q got %q", i, w, groups[i].Phase)
+		}
+	}
+}
+
+func TestSplitByHookWeight_MultiWeight_AscendingOrder(t *testing.T) {
+	objs := []client.Object{
+		hookObj("pre-w2", "pre-install", "2"),
+		hookObj("pre-w1", "pre-install", "1"),
+		hookObj("main", "", ""),
+	}
+	groups := helm.SplitByHookWeight(objs)
+	if len(groups) != 3 {
+		t.Fatalf("want 3, got %d", len(groups))
+	}
+	if groups[0].Weight != 1 {
+		t.Errorf("[0] weight want 1, got %d", groups[0].Weight)
+	}
+	if groups[1].Weight != 2 {
+		t.Errorf("[1] weight want 2, got %d", groups[1].Weight)
+	}
+}
+
+func TestSplitByHookWeight_ExcludedPhases_Dropped(t *testing.T) {
+	// pre-delete, post-delete, pre-rollback, post-rollback, test have no FluxCD equivalent.
+	objs := []client.Object{
+		hookObj("main", "", ""),
+		hookObj("predelete", "pre-delete", "0"),
+		hookObj("postdel", "post-delete", "0"),
+		hookObj("preroll", "pre-rollback", "0"),
+		hookObj("postroll", "post-rollback", "0"),
+		hookObj("test", "test", "0"),
+	}
+	groups := helm.SplitByHookWeight(objs)
+	if len(groups) != 1 {
+		t.Fatalf("want 1 (main only), got %d", len(groups))
+	}
+	if groups[0].Phase != "" {
+		t.Errorf("want main phase, got %q", groups[0].Phase)
+	}
+}
+
+func TestSplitByHookWeight_UnknownPhase_LastAlphabetical(t *testing.T) {
+	// Unknown phases (not in the include/exclude lists) go after post-upgrade, sorted alphabetically.
+	objs := []client.Object{
+		hookObj("pre", "pre-install", "0"),
+		hookObj("custom", "custom-hook", "0"), // unknown, not excluded
+		hookObj("main", "", ""),
+	}
+	groups := helm.SplitByHookWeight(objs)
+	if len(groups) != 3 {
+		t.Fatalf("want 3, got %d", len(groups))
+	}
+	if groups[0].Phase != "pre-install" {
+		t.Errorf("[0]: %q", groups[0].Phase)
+	}
+	if groups[1].Phase != "" {
+		t.Errorf("[1]: %q", groups[1].Phase)
+	}
+	if groups[2].Phase != "custom-hook" {
+		t.Errorf("[2]: %q (want unknown last)", groups[2].Phase)
+	}
+}
+
+func TestSplitByHookWeight_NilInput(t *testing.T) {
+	if groups := helm.SplitByHookWeight(nil); len(groups) != 0 {
+		t.Fatalf("want 0, got %d", len(groups))
+	}
+}
+
+func TestSplitByHookWeight_CommaAnnotation_TreatedAsUnknown(t *testing.T) {
+	// Comma-separated annotations must remain opaque (no splitting), placed last as unknown.
+	// This locks in the review decision to avoid later regression into duplication.
+	objs := []client.Object{
+		hookObj("pre", "pre-install", "0"),
+		hookObj("main", "", ""),
+		hookObj("multi", "pre-install,post-install", "0"),
+	}
+	groups := helm.SplitByHookWeight(objs)
+	if len(groups) != 3 {
+		t.Fatalf("want 3, got %d", len(groups))
+	}
+	if groups[0].Phase != "pre-install" {
+		t.Errorf("[0]: %q", groups[0].Phase)
+	}
+	if groups[1].Phase != "" {
+		t.Errorf("[1]: %q", groups[1].Phase)
+	}
+	if groups[2].Phase != "pre-install,post-install" {
+		t.Errorf("[2]: %q (want comma annotation as unknown, last)", groups[2].Phase)
+	}
+}


### PR DESCRIPTION
Closes #550

## Summary

- Adds `SplitByHookWeight([]client.Object) []HookGroup` to `pkg/stack/helm`
- Groups manifests by `helm.sh/hook` phase and weight for ordered FluxCD Kustomization generation

**Phase ordering (execution order):** `pre-install` → `pre-upgrade` → main → `post-install` → `post-upgrade` → unknown phases (alphabetical)

**Design decision (extends #550 scope):** `pre-upgrade` and `post-upgrade` are included because FluxCD reconciliations are semantically equivalent to Helm upgrades. Phases with no FluxCD lifecycle equivalent (`pre-delete`, `post-delete`, `pre-rollback`, `post-rollback`, `test`) are excluded — objects with these phases are dropped from output. Comma-separated annotations (e.g. `"pre-install,post-install"`) are treated as a single opaque phase (unknown group) to avoid SSA ownership conflicts when duplicating objects across Kustomizations.

## Test plan

- [ ] 8 test cases in `TestSplitByHookWeight_*`: NoHooks, PreMainPost, UpgradePhases, MultiWeight, ExcludedPhases, UnknownPhase, NilInput, CommaAnnotation
- [ ] `mise run check` passes