### PR TITLE
fix: pre-release review — deepCopyBundle fields, renderHTTP guard, coverage, docs

### DIFF
--- a/pkg/kubernetes/fluxcd/README.md
+++ b/pkg/kubernetes/fluxcd/README.md
@@ -143,7 +143,9 @@ fluxcd.SetHelmReleaseChart(hr, &helmv2.HelmChartTemplate{
         },
     },
 })
-fluxcd.SetHelmReleaseValues(hr, &apiextensionsv1.JSON{Raw: []byte(`{"replicaCount":3}`)})
+_ = fluxcd.SetHelmReleaseValuesFromMap(hr, map[string]any{"replicaCount": 3}) // handle err
+// Alternative — pre-marshalled JSON:
+// fluxcd.SetHelmReleaseValues(hr, &apiextensionsv1.JSON{Raw: []byte(`{"replicaCount":3}`)})
 fluxcd.AddHelmReleaseValuesFrom(hr, helmv2.ValuesReference{
     Kind: "ConfigMap",
     Name: "redis-defaults",
@@ -184,8 +186,22 @@ Additional setters: `SetHelmReleaseKubeConfig`, `SetHelmReleaseSuspend`,
 `SetHelmReleaseMaxHistory`, `SetHelmReleaseServiceAccountName`, `SetHelmReleasePersistentClient`,
 `SetHelmReleaseInstall`, `SetHelmReleaseUpgrade`, `SetHelmReleaseRollback`,
 `SetHelmReleaseUninstall`, `SetHelmReleaseTest`, `SetHelmReleaseValues`,
-`SetHelmReleaseCommonMetadata`, `AddHelmReleaseHealthCheckExpr`, `SetHelmReleaseWaitStrategy`,
-plus fine-grained `SetHelmReleaseInstall*` and `SetHelmReleaseUpgrade*` flag setters.
+`SetHelmReleaseValuesFromMap`, `SetHelmReleaseCommonMetadata`, `AddHelmReleaseHealthCheckExpr`,
+`SetHelmReleaseWaitStrategy`.
+
+Install flag setters: `SetHelmReleaseInstallTimeout`, `SetHelmReleaseInstallCRDs`,
+`SetHelmReleaseInstallCreateNamespace`, `SetHelmReleaseInstallDisableSchemaValidation`,
+`SetHelmReleaseInstallDisableOpenAPIValidation`, `SetHelmReleaseInstallDisableHooks`,
+`SetHelmReleaseInstallDisableWait`, `SetHelmReleaseInstallDisableWaitForJobs`,
+`SetHelmReleaseInstallDisableTakeOwnership`, `SetHelmReleaseInstallReplace`,
+`SetHelmReleaseInstallRemediation`.
+
+Upgrade flag setters: `SetHelmReleaseUpgradeTimeout`, `SetHelmReleaseUpgradeCRDs`,
+`SetHelmReleaseUpgradeDisableSchemaValidation`, `SetHelmReleaseUpgradeDisableOpenAPIValidation`,
+`SetHelmReleaseUpgradeDisableHooks`, `SetHelmReleaseUpgradeDisableWait`,
+`SetHelmReleaseUpgradeDisableWaitForJobs`, `SetHelmReleaseUpgradeDisableTakeOwnership`,
+`SetHelmReleaseUpgradeForce`, `SetHelmReleaseUpgradePreserveValues`,
+`SetHelmReleaseUpgradeCleanupOnFail`, `SetHelmReleaseUpgradeRemediation`.
 
 ## Notification Controllers
 

--- a/pkg/stack/builders.go
+++ b/pkg/stack/builders.go
@@ -120,6 +120,11 @@ func deepCopyNode(n *Node) *Node {
 //
 // Invariant: callers must not mutate existing Application or Bundle objects
 // after branching; they may only append new entries to the copied slices.
+//
+// Patches and PostBuild use the same shallow strategy: Target *PatchSelector
+// pointers and PostBuild.Substitute map / SubstituteFrom slice backing are
+// shared. If fluent setters for Patches or PostBuild are added later,
+// deepCopyBundle must be revisited for true deep copy of those nested values.
 func deepCopyBundle(b *Bundle) *Bundle {
 	if b == nil {
 		return nil
@@ -152,6 +157,26 @@ func deepCopyBundle(b *Bundle) *Bundle {
 	if b.NamedDependsOn != nil {
 		newBundle.NamedDependsOn = make([]string, len(b.NamedDependsOn))
 		copy(newBundle.NamedDependsOn, b.NamedDependsOn)
+	}
+	if b.Force != nil {
+		v := *b.Force
+		newBundle.Force = &v
+	}
+	if b.Suspend != nil {
+		v := *b.Suspend
+		newBundle.Suspend = &v
+	}
+	if b.HealthChecks != nil {
+		newBundle.HealthChecks = make([]HealthCheck, len(b.HealthChecks))
+		copy(newBundle.HealthChecks, b.HealthChecks)
+	}
+	if b.Patches != nil {
+		newBundle.Patches = make([]Patch, len(b.Patches))
+		copy(newBundle.Patches, b.Patches)
+	}
+	if b.PostBuild != nil {
+		pb := *b.PostBuild
+		newBundle.PostBuild = &pb
 	}
 	// Same shallow-copy strategy for Children (umbrella) bundle references.
 	if b.Children != nil {

--- a/pkg/stack/builders_test.go
+++ b/pkg/stack/builders_test.go
@@ -760,3 +760,53 @@ func TestDeepCopyBundle_PreservesChildren(t *testing.T) {
 		t.Fatalf("appending to copy must not affect original; got %d", len(original.Children))
 	}
 }
+
+func TestDeepCopyBundle_PreservesNewFields(t *testing.T) {
+	force := true
+	suspend := false
+	b := &Bundle{
+		Name:    "src",
+		Force:   &force,
+		Suspend: &suspend,
+		HealthChecks: []HealthCheck{
+			{APIVersion: "apps/v1", Kind: "Deployment", Name: "app", Namespace: "default"},
+		},
+		Patches: []Patch{
+			{Patch: "patch-content", Target: &PatchSelector{Kind: "Deployment"}},
+		},
+		PostBuild: &PostBuild{
+			Substitute:     map[string]string{"VAR": "val"},
+			SubstituteFrom: []SubstituteRef{{Kind: "ConfigMap", Name: "cfg"}},
+		},
+	}
+	got := deepCopyBundle(b)
+	if got.Force == nil {
+		t.Fatal("Force not copied (nil)")
+	}
+	if *got.Force != force {
+		t.Errorf("Force value: got %v, want %v", *got.Force, force)
+	}
+	if got.Suspend == nil {
+		t.Fatal("Suspend not copied (nil)")
+	}
+	if *got.Suspend != suspend {
+		t.Errorf("Suspend value: got %v, want %v", *got.Suspend, suspend)
+	}
+	if len(got.HealthChecks) != 1 || got.HealthChecks[0].Kind != "Deployment" {
+		t.Error("HealthChecks not copied")
+	}
+	if len(got.Patches) != 1 || got.Patches[0].Patch != "patch-content" {
+		t.Error("Patches not copied")
+	}
+	if got.PostBuild == nil {
+		t.Fatal("PostBuild not copied (nil)")
+	}
+	if got.PostBuild.Substitute["VAR"] != "val" {
+		t.Error("PostBuild.Substitute not copied")
+	}
+	// Pointer isolation: mutate through the copy's pointer; original must be unaffected.
+	*got.Force = false
+	if *b.Force != true {
+		t.Error("Force bool copy is shared, not isolated")
+	}
+}

--- a/pkg/stack/bundle_test.go
+++ b/pkg/stack/bundle_test.go
@@ -748,3 +748,28 @@ func TestBundleSetParent(t *testing.T) {
 		t.Errorf("expected empty ParentPath, got %q", child.ParentPath)
 	}
 }
+
+func TestNewBundle_Constructor(t *testing.T) {
+	apps := []*Application{{Name: "app"}}
+	labels := map[string]string{"env": "prod"}
+	b, err := NewBundle("my-bundle", apps, labels)
+	if err != nil {
+		t.Fatalf("NewBundle: %v", err)
+	}
+	if b.Name != "my-bundle" {
+		t.Errorf("Name: got %q", b.Name)
+	}
+	if len(b.Applications) != 1 || b.Applications[0].Name != "app" {
+		t.Error("Applications not set")
+	}
+	if b.Labels["env"] != "prod" {
+		t.Error("Labels not set")
+	}
+}
+
+func TestNewBundle_ValidationError(t *testing.T) {
+	_, err := NewBundle("", nil, nil)
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+}

--- a/pkg/stack/helm/hooks_test.go
+++ b/pkg/stack/helm/hooks_test.go
@@ -165,3 +165,20 @@ func TestSplitByHookWeight_CommaAnnotation_TreatedAsUnknown(t *testing.T) {
 		t.Errorf("[2]: %q (want comma annotation as unknown, last)", groups[2].Phase)
 	}
 }
+
+func TestSplitByHookWeight_AllExcluded(t *testing.T) {
+	objs := []client.Object{
+		hookObj("a", "pre-delete", "0"),
+		hookObj("b", "test", "0"),
+		hookObj("c", "post-delete", "0"),
+	}
+	groups := helm.SplitByHookWeight(objs)
+	// Non-empty input that filters to nothing should return a non-nil empty slice
+	// (distinct from the nil returned for empty/nil input — see hooks.go).
+	if groups == nil {
+		t.Fatal("want non-nil empty slice for all-excluded input, got nil")
+	}
+	if len(groups) != 0 {
+		t.Fatalf("want 0 groups when all objects have excluded phases, got %d", len(groups))
+	}
+}

--- a/pkg/stack/helm/render.go
+++ b/pkg/stack/helm/render.go
@@ -66,6 +66,9 @@ func renderHTTP(chartURL, version string, values map[string]any) ([]byte, error)
 		return nil, errors.Errorf("invalid HTTP chart URL %q: expected https://repo-base/chart-name", chartURL)
 	}
 	repoURL, chartName := chartURL[:last], chartURL[last+1:]
+	if chartName == "" {
+		return nil, errors.Errorf("invalid HTTP chart URL %q: missing chart name after last /", chartURL)
+	}
 
 	getters := getter.Getters()
 	archiveURL, err := repov1.FindChartInRepoURL(repoURL, chartName, getters,

--- a/pkg/stack/helm/render_test.go
+++ b/pkg/stack/helm/render_test.go
@@ -168,6 +168,13 @@ func TestRenderChart_UnsupportedScheme_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestRenderChart_HTTP_EmptyChartName(t *testing.T) {
+	_, err := RenderChart("https://charts.example.com/", "1.0.0", nil)
+	if err == nil {
+		t.Fatal("expected error for URL with trailing slash and empty chart name")
+	}
+}
+
 func buildMinimalChartTar(t *testing.T, name, version string) []byte {
 	t.Helper()
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary

Pre-release correctness review before cutting v0.2.0. All items are in code written since v0.2.0-alpha.4.

**Bugs fixed:**

- `deepCopyBundle` (`pkg/stack/builders.go`) silently dropped `Force`, `Suspend`, `HealthChecks`, `Patches`, and `PostBuild` when branching — any direct field assignment to these was lost. Added copy blocks using the same shallow strategy documented in the function comment (safe under the append-only / no-mutation-after-branch invariant). Regression test added. Note: no fluent builder setter exists for these fields today, so the bug was not reachable via the public API, but the copy was wrong.
- `renderHTTP` (`pkg/stack/helm/render.go`) forwarded an empty `chartName` string to `FindChartInRepoURL` when the URL ended with `"/"`. Added an explicit guard with a clear error message.

**Coverage gaps (new code only):**

- `NewBundle` constructor had zero test coverage — `TestNewBundle_Constructor` + `TestNewBundle_ValidationError` added.
- `renderHTTP` empty-chart-name error path — `TestRenderChart_HTTP_EmptyChartName` added.
- `SplitByHookWeight` "all objects excluded → non-nil empty slice" — `TestSplitByHookWeight_AllExcluded` added (asserts non-nil to lock in the distinction from the nil-for-empty-input path).

**Documentation:**

- `pkg/kubernetes/fluxcd/README.md`: HelmRelease values example updated to prefer `SetHelmReleaseValuesFromMap`; Install and Upgrade flag setters enumerated explicitly (was a vague summary phrase).

## Test plan

- [ ] `mise run check` — lint + vet + short tests all pass
- [ ] `GOWORK=off go test ./pkg/stack/... ./pkg/stack/helm/... ./pkg/kubernetes/fluxcd/... -race -count=1` — no races
- [ ] `./scripts/sync-versions.sh check` — version consistency clean