### PR TITLE
fix: cliff.toml and CHANGELOG for alpha.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.2.0-alpha.6] - 2026-05-21
+
+### Maintenance
+
+- Add goreleaser config for library-only release (kure is a Go library, no binary builds)
+
 ## [0.2.0-alpha.5] - 2026-05-21
 
 ### Added

--- a/cliff.toml
+++ b/cliff.toml
@@ -38,7 +38,13 @@ commit_parsers = [
     { message = "^build", group = "Build" },
     { message = "^ci", group = "CI" },
     { message = "^chore\\(deps\\)", group = "Dependencies" },
-    { message = "^chore", skip = true },
+    # Skip release-bot and version-bump commits — internal release machinery.
+    { message = "^release", skip = true },
+    { message = "^chore: bump version", skip = true },
+    { message = "^chore: start next cycle", skip = true },
+    # Group remaining chore commits so releases with only chore changes still
+    # produce a CHANGELOG section (required by release validation).
+    { message = "^chore", group = "Maintenance" },
     # Catch unconventional commits and skip them (case-insensitive)
     { message = "(?i)^wip", skip = true },
     { message = "(?i)^demo", skip = true },


### PR DESCRIPTION
## Root cause

Two issues caused the v0.2.0-alpha.6 release workflow to fail at the changelog validation step:

1. **`release:` bot commits not skipped** — the `release: v0.x.x` commits created by the release script were not in any skip rule, so git-cliff included them in CHANGELOG sections (adding a spurious "### Release" group to the alpha.5 section).

2. **Plain `chore:` commits fully skipped** — when all commits between two tags are `chore:` type (e.g. goreleaser config addition), git-cliff generates no section at all. The validation requires `## [version]` to be present, so it fails.

## Fix

**cliff.toml:**
- Add `{ message = "^release", skip = true }` — silences release-bot commits
- Add specific skips for `"^chore: bump version"` and `"^chore: start next cycle"` — these are pure release machinery
- Change the catch-all `{ message = "^chore", skip = true }` to `group = "Maintenance"` — ensures any other chore commit produces a visible section

**CHANGELOG.md:**
- Manually add `## [0.2.0-alpha.6]` section (the goreleaser config addition that makes up this release)

## After merge

The `v0.2.0-alpha.6` tag must be moved to the new main HEAD so the release workflow checks out a commit that has the corrected CHANGELOG. (No GitHub Release was ever published for alpha.6 — the workflow failed before goreleaser ran.)