### PR TITLE
test: add HelmRepository golden tests; rewrite pkg/kubernetes/fluxcd README

### DIFF
--- a/pkg/kubernetes/fluxcd/README.md
+++ b/pkg/kubernetes/fluxcd/README.md
@@ -143,9 +143,7 @@ fluxcd.SetHelmReleaseChart(hr, &helmv2.HelmChartTemplate{
         },
     },
 })
-_ = fluxcd.SetHelmReleaseValuesFromMap(hr, map[string]any{
-    "replicaCount": 3,
-})
+fluxcd.SetHelmReleaseValues(hr, &apiextensionsv1.JSON{Raw: []byte(`{"replicaCount":3}`)})
 fluxcd.AddHelmReleaseValuesFrom(hr, helmv2.ValuesReference{
     Kind: "ConfigMap",
     Name: "redis-defaults",

--- a/pkg/kubernetes/fluxcd/README.md
+++ b/pkg/kubernetes/fluxcd/README.md
@@ -1,193 +1,224 @@
-# FluxCD Builders - Flux Resource Constructors
+# pkg/kubernetes/fluxcd
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/go-kure/kure/pkg/kubernetes/fluxcd.svg)](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/fluxcd)
 
-The `fluxcd` package provides strongly-typed constructor functions for creating FluxCD Kubernetes resources. These are the low-level building blocks used by Kure's higher-level stack and workflow packages.
+Low-level builder functions for FluxCD Kubernetes resources. Each resource type follows the `Create*(name, namespace)` + `Set*()/Add*()` pattern.
 
-## Overview
+## Source Controllers
 
-Each function takes a configuration struct and returns a fully initialized Flux custom resource. The builders handle API version and kind metadata, letting you focus on the resource specification.
-
-## Supported Resources
-
-### Source Controllers
+### GitRepository
 
 ```go
-import "github.com/go-kure/kure/pkg/kubernetes/fluxcd"
+gr := fluxcd.CreateGitRepository("my-repo", "flux-system")
+fluxcd.SetGitRepositoryURL(gr, "https://github.com/org/repo")
+fluxcd.SetGitRepositoryReference(gr, &sourcev1.GitRepositoryRef{Branch: "main"})
+fluxcd.SetGitRepositoryInterval(gr, metav1.Duration{Duration: 5 * time.Minute})
+fluxcd.SetGitRepositorySecretRef(gr, &meta.LocalObjectReference{Name: "git-credentials"})
+```
 
-// Git repository source
-gitRepo := fluxcd.GitRepository(&fluxcd.GitRepositoryConfig{
-    Name:      "my-repo",
-    Namespace: "flux-system",
-    URL:       "https://github.com/org/repo",
-    Ref:       "main",
-    Interval:  "5m",
+Additional setters: `SetGitRepositoryProvider`, `SetGitRepositoryTimeout`, `SetGitRepositoryVerification`,
+`SetGitRepositoryProxySecretRef`, `SetGitRepositoryIgnore`, `SetGitRepositorySuspend`,
+`SetGitRepositoryRecurseSubmodules`, `AddGitRepositoryInclude`,
+`SetGitRepositorySparseCheckout`, `AddGitRepositorySparseCheckoutPath`,
+`SetGitRepositoryServiceAccountName`.
+
+### OCIRepository
+
+```go
+oci := fluxcd.CreateOCIRepository("my-manifests", "flux-system")
+fluxcd.SetOCIRepositoryURL(oci, "oci://registry.example.com/manifests")
+fluxcd.SetOCIRepositoryReference(oci, &sourcev1.OCIRepositoryRef{Tag: "latest"})
+fluxcd.SetOCIRepositoryInterval(oci, metav1.Duration{Duration: 10 * time.Minute})
+fluxcd.SetOCIRepositorySecretRef(oci, &meta.LocalObjectReference{Name: "registry-credentials"})
+```
+
+Additional setters: `SetOCIRepositoryProvider`, `SetOCIRepositoryLayerSelector`,
+`SetOCIRepositoryVerify`, `SetOCIRepositoryServiceAccountName`, `SetOCIRepositoryCertSecretRef`,
+`SetOCIRepositoryProxySecretRef`, `SetOCIRepositoryTimeout`, `SetOCIRepositoryIgnore`,
+`SetOCIRepositoryInsecure`, `SetOCIRepositorySuspend`.
+
+### HelmRepository
+
+**HTTP/HTTPS repository:**
+
+```go
+hr := fluxcd.CreateHelmRepository("bitnami", "flux-system")
+fluxcd.SetHelmRepositoryURL(hr, "https://charts.bitnami.com/bitnami")
+fluxcd.SetHelmRepositoryType(hr, "default")
+fluxcd.SetHelmRepositoryInterval(hr, metav1.Duration{Duration: 10 * time.Minute})
+fluxcd.SetHelmRepositoryTimeout(hr, &metav1.Duration{Duration: 60 * time.Second})
+fluxcd.SetHelmRepositoryPassCredentials(hr, true)
+fluxcd.SetHelmRepositorySecretRef(hr, &meta.LocalObjectReference{Name: "bitnami-auth"})
+```
+
+**OCI registry:**
+
+```go
+hr := fluxcd.CreateHelmRepository("ghcr-charts", "flux-system")
+fluxcd.SetHelmRepositoryURL(hr, "oci://ghcr.io/example/charts")
+fluxcd.SetHelmRepositoryType(hr, "oci")
+fluxcd.SetHelmRepositoryProvider(hr, "generic") // OCI-only: generic, aws, azure, gcp
+fluxcd.SetHelmRepositoryInterval(hr, metav1.Duration{Duration: 5 * time.Minute})
+fluxcd.SetHelmRepositorySecretRef(hr, &meta.LocalObjectReference{Name: "ghcr-auth"})
+```
+
+Additional setters: `SetHelmRepositoryCertSecretRef`, `SetHelmRepositoryInsecure` (OCI only),
+`SetHelmRepositorySuspend`, `SetHelmRepositoryAccessFrom`.
+
+### HelmChart
+
+```go
+hc := fluxcd.CreateHelmChart("redis", "flux-system")
+fluxcd.SetHelmChartChart(hc, "redis")
+fluxcd.SetHelmChartVersion(hc, "19.0.0")
+fluxcd.SetHelmChartSourceRef(hc, sourcev1.LocalHelmChartSourceReference{
+    Kind: "HelmRepository",
+    Name: "bitnami",
 })
+fluxcd.SetHelmChartInterval(hc, metav1.Duration{Duration: 10 * time.Minute})
+```
 
-// OCI repository source — tag reference
-ociRepo := fluxcd.OCIRepository(&fluxcd.OCIRepositoryConfig{
-    Name:      "my-oci",
-    Namespace: "flux-system",
-    URL:       "oci://registry.example.com/manifests",
-    Ref:       "latest",
-    Interval:  "10m",
+Additional setters: `SetHelmChartReconcileStrategy`, `AddHelmChartValuesFile`,
+`SetHelmChartValuesFiles`, `SetHelmChartIgnoreMissingValuesFiles`,
+`SetHelmChartSuspend`, `SetHelmChartVerify`.
+
+### Bucket
+
+```go
+b := fluxcd.CreateBucket("my-bucket", "flux-system")
+fluxcd.SetBucketEndpoint(b, "minio.example.com")
+fluxcd.SetBucketName(b, "manifests")
+fluxcd.SetBucketInterval(b, metav1.Duration{Duration: 10 * time.Minute})
+fluxcd.SetBucketSecretRef(b, &meta.LocalObjectReference{Name: "minio-credentials"})
+```
+
+Additional setters: `SetBucketProvider`, `SetBucketSTS`, `SetBucketInsecure`, `SetBucketRegion`,
+`SetBucketPrefix`, `SetBucketCertSecretRef`, `SetBucketProxySecretRef`,
+`SetBucketTimeout`, `SetBucketIgnore`, `SetBucketSuspend`.
+
+## Deployment Controllers
+
+### Kustomization
+
+```go
+k := fluxcd.CreateKustomization("my-app", "flux-system")
+fluxcd.SetKustomizationSourceRef(k, kustv1.CrossNamespaceSourceReference{
+    Kind: "GitRepository",
+    Name: "my-repo",
 })
+fluxcd.SetKustomizationPath(k, "./clusters/production/apps")
+fluxcd.SetKustomizationInterval(k, metav1.Duration{Duration: 10 * time.Minute})
+fluxcd.SetKustomizationPrune(k, true)
+fluxcd.SetKustomizationTargetNamespace(k, "production")
+fluxcd.SetKustomizationWait(k, true)
+fluxcd.AddKustomizationDependsOn(k, kustv1.DependencyReference{Name: "cert-manager"})
+```
 
-// OCI repository source — digest (content-addressable) reference
-ociRepoDigest := fluxcd.OCIRepository(&fluxcd.OCIRepositoryConfig{
-    Name:      "my-oci-pinned",
-    Namespace: "flux-system",
-    URL:       "oci://registry.example.com/manifests",
-    Digest:    "sha256:abc123...",
-    Interval:  "10m",
+Additional setters: `SetKustomizationRetryInterval`, `SetKustomizationKubeConfig`,
+`SetKustomizationDeletionPolicy`, `AddKustomizationHealthCheck`,
+`AddKustomizationHealthCheckExpr`, `AddKustomizationComponent`,
+`SetKustomizationServiceAccountName`, `SetKustomizationSuspend`,
+`SetKustomizationTimeout`, `SetKustomizationForce`,
+`SetKustomizationIgnoreMissingComponents`, `AddKustomizationImage`,
+`AddKustomizationPatch`, `SetKustomizationNamePrefix`, `SetKustomizationNameSuffix`,
+`SetKustomizationCommonMetadata`, `SetKustomizationDecryption`, `SetKustomizationPostBuild`.
+
+### HelmRelease
+
+**Chart template (chart + version + source reference):**
+
+```go
+hr := fluxcd.CreateHelmRelease("redis", "apps")
+fluxcd.SetHelmReleaseReleaseName(hr, "redis-prod")
+fluxcd.SetHelmReleaseTargetNamespace(hr, "apps")
+fluxcd.SetHelmReleaseInterval(hr, metav1.Duration{Duration: 10 * time.Minute})
+fluxcd.SetHelmReleaseChart(hr, &helmv2.HelmChartTemplate{
+    Spec: helmv2.HelmChartTemplateSpec{
+        Chart:   "redis",
+        Version: "19.0.0",
+        SourceRef: helmv2.CrossNamespaceObjectReference{
+            Kind:      "HelmRepository",
+            Name:      "bitnami",
+            Namespace: "flux-system",
+        },
+    },
 })
-
-// Helm repository (HTTP/HTTPS)
-helmRepo := fluxcd.HelmRepository(&fluxcd.HelmRepositoryConfig{
-    Name:      "bitnami",
-    Namespace: "flux-system",
-    URL:       "https://charts.bitnami.com/bitnami",
-    Interval:  "10m",
+_ = fluxcd.SetHelmReleaseValuesFromMap(hr, map[string]any{
+    "replicaCount": 3,
 })
-
-// Helm repository (OCI registry)
-ociHelmRepo := fluxcd.HelmRepository(&fluxcd.HelmRepositoryConfig{
-    Name:      "ghcr",
-    Namespace: "flux-system",
-    URL:       "oci://ghcr.io/example/charts",
-    Type:      sourcev1.HelmRepositoryTypeOCI, // "oci"
-    Interval:  "10m",
-})
-
-// Bucket source
-bucket := fluxcd.Bucket(&fluxcd.BucketConfig{
-    Name:       "my-bucket",
-    Namespace:  "flux-system",
-    Endpoint:   "minio.example.com",
-    BucketName: "manifests",
+fluxcd.AddHelmReleaseValuesFrom(hr, helmv2.ValuesReference{
+    Kind: "ConfigMap",
+    Name: "redis-defaults",
 })
 ```
 
-### Deployment Controllers
+**ChartRef mode (existing OCIRepository or HelmChart):**
 
 ```go
-// Kustomization (reconciles manifests from a source)
-ks := fluxcd.Kustomization(&fluxcd.KustomizationConfig{
-    Name:            "my-app",
-    Namespace:       "flux-system",
-    Path:            "./clusters/production/apps",
-    Interval:        "10m",
-    Prune:           true,
-    TargetNamespace: "production",
-    Wait:            true,
-    SourceRef: kustv1.CrossNamespaceSourceReference{
-        Kind: "GitRepository",
-        Name: "my-repo",
-    },
-})
-
-// HelmRelease — chart template mode (chart + version + source reference)
-installRetries := 3
-upgradeRetries := 3
-hr := fluxcd.HelmRelease(&fluxcd.HelmReleaseConfig{
-    Name:        "redis",
-    Namespace:   "apps",
-    Chart:       "redis",
-    Version:     "17.0.0",
-    SourceRef:   helmv2.CrossNamespaceObjectReference{Kind: "HelmRepository", Name: "bitnami"},
-    Interval:    "10m",
-    ReleaseName: "redis",
-    TargetNamespace:       "databases",
-    DriftDetectionMode:    "enabled",
-    InstallCRDs:           "CreateReplace",
-    InstallRetries:        &installRetries,
-    UpgradeCRDs:           "Skip",
-    UpgradeCleanupOnFail:  true,
-    UpgradeRetries:        &upgradeRetries,
-    RollbackCleanupOnFail: true,
-    ValuesFrom: []fluxcd.ValuesFromConfig{
-        {Kind: "ConfigMap", Name: "redis-values"},
-        {Kind: "Secret", Name: "redis-secret", Optional: true},
-    },
-    Values: map[string]any{
-        "replicaCount": 1,
-    },
-})
-
-// HelmRelease — chartRef mode (references an existing OCIRepository or HelmChart)
-hr = fluxcd.HelmRelease(&fluxcd.HelmReleaseConfig{
-    Name:      "my-app",
-    Namespace: "apps",
-    Interval:  "10m",
-    ChartRef: &fluxcd.ChartRefConfig{
-        Kind:      "OCIRepository",
-        Name:      "my-oci-source",
-        Namespace: "flux-system",
-    },
+hr := fluxcd.CreateHelmRelease("my-app", "apps")
+fluxcd.SetHelmReleaseChartRef(hr, &helmv2.CrossNamespaceSourceReference{
+    Kind:      "OCIRepository",
+    Name:      "my-oci-source",
+    Namespace: "flux-system",
 })
 ```
 
-### Notification Controllers
+**Drift detection and remediation:**
 
-> **Note:** Provider and Alert use `notification.toolkit.fluxcd.io/v1beta3` — the highest
-> API version available upstream. Receiver is on v1. See [compatibility](/api-reference/compatibility/#notification-controller-provider-and-alert-on-v1beta3)
+```go
+fluxcd.SetHelmReleaseDriftDetection(hr, fluxcd.CreateDriftDetection(helmv2.DriftDetectionEnabled))
+fluxcd.SetHelmReleaseInstallCRDs(hr, helmv2.CreateReplace)
+fluxcd.SetHelmReleaseInstallRemediation(hr, fluxcd.CreateInstallRemediation(3))
+fluxcd.SetHelmReleaseUpgradeCRDs(hr, helmv2.CreateReplace)
+fluxcd.SetHelmReleaseUpgradeRemediation(hr, fluxcd.CreateUpgradeRemediation(3))
+```
+
+**Post-render:**
+
+```go
+k := fluxcd.CreatePostRendererKustomize()
+fluxcd.AddPostRendererKustomizeImage(k, kustomize.Image{Name: "redis", NewTag: "7.0"})
+fluxcd.AddHelmReleasePostRenderer(hr, helmv2.PostRenderer{Kustomize: k})
+```
+
+Additional setters: `SetHelmReleaseKubeConfig`, `SetHelmReleaseSuspend`,
+`SetHelmReleaseStorageNamespace`, `AddHelmReleaseDependsOn`, `SetHelmReleaseTimeout`,
+`SetHelmReleaseMaxHistory`, `SetHelmReleaseServiceAccountName`, `SetHelmReleasePersistentClient`,
+`SetHelmReleaseInstall`, `SetHelmReleaseUpgrade`, `SetHelmReleaseRollback`,
+`SetHelmReleaseUninstall`, `SetHelmReleaseTest`, `SetHelmReleaseValues`,
+`SetHelmReleaseCommonMetadata`, `AddHelmReleaseHealthCheckExpr`, `SetHelmReleaseWaitStrategy`,
+plus fine-grained `SetHelmReleaseInstall*` and `SetHelmReleaseUpgrade*` flag setters.
+
+## Notification Controllers
+
+> **Note:** Provider and Alert use `notification.toolkit.fluxcd.io/v1beta3`. Receiver is on v1.
+> See [compatibility](/api-reference/compatibility/#notification-controller-provider-and-alert-on-v1beta3)
 > for details and tracking issue [#250](https://github.com/go-kure/kure/issues/250).
 
 ```go
-// Alert
-alert := fluxcd.Alert(&fluxcd.AlertConfig{
-    Name:          "slack-alert",
-    Namespace:     "flux-system",
-    ProviderRef:   "slack",
-    EventSeverity: "error",
-})
+provider := fluxcd.CreateProvider("slack", "flux-system")
+// SetProvider* setters configure type, channel, secretRef, etc.
 
-// Provider
-provider := fluxcd.Provider(&fluxcd.ProviderConfig{
-    Name:      "slack",
-    Namespace: "flux-system",
-    Type:      "slack",
-    Channel:   "#alerts",
-})
+alert := fluxcd.CreateAlert("slack-alert", "flux-system")
+// SetAlert* setters configure providerRef, eventSeverity, summary, etc.
 
-// Receiver (for webhooks)
-receiver := fluxcd.Receiver(&fluxcd.ReceiverConfig{
-    Name:      "github-receiver",
-    Namespace: "flux-system",
-    Type:      "github",
-})
+receiver := fluxcd.CreateReceiver("github-receiver", "flux-system")
+// SetReceiver* setters configure type, events, resources, secretRef, etc.
 ```
 
-### Flux Operator
+## Flux Operator
 
 ```go
-// FluxInstance (for flux-operator deployments)
-instance := fluxcd.FluxInstance(&fluxcd.FluxInstanceConfig{
-    Name:      "flux",
-    Namespace: "flux-system",
-})
+instance := fluxcd.CreateFluxInstance("flux", "flux-system")
+fluxcd.SetFluxInstanceDistributionVariant(instance, "upstream-alpine")
+// Additional: SetFluxInstance* for distribution, cluster, sharding, storage, kustomize, sync, wait.
 ```
 
-## Modifier Functions
+## Extended Resource Types
 
-Update existing resources:
+### ExternalArtifact
 
-```go
-// Update Kustomization spec
-err := fluxcd.SetKustomizationSpec(ks, newSpec)
-
-// Update HelmRelease spec
-err := fluxcd.SetHelmReleaseSpec(hr, newSpec)
-
-// Add dependency to Kustomization
-err := fluxcd.AddKustomizationDependency(ks, kustv1.Dependency{
-    Name: "cert-manager",
-})
-```
-
-### ExternalArtifact (source.toolkit.fluxcd.io/v1)
-
-`ExternalArtifact` allows a Flux source artifact produced outside the cluster to be referenced by other Flux resources.
+Allows a Flux source artifact produced outside the cluster to be referenced by other Flux resources.
 
 ```go
 ea := fluxcd.CreateExternalArtifact("my-artifact", "flux-system")
@@ -197,92 +228,27 @@ fluxcd.SetExternalArtifactSourceRef(ea, &meta.NamespacedObjectKindReference{
     Name:       "my-oci-source",
     Namespace:  "flux-system",
 })
-// Replace the full spec when needed:
-// fluxcd.SetExternalArtifactSpec(ea, newSpec)
 ```
 
-Available functions: `CreateExternalArtifact`, `SetExternalArtifactSourceRef`, `SetExternalArtifactSpec`.
+### ArtifactGenerator
 
-### ArtifactGenerator (source.extensions.fluxcd.io/v1beta1)
-
-`ArtifactGenerator` is provided by the optional **source-watcher** component. It assembles a new artifact by copying files from one or more source artifacts.
+Provided by the optional **source-watcher** component. Assembles a new artifact by copying files from one or more source artifacts.
 
 ```go
 ag := fluxcd.CreateArtifactGenerator("my-gen", "flux-system")
 
-// Declare source references
 src := fluxcd.CreateSourceReference("app", "my-oci-source", "OCIRepository")
 fluxcd.SetSourceReferenceNamespace(&src, "flux-system")
 fluxcd.AddArtifactGeneratorSource(ag, src)
 
-// Build an output artifact with a copy operation
 out := fluxcd.CreateOutputArtifact("combined")
 fluxcd.SetOutputArtifactRevision(&out, "@app")
-
 cp := fluxcd.CreateCopyOperation("@app/manifests/**", "@artifact/manifests")
-fluxcd.AddCopyOperationExclude(&cp, "**/*.secret.yaml")
-fluxcd.SetCopyOperationStrategy(&cp, "Overwrite")
 fluxcd.AddOutputArtifactCopyOperation(&out, cp)
-
 fluxcd.AddArtifactGeneratorOutputArtifact(ag, out)
 ```
 
-Available functions:
-- Resource: `CreateArtifactGenerator`, `AddArtifactGeneratorSource`, `AddArtifactGeneratorOutputArtifact`
-- Source references: `CreateSourceReference`, `SetSourceReferenceNamespace`
-- Output artifacts: `CreateOutputArtifact`, `SetOutputArtifactRevision`, `SetOutputArtifactOriginRevision`
-- Copy operations: `CreateCopyOperation`, `AddCopyOperationExclude`, `SetCopyOperationStrategy`, `AddOutputArtifactCopyOperation`
-
-## New Setters on Existing Types
-
-### GitRepository
-
-- `SetGitRepositorySparseCheckout(gr, []string)` — restrict checkout to specific directories
-- `AddGitRepositorySparseCheckoutPath(gr, path)` — append a single sparse-checkout path
-- `SetGitRepositoryServiceAccountName(gr, name)` — workload identity via service account
-
-### Kustomization
-
-- `AddKustomizationHealthCheckExpr(k, check)` — add a CEL-based custom health check expression
-- `SetKustomizationIgnoreMissingComponents(k, bool)` — silently skip missing component paths
-- Helper: `CreateCustomHealthCheck(apiVersion, kind, current)` constructs a `CustomHealthCheck`; optionally set `SetCustomHealthCheckInProgress` and `SetCustomHealthCheckFailed` for the remaining CEL expressions.
-
-### HelmRelease Install control flags
-
-Fine-grained setters for `spec.install` — each auto-initialises the `Install` struct if nil:
-
-- `SetHelmReleaseInstallTimeout` — per-action timeout
-- `SetHelmReleaseInstallCRDs` — CRD policy (`Skip`, `Create`, `CreateReplace`)
-- `SetHelmReleaseInstallCreateNamespace` — create target namespace
-- `SetHelmReleaseInstallDisableSchemaValidation`
-- `SetHelmReleaseInstallDisableOpenAPIValidation`
-- `SetHelmReleaseInstallDisableHooks`
-- `SetHelmReleaseInstallDisableWait`
-- `SetHelmReleaseInstallDisableWaitForJobs`
-- `SetHelmReleaseInstallDisableTakeOwnership`
-- `SetHelmReleaseInstallReplace`
-
-### HelmRelease Upgrade control flags
-
-Fine-grained setters for `spec.upgrade` — each auto-initialises the `Upgrade` struct if nil:
-
-- `SetHelmReleaseUpgradeTimeout` — per-action timeout
-- `SetHelmReleaseUpgradeCRDs` — CRD policy
-- `SetHelmReleaseUpgradeDisableSchemaValidation`
-- `SetHelmReleaseUpgradeDisableOpenAPIValidation`
-- `SetHelmReleaseUpgradeDisableHooks`
-- `SetHelmReleaseUpgradeDisableWait`
-- `SetHelmReleaseUpgradeDisableWaitForJobs`
-- `SetHelmReleaseUpgradeDisableTakeOwnership`
-- `SetHelmReleaseUpgradeForce`
-- `SetHelmReleaseUpgradePreserveValues`
-- `SetHelmReleaseUpgradeCleanupOnFail`
-
-### FluxInstance
-
-- `SetFluxInstanceDistributionVariant(obj, variant)` — set the image variant (`upstream-alpine`, `enterprise-alpine`, `enterprise-distroless`, `enterprise-distroless-fips`)
-
 ## Related Packages
 
-- [stack/fluxcd](/api-reference/flux-engine/) - High-level Flux workflow engine
-- [stack](/api-reference/stack/) - Domain model that produces Flux resources
+- [stack/fluxcd](/api-reference/flux-engine/) — high-level Flux workflow engine
+- [stack](/api-reference/stack/) — domain model that produces Flux resources

--- a/pkg/kubernetes/fluxcd/golden_test.go
+++ b/pkg/kubernetes/fluxcd/golden_test.go
@@ -1,0 +1,42 @@
+package fluxcd
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kureio "github.com/go-kure/kure/pkg/io"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func goldenTest(t *testing.T, filename string, obj client.Object) {
+	t.Helper()
+	objects := []*client.Object{&obj}
+	got, err := kureio.EncodeObjectsToYAMLWithOptions(objects, kureio.EncodeOptions{
+		KubernetesFieldOrder: true,
+	})
+	if err != nil {
+		t.Fatalf("encoding to YAML: %v", err)
+	}
+	golden := filepath.Join("testdata", filename)
+	if *update {
+		if err := os.MkdirAll("testdata", 0o755); err != nil {
+			t.Fatalf("creating testdata dir: %v", err)
+		}
+		if err := os.WriteFile(golden, got, 0o644); err != nil {
+			t.Fatalf("updating golden file: %v", err)
+		}
+		return
+	}
+	want, err := os.ReadFile(golden)
+	if err != nil {
+		t.Fatalf("reading golden file (run with -update to create): %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("output does not match golden file %s\n\ngot:\n%s\nwant:\n%s", golden, got, want)
+	}
+}

--- a/pkg/kubernetes/fluxcd/setters_test.go
+++ b/pkg/kubernetes/fluxcd/setters_test.go
@@ -254,6 +254,28 @@ func TestSetHelmRepositoryProvider(t *testing.T) {
 	}
 }
 
+func TestHelmRepository_HTTP(t *testing.T) {
+	hr := CreateHelmRepository("bitnami", "flux-system")
+	SetHelmRepositoryURL(hr, "https://charts.bitnami.com/bitnami")
+	SetHelmRepositoryType(hr, "default")
+	SetHelmRepositoryInterval(hr, metav1.Duration{Duration: 10 * time.Minute})
+	SetHelmRepositoryTimeout(hr, &metav1.Duration{Duration: 60 * time.Second})
+	SetHelmRepositoryPassCredentials(hr, true)
+	SetHelmRepositorySecretRef(hr, &meta.LocalObjectReference{Name: "bitnami-auth"})
+	goldenTest(t, "helmrepository_http.yaml", hr)
+}
+
+func TestHelmRepository_OCI(t *testing.T) {
+	hr := CreateHelmRepository("ghcr-charts", "flux-system")
+	SetHelmRepositoryURL(hr, "oci://ghcr.io/example/charts")
+	SetHelmRepositoryType(hr, "oci")
+	SetHelmRepositoryProvider(hr, "generic")
+	SetHelmRepositoryInsecure(hr, false)
+	SetHelmRepositoryInterval(hr, metav1.Duration{Duration: 5 * time.Minute})
+	SetHelmRepositorySecretRef(hr, &meta.LocalObjectReference{Name: "ghcr-auth"})
+	goldenTest(t, "helmrepository_oci.yaml", hr)
+}
+
 // Bucket setters
 
 func TestSetBucketProvider(t *testing.T) {

--- a/pkg/kubernetes/fluxcd/testdata/helmrepository_http.yaml
+++ b/pkg/kubernetes/fluxcd/testdata/helmrepository_http.yaml
@@ -1,0 +1,13 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: bitnami
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  passCredentials: true
+  secretRef:
+    name: bitnami-auth
+  timeout: 1m0s
+  type: default
+  url: https://charts.bitnami.com/bitnami

--- a/pkg/kubernetes/fluxcd/testdata/helmrepository_oci.yaml
+++ b/pkg/kubernetes/fluxcd/testdata/helmrepository_oci.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: ghcr-charts
+  namespace: flux-system
+spec:
+  interval: 5m0s
+  provider: generic
+  secretRef:
+    name: ghcr-auth
+  type: oci
+  url: oci://ghcr.io/example/charts

--- a/site/content/guides/library-usage.md
+++ b/site/content/guides/library-usage.md
@@ -25,6 +25,7 @@ import (
 
     metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
     kustv1 "github.com/fluxcd/kustomize-controller/api/v1"
+    sourcev1 "github.com/fluxcd/source-controller/api/v1"
     "github.com/go-kure/kure/pkg/kubernetes/fluxcd"
 )
 

--- a/site/content/guides/library-usage.md
+++ b/site/content/guides/library-usage.md
@@ -20,29 +20,29 @@ Kure provides typed builder functions for Kubernetes and FluxCD resources.
 ### FluxCD Resources
 
 ```go
-import "github.com/go-kure/kure/pkg/kubernetes/fluxcd"
+import (
+    "time"
+
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    kustv1 "github.com/fluxcd/kustomize-controller/api/v1"
+    "github.com/go-kure/kure/pkg/kubernetes/fluxcd"
+)
 
 // Create a GitRepository source
-repo := fluxcd.GitRepository(&fluxcd.GitRepositoryConfig{
-    Name:      "my-repo",
-    Namespace: "flux-system",
-    URL:       "https://github.com/org/repo",
-    Branch:    "main",
-    Interval:  "5m",
-})
+repo := fluxcd.CreateGitRepository("my-repo", "flux-system")
+fluxcd.SetGitRepositoryURL(repo, "https://github.com/org/repo")
+fluxcd.SetGitRepositoryReference(repo, &sourcev1.GitRepositoryRef{Branch: "main"})
+fluxcd.SetGitRepositoryInterval(repo, metav1.Duration{Duration: 5 * time.Minute})
 
 // Create a Kustomization that references the source
-ks := fluxcd.Kustomization(&fluxcd.KustomizationConfig{
-    Name:      "my-app",
-    Namespace: "flux-system",
-    Path:      "./clusters/production",
-    Interval:  "10m",
-    Prune:     true,
-    SourceRef: kustv1.CrossNamespaceSourceReference{
-        Kind: "GitRepository",
-        Name: "my-repo",
-    },
+ks := fluxcd.CreateKustomization("my-app", "flux-system")
+fluxcd.SetKustomizationSourceRef(ks, kustv1.CrossNamespaceSourceReference{
+    Kind: "GitRepository",
+    Name: "my-repo",
 })
+fluxcd.SetKustomizationPath(ks, "./clusters/production")
+fluxcd.SetKustomizationInterval(ks, metav1.Duration{Duration: 10 * time.Minute})
+fluxcd.SetKustomizationPrune(ks, true)
 ```
 
 See the [FluxCD Builders reference](/api-reference/fluxcd-builders) for all available resource types.


### PR DESCRIPTION
Closes #549

## Summary

- Creates `pkg/kubernetes/fluxcd/golden_test.go` with reusable `goldenTest` harness using `kureio.EncodeObjectsToYAMLWithOptions` + `-update` flag + `testdata/` directory
- Adds `TestHelmRepository_HTTP` and `TestHelmRepository_OCI` golden tests covering the common setter combinations for each type (HTTP: URL/type/interval/timeout/passCredentials/secretRef; OCI: URL/type/provider/interval/secretRef — `Provider` and `Insecure` are OCI-only fields)
- Fully rewrites `pkg/kubernetes/fluxcd/README.md`: removes all stale `*Config` struct constructor references, documents all resource types with `Create*+Set*` pattern
- Updates `site/content/guides/library-usage.md` to use the current builder API

## Test plan

- [ ] `go test ./pkg/kubernetes/fluxcd/... -run "TestHelmRepository_HTTP|TestHelmRepository_OCI"` — both pass
- [ ] `mise run check` passes