### PR TITLE
fix(fluxcd): raise default reconciliation interval to 60m

### DIFF
--- a/pkg/stack/fluxcd/bootstrap_generator.go
+++ b/pkg/stack/fluxcd/bootstrap_generator.go
@@ -31,7 +31,7 @@ type BootstrapGenerator struct {
 func NewBootstrapGenerator() *BootstrapGenerator {
 	return &BootstrapGenerator{
 		DefaultNamespace: "flux-system",
-		DefaultInterval:  10 * time.Minute,
+		DefaultInterval:  60 * time.Minute,
 	}
 }
 

--- a/pkg/stack/fluxcd/bootstrap_generator_test.go
+++ b/pkg/stack/fluxcd/bootstrap_generator_test.go
@@ -2,6 +2,7 @@ package fluxcd_test
 
 import (
 	"testing"
+	"time"
 
 	fluxv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,8 +37,8 @@ func TestNewBootstrapGenerator(t *testing.T) {
 		t.Errorf("DefaultNamespace = %q, want %q", bg.DefaultNamespace, "flux-system")
 	}
 
-	if bg.DefaultInterval != 10*60*1e9 { // 10 minutes in nanoseconds
-		t.Errorf("DefaultInterval = %v, want 10 minutes", bg.DefaultInterval)
+	if bg.DefaultInterval != 60*time.Minute {
+		t.Errorf("DefaultInterval = %v, want 60 minutes", bg.DefaultInterval)
 	}
 }
 

--- a/pkg/stack/fluxcd/resource_generator.go
+++ b/pkg/stack/fluxcd/resource_generator.go
@@ -33,7 +33,7 @@ type ResourceGenerator struct {
 func NewResourceGenerator() *ResourceGenerator {
 	return &ResourceGenerator{
 		Mode:             layout.KustomizationExplicit,
-		DefaultInterval:  5 * time.Minute,
+		DefaultInterval:  60 * time.Minute,
 		DefaultNamespace: "flux-system",
 	}
 }

--- a/pkg/stack/fluxcd/resource_generator_test.go
+++ b/pkg/stack/fluxcd/resource_generator_test.go
@@ -18,8 +18,8 @@ func TestResourceGenerator_NewDefaults(t *testing.T) {
 	if gen.Mode != layout.KustomizationExplicit {
 		t.Errorf("Mode = %q, want %q", gen.Mode, layout.KustomizationExplicit)
 	}
-	if gen.DefaultInterval != 5*time.Minute {
-		t.Errorf("DefaultInterval = %v, want %v", gen.DefaultInterval, 5*time.Minute)
+	if gen.DefaultInterval != 60*time.Minute {
+		t.Errorf("DefaultInterval = %v, want %v", gen.DefaultInterval, 60*time.Minute)
 	}
 	if gen.DefaultNamespace != "flux-system" {
 		t.Errorf("DefaultNamespace = %q, want %q", gen.DefaultNamespace, "flux-system")


### PR DESCRIPTION
## Summary

- Raises `ResourceGenerator.DefaultInterval` from 5m to 60m
- Raises `BootstrapGenerator.DefaultInterval` from 10m to 60m

Per upstream FluxCD recommendation, default reconciliation intervals for Kustomizations and source objects should be 60 minutes to reduce control-plane load.

Related: go-kure/kure#562

## Test plan

- [ ] `go test ./pkg/stack/fluxcd/...` passes