### PR TITLE
chore: add goreleaser config for library-only release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,21 @@
+version: 2
+project_name: kure
+
+# kure is a Go library — no binary builds.
+builds:
+  - skip: true
+
+# Nothing to checksum without build artifacts.
+checksum:
+  disable: true
+
+release:
+  github:
+    owner: go-kure
+    name: kure
+  draft: false
+  prerelease: auto
+
+# Disable built-in changelog — we use git-cliff for CHANGELOG.md.
+changelog:
+  disable: true


### PR DESCRIPTION
## Summary

- GoReleaser failed for v0.2.0-alpha.5 because there was no `.goreleaser.yml` and the default config assumes a binary build (`main` package)
- kure is a pure Go library — no binary, no archives, no checksums
- This config skips builds and disables checksum; the GitHub Release (with release notes) is still created by GoReleaser

## After merge

The v0.2.0-alpha.5 tag must be moved to the new main HEAD so GoReleaser checks out a commit that includes this config, then re-pushed to trigger the release workflow.