### PR TITLE
feat: add SetHelmReleaseValuesFromMap; add HelmRelease golden test

### DIFF
--- a/pkg/kubernetes/fluxcd/setters.go
+++ b/pkg/kubernetes/fluxcd/setters.go
@@ -1,6 +1,8 @@
 package fluxcd
 
 import (
+	"encoding/json"
+
 	fluxv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	imagev1 "github.com/fluxcd/image-automation-controller/api/v1"
@@ -749,6 +751,16 @@ func AddHelmReleaseValuesFrom(obj *helmv2.HelmRelease, ref helmv2.ValuesReferenc
 // SetHelmReleaseValues sets the values for the release.
 func SetHelmReleaseValues(obj *helmv2.HelmRelease, values *apiextensionsv1.JSON) {
 	obj.Spec.Values = values
+}
+
+// SetHelmReleaseValuesFromMap marshals values to JSON and sets them on the HelmRelease.
+func SetHelmReleaseValuesFromMap(obj *helmv2.HelmRelease, values map[string]any) error {
+	raw, err := json.Marshal(values)
+	if err != nil {
+		return err
+	}
+	obj.Spec.Values = &apiextensionsv1.JSON{Raw: raw}
+	return nil
 }
 
 // AddHelmReleasePostRenderer appends a post renderer.

--- a/pkg/kubernetes/fluxcd/setters_test.go
+++ b/pkg/kubernetes/fluxcd/setters_test.go
@@ -1,6 +1,7 @@
 package fluxcd
 
 import (
+	jsonPkg "encoding/json"
 	"testing"
 	"time"
 
@@ -1700,6 +1701,62 @@ func TestSetHelmReleaseUpgradeCleanupOnFail(t *testing.T) {
 	if !obj.Spec.Upgrade.CleanupOnFail {
 		t.Error("expected Upgrade.CleanupOnFail true")
 	}
+}
+
+func TestSetHelmReleaseValuesFromMap(t *testing.T) {
+	hr := CreateHelmRelease("redis", "apps")
+	err := SetHelmReleaseValuesFromMap(hr, map[string]any{
+		"replicaCount": 3,
+		"image":        map[string]any{"tag": "latest"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hr.Spec.Values == nil {
+		t.Fatal("values nil")
+	}
+	var got map[string]any
+	_ = jsonPkg.Unmarshal(hr.Spec.Values.Raw, &got)
+	if got["replicaCount"] != float64(3) {
+		t.Errorf("got %v", got["replicaCount"])
+	}
+}
+
+func TestHelmRelease_FullSpec(t *testing.T) {
+	hr := CreateHelmRelease("redis", "apps")
+	SetHelmReleaseReleaseName(hr, "redis-prod")
+	SetHelmReleaseTargetNamespace(hr, "apps")
+	SetHelmReleaseInterval(hr, metav1.Duration{Duration: 5 * time.Minute})
+	SetHelmReleaseChart(hr, &helmv2.HelmChartTemplate{
+		Spec: helmv2.HelmChartTemplateSpec{
+			Chart:   "redis",
+			Version: "19.0.0",
+			SourceRef: helmv2.CrossNamespaceObjectReference{
+				Kind:      "HelmRepository",
+				Name:      "bitnami",
+				Namespace: "flux-system",
+			},
+		},
+	})
+	_ = SetHelmReleaseValuesFromMap(hr, map[string]any{
+		"replicaCount": 3,
+		"auth":         map[string]any{"enabled": true},
+	})
+	AddHelmReleaseValuesFrom(hr, helmv2.ValuesReference{
+		Kind: "ConfigMap", Name: "redis-defaults",
+	})
+	SetHelmReleaseDriftDetection(hr, CreateDriftDetection(helmv2.DriftDetectionEnabled))
+	SetHelmReleaseCommonMetadata(hr, &helmv2.CommonMetadata{
+		Labels: map[string]string{"app": "redis"},
+	})
+	SetHelmReleaseInstallCRDs(hr, helmv2.CreateReplace)
+	SetHelmReleaseInstallRemediation(hr, CreateInstallRemediation(3))
+	SetHelmReleaseUpgradeCRDs(hr, helmv2.CreateReplace)
+	SetHelmReleaseUpgradeRemediation(hr, CreateUpgradeRemediation(3))
+	k := CreatePostRendererKustomize()
+	AddPostRendererKustomizeImage(k, kustomize.Image{Name: "redis", NewTag: "7.0"})
+	AddHelmReleasePostRenderer(hr, helmv2.PostRenderer{Kustomize: k})
+	goldenTest(t, "helmrelease_full_spec.yaml", hr)
 }
 
 // Provider setters

--- a/pkg/kubernetes/fluxcd/testdata/helmrelease_full_spec.yaml
+++ b/pkg/kubernetes/fluxcd/testdata/helmrelease_full_spec.yaml
@@ -1,0 +1,42 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: redis
+  namespace: apps
+spec:
+  chart:
+    spec:
+      chart: redis
+      sourceRef:
+        kind: HelmRepository
+        name: bitnami
+        namespace: flux-system
+      version: 19.0.0
+  commonMetadata:
+    labels:
+      app: redis
+  driftDetection:
+    mode: enabled
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  interval: 5m0s
+  postRenderers:
+    - kustomize:
+        images:
+          - name: redis
+            newTag: "7.0"
+  releaseName: redis-prod
+  targetNamespace: apps
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  values:
+    auth:
+      enabled: true
+    replicaCount: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: redis-defaults


### PR DESCRIPTION
Closes #548

## Summary

- Adds `SetHelmReleaseValuesFromMap(obj, map[string]any) error` convenience helper that marshals a Go map to JSON and sets it as `spec.values` — does not replace the existing `SetHelmReleaseValues(*apiextensionsv1.JSON)`
- Adds `TestSetHelmReleaseValuesFromMap` unit test
- Adds `TestHelmRelease_FullSpec` golden test exercising: chart template, valuesFromMap, valuesFrom, drift detection, commonMetadata, install/upgrade CRDs and remediation, post-render kustomize images

Note: this branch also cherry-picks the golden test infrastructure from #549 (`golden_test.go`, `testdata/helmrepository_*.yaml`) — intended to merge after #549.

## Test plan

- [ ] `go test ./pkg/kubernetes/fluxcd/... -run "TestSetHelmReleaseValuesFromMap|TestHelmRelease_FullSpec"` — both pass
- [ ] `mise run check` passes