### PR TITLE
fix(helm): skip NOTES.txt in assembleManifests

### DIFF
--- a/pkg/stack/helm/render.go
+++ b/pkg/stack/helm/render.go
@@ -124,6 +124,9 @@ func assembleManifests(rendered map[string]string) []byte {
 		if strings.HasPrefix(filepath.Base(name), "_") {
 			continue
 		}
+		if filepath.Base(name) == "NOTES.txt" {
+			continue // skip Helm info file — not a Kubernetes manifest
+		}
 		content := strings.TrimSpace(rendered[name])
 		if content == "" {
 			continue


### PR DESCRIPTION
## Summary

`assembleManifests` currently skips partial templates (`_`-prefixed) and empty output, but includes `NOTES.txt`. After Helm renders templates, `NOTES.txt` produces a YAML map (e.g. `chart: kube-prometheus-stack\n  version: 1.16.5`) that callers cannot reliably distinguish from a broken manifest.

This PR skips `NOTES.txt` by name, analogous to the existing partial-template skip.

## Motivation

Needed by go-kure/launcher#83 (helmchart template delivery). The launcher decodes `RenderChart` output into Kubernetes objects; if `NOTES.txt` is included, it produces a map lacking `apiVersion`/`kind` that cannot be reliably filtered without heuristics.

## Test plan

- [x] Existing `pkg/stack/helm` tests pass