### PR TITLE
feat(fluxcd): emit Flux CRs for augmenter-added child layouts (#571)

### DIFF
--- a/pkg/stack/fluxcd/README.md
+++ b/pkg/stack/fluxcd/README.md
@@ -168,6 +168,19 @@ subdirectory. The child subdirectory still exists and still contains its own
 `kustomization.yaml` plus workload YAML files — but **no** Flux CR files, so
 Flux does not double-apply the child's resources.
 
+## Non-Bundle Child Layout CRs
+
+In `FluxIntegrated` mode the layout integrator generates `Kustomization` CRs for **all eligible children** of each node layout, not only the node's own bundle. A child is eligible when `!UmbrellaChild && ApplicationFileMode != AppFileSingle`.
+
+This covers two cases with the same code path:
+
+- **Flat/nodeOnly layouts** — app layouts are direct children of the node layout. Each eligible app layout gets a `Kustomization` CR placed in the node layout's `Resources`, with `spec.path` set to `child.FullRepoPath()`.
+- **Augmenter sub-layouts** — hook-group child layouts added by a `LayoutAugmenter` are children of an app layout. Each eligible child gets a CR placed in the app layout's `Resources`. `spec.dependsOn` is populated from `ManifestLayout.DependsOn`, enabling ordered reconciliation between hook groups.
+
+The integrator applies this rule recursively: it covers children at any depth, always placing the CR in the immediate parent's `Resources`.
+
+If the ancestor bundle has a nil, empty, or incomplete `SourceRef` (missing `Kind` or `Name`) and eligible children without existing CRs are present, `IntegrateWithLayout` returns a hard error. A `Kustomization` without a valid `spec.sourceRef` is rejected by Flux and must not be emitted silently.
+
 ## Validation
 
 All cluster-level entry points (`GenerateFromCluster`, `CreateLayoutWithResources`)

--- a/pkg/stack/fluxcd/layout_integrator.go
+++ b/pkg/stack/fluxcd/layout_integrator.go
@@ -183,7 +183,8 @@ func (li *LayoutIntegrator) processNodeForIntegratedFlux(root *layout.ManifestLa
 			// A new CR without spec.sourceRef is invalid — fail fast.
 			// Children that already have CRs (e.g. umbrella bundle layouts) are
 			// exempt from this check; they were placed by GenerateFromBundle which
-			// handles absent SourceRef separately.
+			// handles absent SourceRef separately. Descendant children are validated
+			// inside generateChildFluxCRs as it recurses.
 			if len(newCRChildren) > 0 && sr.Kind == "" {
 				return errors.ResourceValidationError(
 					"Bundle", node.Bundle.Name, "sourceRef",
@@ -194,16 +195,18 @@ func (li *LayoutIntegrator) processNodeForIntegratedFlux(root *layout.ManifestLa
 				)
 			}
 
-			// Emit CRs and recurse only when a sourceRef is available.
-			if sr.Kind != "" {
-				for _, child := range eligibleChildren {
-					if !li.hasKustomizationCR(layoutNode.Resources, child.Name) {
-						layoutNode.Resources = append(layoutNode.Resources,
-							li.Generator.createKustomizationForLayout(child, sr))
-					}
-					if err := li.generateChildFluxCRs(child, sr); err != nil {
-						return err
-					}
+			// Emit direct-child CRs and recurse into all eligible children.
+			// Recursion is unconditional: even when sr is empty (all direct children
+			// already have CRs), grandchildren may need new CRs — generateChildFluxCRs
+			// will error if it encounters one that needs a CR but sr is invalid.
+			for _, child := range eligibleChildren {
+				if !li.hasKustomizationCR(layoutNode.Resources, child.Name) {
+					// sr.Kind is guaranteed non-empty here (checked above).
+					layoutNode.Resources = append(layoutNode.Resources,
+						li.Generator.createKustomizationForLayout(child, sr))
+				}
+				if err := li.generateChildFluxCRs(child, sr); err != nil {
+					return err
 				}
 			}
 		}
@@ -259,6 +262,15 @@ func (li *LayoutIntegrator) generateChildFluxCRs(
 			continue
 		}
 		if !li.hasKustomizationCR(parent.Resources, child.Name) {
+			if sourceRef.Kind == "" {
+				return errors.ResourceValidationError(
+					"ManifestLayout", child.Name, "sourceRef",
+					"FluxIntegrated mode requires a SourceRef with Kind and Name; "+
+						"this descendant layout needs a Kustomization CR but the "+
+						"ancestor bundle has no valid SourceRef",
+					nil,
+				)
+			}
 			parent.Resources = append(parent.Resources,
 				li.Generator.createKustomizationForLayout(child, sourceRef))
 		}

--- a/pkg/stack/fluxcd/layout_integrator.go
+++ b/pkg/stack/fluxcd/layout_integrator.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"path/filepath"
 
+	kustv1 "github.com/fluxcd/kustomize-controller/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/go-kure/kure/pkg/errors"
 	"github.com/go-kure/kure/pkg/stack"
 	"github.com/go-kure/kure/pkg/stack/layout"
@@ -129,6 +132,83 @@ func (li *LayoutIntegrator) processNodeForIntegratedFlux(root *layout.ManifestLa
 		}
 	}
 
+	// In FluxIntegrated mode, emit Kustomization CRs for all eligible direct
+	// children of layoutNode and recurse into their subtrees.
+	//
+	// "Eligible" mirrors the writer condition: !UmbrellaChild &&
+	// ApplicationFileMode != AppFileSingle. Stack-node children are skipped
+	// because processNodeForIntegratedFlux handles them recursively below.
+	//
+	// This covers two cases with the same code:
+	//   (a) Flat/nodeOnly: app layouts are direct children of the node layout;
+	//       writers reference each as flux-system-kustomization-{name}.yaml
+	//       from the node kustomization.yaml, so a CR is required at that level.
+	//   (b) Augmenter sub-layouts: hook-group children of app layouts;
+	//       generateChildFluxCRs recurses and places those CRs in the app
+	//       layout's Resources.
+	if node.Bundle != nil {
+		var eligibleChildren []*layout.ManifestLayout
+		for _, child := range layoutNode.Children {
+			if child.UmbrellaChild || child.ApplicationFileMode == layout.AppFileSingle {
+				continue
+			}
+			if li.isStackNodeChild(child.Name, node) {
+				continue
+			}
+			eligibleChildren = append(eligibleChildren, child)
+		}
+
+		if len(eligibleChildren) > 0 {
+			// Determine which eligible children need a NEW CR (not already placed
+			// by GenerateFromBundle, e.g. umbrella bundle layouts already have one).
+			var newCRChildren []*layout.ManifestLayout
+			for _, child := range eligibleChildren {
+				if !li.hasKustomizationCR(layoutNode.Resources, child.Name) {
+					newCRChildren = append(newCRChildren, child)
+				}
+			}
+
+			// Resolve sourceRef once; used for both new CRs and recursion.
+			var sr kustv1.CrossNamespaceSourceReference
+			if node.Bundle.SourceRef != nil &&
+				node.Bundle.SourceRef.Kind != "" &&
+				node.Bundle.SourceRef.Name != "" {
+				sr = kustv1.CrossNamespaceSourceReference{
+					Kind:      node.Bundle.SourceRef.Kind,
+					Name:      node.Bundle.SourceRef.Name,
+					Namespace: node.Bundle.SourceRef.Namespace,
+				}
+			}
+
+			// A new CR without spec.sourceRef is invalid — fail fast.
+			// Children that already have CRs (e.g. umbrella bundle layouts) are
+			// exempt from this check; they were placed by GenerateFromBundle which
+			// handles absent SourceRef separately.
+			if len(newCRChildren) > 0 && sr.Kind == "" {
+				return errors.ResourceValidationError(
+					"Bundle", node.Bundle.Name, "sourceRef",
+					"FluxIntegrated mode requires a SourceRef with Kind and Name on bundles "+
+						"whose layout has eligible children without existing Kustomization CRs; "+
+						"omitting it produces invalid Flux Kustomization CRs",
+					nil,
+				)
+			}
+
+			// Emit CRs and recurse only when a sourceRef is available.
+			if sr.Kind != "" {
+				for _, child := range eligibleChildren {
+					if !li.hasKustomizationCR(layoutNode.Resources, child.Name) {
+						layoutNode.Resources = append(layoutNode.Resources,
+							li.Generator.createKustomizationForLayout(child, sr))
+					}
+					if err := li.generateChildFluxCRs(child, sr); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+
 	// Process child nodes — always search from root for path-based matching
 	for _, child := range node.Children {
 		if err := li.processNodeForIntegratedFlux(root, child, clusterName); err != nil {
@@ -136,6 +216,56 @@ func (li *LayoutIntegrator) processNodeForIntegratedFlux(root *layout.ManifestLa
 		}
 	}
 
+	return nil
+}
+
+// isStackNodeChild returns true when name matches a direct child stack.Node of
+// node. Used to skip ManifestLayout.Children that correspond to child nodes
+// already processed by the recursive processNodeForIntegratedFlux call.
+func (li *LayoutIntegrator) isStackNodeChild(name string, node *stack.Node) bool {
+	for _, child := range node.Children {
+		if child.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// hasKustomizationCR returns true when resources already contains a
+// *kustv1.Kustomization with the given name.
+func (li *LayoutIntegrator) hasKustomizationCR(resources []client.Object, name string) bool {
+	for _, r := range resources {
+		if k, ok := r.(*kustv1.Kustomization); ok && k.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// generateChildFluxCRs places a Kustomization CR in parent.Resources for each
+// eligible child of parent, then recurses. A child is eligible when:
+//   - !child.UmbrellaChild
+//   - child.ApplicationFileMode != layout.AppFileSingle
+//
+// These conditions match exactly what the writers use to emit
+// flux-system-kustomization-{child.Name}.yaml from the parent kustomization.yaml,
+// ensuring every reference the writers produce has a backing CR.
+func (li *LayoutIntegrator) generateChildFluxCRs(
+	parent *layout.ManifestLayout,
+	sourceRef kustv1.CrossNamespaceSourceReference,
+) error {
+	for _, child := range parent.Children {
+		if child.UmbrellaChild || child.ApplicationFileMode == layout.AppFileSingle {
+			continue
+		}
+		if !li.hasKustomizationCR(parent.Resources, child.Name) {
+			parent.Resources = append(parent.Resources,
+				li.Generator.createKustomizationForLayout(child, sourceRef))
+		}
+		if err := li.generateChildFluxCRs(child, sourceRef); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/stack/fluxcd/layout_integrator_test.go
+++ b/pkg/stack/fluxcd/layout_integrator_test.go
@@ -948,6 +948,51 @@ func TestAugmenterChildrenErrorWhenNoSourceRef(t *testing.T) {
 	}
 }
 
+// TestAugmenterGrandchildErrorWhenNoSourceRef verifies the edge case where a
+// direct eligible child ALREADY has a Kustomization CR (placed externally, as
+// GenerateFromBundle does for bundle sub-layouts), so newCRChildren is empty
+// and the fast-path error check does not fire — but that child has its own
+// eligible sub-layout (grandchild) that needs a new CR. With an empty/nil
+// SourceRef on the ancestor bundle, generateChildFluxCRs must still error
+// rather than silently skipping the grandchild and leaving a dangling writer
+// reference.
+func TestAugmenterGrandchildErrorWhenNoSourceRef(t *testing.T) {
+	grandchild := &layout.ManifestLayout{
+		Name:          "myapp-00-pre-install",
+		Namespace:     "clusters/prod/myapp/myapp-00-pre-install",
+		FluxPlacement: layout.FluxIntegrated,
+	}
+	appLayout := &layout.ManifestLayout{
+		Name:          "myapp",
+		Namespace:     "clusters/prod",
+		FluxPlacement: layout.FluxIntegrated,
+		Children:      []*layout.ManifestLayout{grandchild},
+	}
+
+	// Pre-place a CR for "myapp" so newCRChildren is empty — the fast-path
+	// error check for direct children is skipped.
+	existingCR := &kustv1.Kustomization{}
+	existingCR.Name = "myapp"
+	existingCR.Namespace = "flux-system"
+
+	bundle := &stack.Bundle{Name: "apps", SourceRef: nil}
+	node := &stack.Node{Name: "prod", Bundle: bundle}
+	cluster := &stack.Cluster{Node: node}
+
+	nodeLayout := &layout.ManifestLayout{
+		Name:          "prod",
+		FluxPlacement: layout.FluxIntegrated,
+		Resources:     []client.Object{existingCR},
+		Children:      []*layout.ManifestLayout{appLayout},
+	}
+	root := &layout.ManifestLayout{Children: []*layout.ManifestLayout{nodeLayout}}
+
+	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	if err := li.IntegrateWithLayout(root, cluster, layout.LayoutRules{}); err == nil {
+		t.Fatal("expected error: grandchild needs a CR but ancestor bundle has no SourceRef")
+	}
+}
+
 // --- shared test helpers for augmenter tests ---
 
 // buildAugmenterTestTree constructs a layout+cluster tree simulating crane's

--- a/pkg/stack/fluxcd/layout_integrator_test.go
+++ b/pkg/stack/fluxcd/layout_integrator_test.go
@@ -1,10 +1,17 @@
 package fluxcd_test
 
 import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	kustv1 "github.com/fluxcd/kustomize-controller/api/v1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-kure/kure/pkg/stack"
 	fluxstack "github.com/go-kure/kure/pkg/stack/fluxcd"
@@ -787,4 +794,252 @@ func TestIntegrateWithLayout_RepeatedCallSucceeds(t *testing.T) {
 	if err := integrator.IntegrateWithLayout(walked, cluster, layout.LayoutRules{}); err != nil {
 		t.Fatalf("second IntegrateWithLayout: %v (alias state was destroyed by the first pass)", err)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Augmenter child layout CR generation (#571)
+// ---------------------------------------------------------------------------
+
+// TestAugmenterChildrenGetFluxCRs verifies that:
+//
+//	(a) direct app-layout children of the node layout receive CRs in
+//	    nodeLayout.Resources (flat/nodeOnly path), and
+//	(b) augmenter sub-layouts (children of app layouts) receive CRs in
+//	    app.Resources with correct DependsOn wiring.
+func TestAugmenterChildrenGetFluxCRs(t *testing.T) {
+	root, nodeLayout, app, preInstall, hooks, cluster := buildAugmenterTestTree()
+
+	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	if err := li.IntegrateWithLayout(root, cluster, layout.LayoutRules{}); err != nil {
+		t.Fatalf("IntegrateWithLayout: %v", err)
+	}
+
+	// (a) nodeLayout.Resources must contain a CR for the direct child "myapp".
+	if !augHasCR(nodeLayout.Resources, "myapp") {
+		t.Error("expected CR for 'myapp' in nodeLayout.Resources (flat path)")
+	}
+
+	// (b) app.Resources must contain CRs for both augmenter sub-layouts.
+	if len(app.Resources) != 2 {
+		t.Fatalf("expected 2 CRs in app.Resources, got %d", len(app.Resources))
+	}
+	k0 := augMustKustomization(t, app.Resources[0])
+	if k0.Name != preInstall.Name {
+		t.Errorf("unexpected first CR name: got %q, want %q", k0.Name, preInstall.Name)
+	}
+	if len(k0.Spec.DependsOn) != 0 {
+		t.Errorf("expected no dependsOn on pre-install CR, got %v", k0.Spec.DependsOn)
+	}
+	k1 := augMustKustomization(t, app.Resources[1])
+	if k1.Name != hooks.Name {
+		t.Errorf("unexpected second CR name: got %q, want %q", k1.Name, hooks.Name)
+	}
+	if len(k1.Spec.DependsOn) != 1 || k1.Spec.DependsOn[0].Name != preInstall.Name {
+		t.Errorf("unexpected dependsOn on hooks CR: %v", k1.Spec.DependsOn)
+	}
+	// spec.path must equal FullRepoPath().
+	if k0.Spec.Path != preInstall.FullRepoPath() {
+		t.Errorf("spec.path: got %q, want %q", k0.Spec.Path, preInstall.FullRepoPath())
+	}
+}
+
+// TestAugmenterChildrenNoDuplicateInKustomizationYAML verifies that WriteToDisk
+// does not emit the same flux-system-kustomization-*.yaml filename twice in
+// either the node-level or app-level kustomization.yaml.
+func TestAugmenterChildrenNoDuplicateInKustomizationYAML(t *testing.T) {
+	root, nodeLayout, app, preInstall, _, cluster := buildAugmenterTestTree()
+
+	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	if err := li.IntegrateWithLayout(root, cluster, layout.LayoutRules{}); err != nil {
+		t.Fatalf("IntegrateWithLayout: %v", err)
+	}
+
+	dir := t.TempDir()
+	if err := root.WriteToDisk(dir); err != nil {
+		t.Fatalf("WriteToDisk: %v", err)
+	}
+
+	// Node-level kustomization.yaml must reference "myapp" exactly once.
+	augAssertOnce(t, dir, nodeLayout.FullRepoPath(), "flux-system-kustomization-myapp.yaml")
+
+	// App-level kustomization.yaml must reference the pre-install CR exactly once.
+	augAssertOnce(t, dir, app.FullRepoPath(),
+		"flux-system-kustomization-"+preInstall.Name+".yaml")
+}
+
+// TestAugmenterChildrenWriteToTar verifies no duplicate entries in the tar
+// output. Crane consumes WriteToTar for OCI artifacts.
+func TestAugmenterChildrenWriteToTar(t *testing.T) {
+	root, nodeLayout, app, preInstall, _, cluster := buildAugmenterTestTree()
+
+	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	if err := li.IntegrateWithLayout(root, cluster, layout.LayoutRules{}); err != nil {
+		t.Fatalf("IntegrateWithLayout: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := root.WriteToTar(&buf); err != nil {
+		t.Fatalf("WriteToTar: %v", err)
+	}
+
+	files := map[string]string{}
+	tr := tar.NewReader(&buf)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar.Next: %v", err)
+		}
+		if strings.HasSuffix(hdr.Name, "kustomization.yaml") {
+			data, _ := io.ReadAll(tr)
+			files[hdr.Name] = string(data)
+		}
+	}
+
+	nodeKust := augFindKust(t, files, nodeLayout.FullRepoPath())
+	augAssertCount(t, nodeKust, "flux-system-kustomization-myapp.yaml", 1)
+
+	appKust := augFindKust(t, files, app.FullRepoPath())
+	augAssertCount(t, appKust, "flux-system-kustomization-"+preInstall.Name+".yaml", 1)
+}
+
+// TestAugmenterChildrenErrorWhenNoSourceRef verifies that IntegrateWithLayout
+// returns a blocking error when augmenter children need CRs but the bundle
+// has a nil, empty, or incomplete SourceRef.
+func TestAugmenterChildrenErrorWhenNoSourceRef(t *testing.T) {
+	cases := []struct {
+		name string
+		sr   *stack.SourceRef
+	}{
+		{"nil", nil},
+		{"empty struct", &stack.SourceRef{}},
+		{"missing Kind", &stack.SourceRef{Name: "flux-system"}},
+		{"missing Name", &stack.SourceRef{Kind: "GitRepository"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			appChild := &layout.ManifestLayout{
+				Name:          "myapp",
+				Namespace:     "clusters/prod",
+				FluxPlacement: layout.FluxIntegrated,
+				Children: []*layout.ManifestLayout{{
+					Name:          "myapp-00-pre-install",
+					Namespace:     "clusters/prod/myapp/myapp-00-pre-install",
+					FluxPlacement: layout.FluxIntegrated,
+				}},
+			}
+			bundle := &stack.Bundle{Name: "apps", SourceRef: tc.sr}
+			node := &stack.Node{Name: "prod", Bundle: bundle}
+			cluster := &stack.Cluster{Node: node}
+			nodeLayout := &layout.ManifestLayout{
+				Name:          "prod",
+				FluxPlacement: layout.FluxIntegrated,
+				Children:      []*layout.ManifestLayout{appChild},
+			}
+			root := &layout.ManifestLayout{Children: []*layout.ManifestLayout{nodeLayout}}
+
+			li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+			if err := li.IntegrateWithLayout(root, cluster, layout.LayoutRules{}); err == nil {
+				t.Fatalf("sourceRef=%v: expected error, got nil", tc.sr)
+			}
+		})
+	}
+}
+
+// --- shared test helpers for augmenter tests ---
+
+// buildAugmenterTestTree constructs a layout+cluster tree simulating crane's
+// augmentLayoutTemplate output: a node layout with one app layout, which has
+// two hook-group sub-layouts (pre-install and hooks with DependsOn).
+//
+// Root is intentionally unnamed so findLayoutNode accumulates the path for
+// nodeLayout as "prod", matching node.GetPath() == "prod".
+func buildAugmenterTestTree() (root, nodeLayout, app, preInstall, hooks *layout.ManifestLayout, cluster *stack.Cluster) {
+	preInstall = &layout.ManifestLayout{
+		Name:          "myapp-00-pre-install",
+		Namespace:     "clusters/prod/myapp/myapp-00-pre-install",
+		FluxPlacement: layout.FluxIntegrated,
+	}
+	hooks = &layout.ManifestLayout{
+		Name:          "myapp-01-hooks",
+		Namespace:     "clusters/prod/myapp/myapp-01-hooks",
+		FluxPlacement: layout.FluxIntegrated,
+		DependsOn:     []string{"myapp-00-pre-install"},
+	}
+	app = &layout.ManifestLayout{
+		Name:          "myapp",
+		Namespace:     "clusters/prod",
+		FluxPlacement: layout.FluxIntegrated,
+		Children:      []*layout.ManifestLayout{preInstall, hooks},
+	}
+	sr := &stack.SourceRef{Kind: "GitRepository", Name: "flux-system", Namespace: "flux-system"}
+	bundle := &stack.Bundle{Name: "apps", SourceRef: sr}
+	node := &stack.Node{Name: "prod", Bundle: bundle}
+	cluster = &stack.Cluster{Node: node}
+	nodeLayout = &layout.ManifestLayout{
+		Name:          "prod",
+		FluxPlacement: layout.FluxIntegrated,
+		Children:      []*layout.ManifestLayout{app},
+	}
+	root = &layout.ManifestLayout{Children: []*layout.ManifestLayout{nodeLayout}}
+	return
+}
+
+func augHasCR(resources []client.Object, name string) bool {
+	for _, r := range resources {
+		if k, ok := r.(*kustv1.Kustomization); ok && k.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func augMustKustomization(t *testing.T, obj client.Object) *kustv1.Kustomization {
+	t.Helper()
+	k, ok := obj.(*kustv1.Kustomization)
+	if !ok {
+		t.Fatalf("expected *kustv1.Kustomization, got %T", obj)
+	}
+	return k
+}
+
+func augAssertOnce(t *testing.T, baseDir, layoutPath, target string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(baseDir, layoutPath, "kustomization.yaml"))
+	if err != nil {
+		t.Fatalf("read kustomization.yaml under %s: %v", layoutPath, err)
+	}
+	if count := strings.Count(string(data), target); count != 1 {
+		t.Errorf("expected exactly 1 reference to %q in %s/kustomization.yaml, got %d:\n%s",
+			target, layoutPath, count, data)
+	}
+}
+
+func augFindKust(t *testing.T, files map[string]string, layoutPath string) string {
+	t.Helper()
+	key := filepath.ToSlash(filepath.Join(layoutPath, "kustomization.yaml"))
+	for k, v := range files {
+		if strings.HasSuffix(k, key) {
+			return v
+		}
+	}
+	t.Fatalf("kustomization.yaml not found for layout path %q; available: %v", layoutPath, augKeysOf(files))
+	return ""
+}
+
+func augAssertCount(t *testing.T, content, target string, want int) {
+	t.Helper()
+	if got := strings.Count(content, target); got != want {
+		t.Errorf("expected %d reference(s) to %q, got %d:\n%s", want, target, got, content)
+	}
+}
+
+func augKeysOf(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/pkg/stack/fluxcd/resource_generator.go
+++ b/pkg/stack/fluxcd/resource_generator.go
@@ -309,6 +309,36 @@ func (g *ResourceGenerator) createKustomization(b *stack.Bundle) client.Object {
 	return kust
 }
 
+// createKustomizationForLayout creates a Flux Kustomization CR for a
+// ManifestLayout child in FluxIntegrated mode. The CR name equals ml.Name;
+// spec.path is ml.FullRepoPath(); spec.dependsOn is populated from ml.DependsOn.
+func (g *ResourceGenerator) createKustomizationForLayout(
+	ml *layout.ManifestLayout,
+	sourceRef kustv1.CrossNamespaceSourceReference,
+) client.Object {
+	kust := &kustv1.Kustomization{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: kustv1.GroupVersion.String(),
+			Kind:       "Kustomization",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ml.Name,
+			Namespace: g.DefaultNamespace,
+		},
+		Spec: kustv1.KustomizationSpec{
+			Interval:  metav1.Duration{Duration: g.DefaultInterval},
+			Path:      ml.FullRepoPath(),
+			Prune:     true,
+			SourceRef: sourceRef,
+		},
+	}
+	for _, dep := range ml.DependsOn {
+		kust.Spec.DependsOn = append(kust.Spec.DependsOn,
+			kustv1.DependencyReference{Name: dep})
+	}
+	return kust
+}
+
 // createSource creates a Flux source resource based on the source reference.
 // When the SourceRef has a URL, the corresponding source CRD is created.
 // When URL is empty, only a reference is used (the source already exists in the cluster).

--- a/pkg/stack/layout/README.md
+++ b/pkg/stack/layout/README.md
@@ -124,7 +124,30 @@ type LayoutAugmenter interface {
 }
 ```
 
-When `app.Config` implements it, the walker invokes `AugmentLayout` on the per-app `ManifestLayout` after resource generation, giving the config a chance to attach `ExtraFiles` and `ConfigMapGenerators`. Only invoked on per-app layouts produced by the non-flat (`GroupByName`) walker paths; `GroupFlat` and umbrella layouts merge resources into shared parent layouts and are not currently augmented.
+When `app.Config` implements it, the walker invokes `AugmentLayout` on the per-app `ManifestLayout` after resource generation, giving the config a chance to attach `ExtraFiles`, `ConfigMapGenerators`, and sub-`ManifestLayout` children. Only invoked on per-app layouts produced by the non-flat (`GroupByName`) walker paths; `GroupFlat` and umbrella layouts merge resources into shared parent layouts and are not currently augmented.
+
+#### Sub-Layout Children and Flux Integration
+
+Augmenters may attach sub-layouts as `Children` of a per-app `ManifestLayout`. In `FluxIntegrated` mode each such child that is eligible (see below) receives a Flux `Kustomization` CR automatically placed in the parent layout's `Resources`.
+
+**Eligibility for CR generation.** A child layout receives a Flux `Kustomization` CR when ALL of the following hold:
+
+- The ancestor node bundle's layout operates in `FluxIntegrated` mode.
+- `!child.UmbrellaChild`
+- `child.ApplicationFileMode != AppFileSingle`
+- The ancestor bundle has a non-nil, non-empty `SourceRef` with both `Kind` and `Name` set. A nil, empty struct, or incomplete `SourceRef` (missing either field) causes `IntegrateWithLayout` to return a hard error — a `Kustomization` without `spec.sourceRef` is rejected by Flux.
+
+This rule mirrors exactly what the writers use to emit `flux-system-kustomization-{child.Name}.yaml` from the parent's `kustomization.yaml`, so every file reference the writers produce has a backing CR. The integrator applies this rule recursively: it covers both direct children of the node layout and augmenter-added sub-layouts at any depth.
+
+#### Naming Constraint
+
+Child layout `Name` is used as the Flux `Kustomization` CR name in `FluxIntegrated` mode (matching the filename emitted by the writers: `flux-system-kustomization-{child.Name}.yaml`). Flux `Kustomization` CRs live in the `flux-system` namespace, so names must be **globally unique across all apps in the cluster** — two CRs with the same `metadata.name` collide.
+
+Augmenters are responsible for ensuring uniqueness. The recommended convention is to prefix each child name with the app name: `{appName}-{hookGroupDir}` (e.g. `nginx-00-pre-install`).
+
+#### DependsOn
+
+Set `ManifestLayout.DependsOn` to a list of sibling layout names. In `FluxIntegrated` mode the layout integrator translates these into `spec.dependsOn` entries on the child's `Kustomization` CR, enabling ordered reconciliation between hook groups (e.g. pre-install → hooks → post-install).
 
 ### ClusterName-Aware Layouts
 

--- a/pkg/stack/layout/manifest.go
+++ b/pkg/stack/layout/manifest.go
@@ -42,6 +42,11 @@ type ManifestLayout struct {
 	// child's Flux Kustomization CR at the parent layout node rather than in
 	// the child's own directory.
 	UmbrellaChild bool
+	// DependsOn lists sibling layout names whose Kustomization CRs must reconcile
+	// before this layout's CR. In FluxIntegrated mode the layout integrator
+	// translates these into spec.dependsOn on the emitted Kustomization CR.
+	// Augmenters (LayoutAugmenter) set this field; the integrator reads it.
+	DependsOn []string
 	// flattenInfo carries the redirects produced by FlattenSingleTier when
 	// this layout absorbed a collapsed child. Set only on the absorbing
 	// layout; never serialised. Consulted by the Flux integrator's

--- a/pkg/stack/layout/manifest.go
+++ b/pkg/stack/layout/manifest.go
@@ -281,6 +281,11 @@ func (ml *ManifestLayout) WriteToDisk(basePath string) error {
 	}
 	sort.Strings(sortedFileNames)
 
+	listedInResources := make(map[string]struct{}, len(sortedFileNames))
+	for _, f := range sortedFileNames {
+		listedInResources[f] = struct{}{}
+	}
+
 	for _, fileName := range sortedFileNames {
 		objs := fileGroups[fileName]
 		f, err := os.Create(filepath.Join(fullPath, fileName))
@@ -375,7 +380,9 @@ func (ml *ManifestLayout) WriteToDisk(basePath string) error {
 				// the parent directory uses FilePerKind.
 				nameFn := ml.resolveManifestFileName()
 				fluxKustName := nameFn("flux-system", "kustomization", child.Name, FilePerResource)
-				writeStr(fmt.Sprintf("  - %s\n", fluxKustName))
+				if _, dup := listedInResources[fluxKustName]; !dup {
+					writeStr(fmt.Sprintf("  - %s\n", fluxKustName))
+				}
 			} else {
 				// For package-aware layouts, use relative path
 				if ml.PackageRef != nil && child.PackageRef != nil && ml.PackageRef != child.PackageRef {

--- a/pkg/stack/layout/tar.go
+++ b/pkg/stack/layout/tar.go
@@ -75,6 +75,11 @@ func (ml *ManifestLayout) writeToTarRecursive(tw *tar.Writer, basePath string) e
 	}
 	sort.Strings(sortedFileNames)
 
+	listedInResources := make(map[string]struct{}, len(sortedFileNames))
+	for _, f := range sortedFileNames {
+		listedInResources[f] = struct{}{}
+	}
+
 	// Write resource files
 	for _, fileName := range sortedFileNames {
 		objs := fileGroups[fileName]
@@ -139,7 +144,9 @@ func (ml *ManifestLayout) writeToTarRecursive(tw *tar.Writer, basePath string) e
 				// Always use FilePerResource here — each child must have a
 				// unique filename; FilePerKind would drop child.Name.
 				fluxKustName := nameFn("flux-system", "kustomization", child.Name, FilePerResource)
-				kustomBuf.WriteString(fmt.Sprintf("  - %s\n", fluxKustName))
+				if _, dup := listedInResources[fluxKustName]; !dup {
+					kustomBuf.WriteString(fmt.Sprintf("  - %s\n", fluxKustName))
+				}
 			} else {
 				if ml.PackageRef != nil && child.PackageRef != nil && ml.PackageRef != child.PackageRef {
 					continue

--- a/pkg/stack/layout/tar_test.go
+++ b/pkg/stack/layout/tar_test.go
@@ -736,3 +736,48 @@ func fileNames(files map[string][]byte) []string {
 	sort.Strings(names)
 	return names
 }
+
+// TestWriteToTar_NoDuplicateFluxEntries guards against the duplicate-entry bug
+// in WriteToTar: when a Kustomization CR is in Resources AND the same child
+// appears in Children, the kustomization.yaml must reference the file only once.
+// Crane uses WriteToTar for OCI artifacts — skipping this path leaves production broken.
+func TestWriteToTar_NoDuplicateFluxEntries(t *testing.T) {
+	cr := &unstructured.Unstructured{}
+	cr.SetAPIVersion("kustomize.toolkit.fluxcd.io/v1")
+	cr.SetKind("Kustomization")
+	cr.SetName("myapp")
+	cr.SetNamespace("flux-system")
+
+	child := &ManifestLayout{
+		Name:          "myapp",
+		Namespace:     "prod/apps/myapp",
+		FluxPlacement: FluxIntegrated,
+	}
+	parent := &ManifestLayout{
+		Name:          "prod",
+		Namespace:     "cl",
+		FluxPlacement: FluxIntegrated,
+		Resources:     []client.Object{cr},
+		Children:      []*ManifestLayout{child},
+	}
+
+	var buf bytes.Buffer
+	if err := parent.WriteToTar(&buf); err != nil {
+		t.Fatalf("WriteToTar: %v", err)
+	}
+
+	files := extractTarFiles(t, &buf)
+
+	// parent.FullRepoPath()="cl/prod" → kustomization.yaml at "cl/prod/kustomization.yaml"
+	kustKey := "cl/prod/kustomization.yaml"
+	kustData, ok := files[kustKey]
+	if !ok {
+		t.Fatalf("kustomization.yaml not found at %q; available: %v", kustKey, fileNames(files))
+	}
+
+	const target = "flux-system-kustomization-myapp.yaml"
+	if count := strings.Count(string(kustData), target); count != 1 {
+		t.Errorf("expected 1 reference to %q in tar kustomization.yaml, got %d:\n%s",
+			target, count, kustData)
+	}
+}

--- a/pkg/stack/layout/write.go
+++ b/pkg/stack/layout/write.go
@@ -68,6 +68,11 @@ func WriteManifest(basePath string, cfg Config, ml *ManifestLayout) error {
 	}
 	sort.Strings(sortedFileNames)
 
+	listedInResources := make(map[string]struct{}, len(sortedFileNames))
+	for _, f := range sortedFileNames {
+		listedInResources[f] = struct{}{}
+	}
+
 	for _, fileName := range sortedFileNames {
 		objs := fileGroups[fileName]
 		f, err := os.Create(filepath.Join(fullPath, fileName))
@@ -168,7 +173,9 @@ func WriteManifest(basePath string, cfg Config, ml *ManifestLayout) error {
 				// Always use FilePerResource — each child must have a unique filename.
 				if ml.FluxPlacement == FluxIntegrated {
 					fluxKustName := manifestFileName("flux-system", "kustomization", child.Name, FilePerResource)
-					writeStr(fmt.Sprintf("  - %s\n", fluxKustName))
+					if _, dup := listedInResources[fluxKustName]; !dup {
+						writeStr(fmt.Sprintf("  - %s\n", fluxKustName))
+					}
 				} else {
 					writeStr(fmt.Sprintf("  - %s\n", child.Name))
 				}

--- a/pkg/stack/layout/write_test.go
+++ b/pkg/stack/layout/write_test.go
@@ -1248,3 +1248,71 @@ func TestWriteToDisk_FileNamingKindName_FluxIntegrated(t *testing.T) {
 		t.Errorf("should not have namespace-prefixed flux reference, got:\n%s", content)
 	}
 }
+
+// TestWriteManifest_NoDuplicateFluxEntries guards against the duplicate-entry bug
+// where a Kustomization CR already in Resources AND a matching child layout entry
+// both produce the same flux-system-kustomization-*.yaml reference in kustomization.yaml.
+func TestWriteManifest_NoDuplicateFluxEntries(t *testing.T) {
+	cr := testObject("kustomize.toolkit.fluxcd.io/v1", "Kustomization", "myapp", "flux-system")
+	child := &ManifestLayout{
+		Name:          "myapp",
+		Namespace:     "clusters/prod/apps/myapp",
+		FluxPlacement: FluxIntegrated,
+	}
+	parent := &ManifestLayout{
+		Name:          "prod",
+		FluxPlacement: FluxIntegrated,
+		Resources:     []client.Object{cr},
+		Children:      []*ManifestLayout{child},
+	}
+
+	dir := t.TempDir()
+	cfg := DefaultLayoutConfig()
+	if err := WriteManifest(dir, cfg, parent); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+
+	// parent.Namespace="" → FullRepoPath()="cluster/prod"; ManifestsDir="clusters"
+	kustPath := filepath.Join(dir, "clusters", "cluster", "prod", "kustomization.yaml")
+	data, err := os.ReadFile(kustPath)
+	if err != nil {
+		t.Fatalf("read kustomization.yaml at %s: %v", kustPath, err)
+	}
+	const target = "flux-system-kustomization-myapp.yaml"
+	if count := strings.Count(string(data), target); count != 1 {
+		t.Errorf("expected 1 reference to %q, got %d:\n%s", target, count, data)
+	}
+}
+
+// TestWriteToDisk_NoDuplicateFluxEntries is the WriteToDisk counterpart.
+func TestWriteToDisk_NoDuplicateFluxEntries(t *testing.T) {
+	cr := testObject("kustomize.toolkit.fluxcd.io/v1", "Kustomization", "myapp", "flux-system")
+	child := &ManifestLayout{
+		Name:          "myapp",
+		Namespace:     "prod/apps/myapp",
+		FluxPlacement: FluxIntegrated,
+	}
+	parent := &ManifestLayout{
+		Name:          "prod",
+		Namespace:     "cl",
+		FluxPlacement: FluxIntegrated,
+		Resources:     []client.Object{cr},
+		Children:      []*ManifestLayout{child},
+	}
+
+	dir := t.TempDir()
+	if err := parent.WriteToDisk(dir); err != nil {
+		t.Fatalf("WriteToDisk: %v", err)
+	}
+
+	// parent.FullRepoPath() = "cl/prod"
+	kustPath := filepath.Join(dir, "cl", "prod", "kustomization.yaml")
+	data, err := os.ReadFile(kustPath)
+	if err != nil {
+		t.Fatalf("read kustomization.yaml: %v", err)
+	}
+	const target = "flux-system-kustomization-myapp.yaml"
+	if count := strings.Count(string(data), target); count != 1 {
+		t.Errorf("expected 1 reference to %q, got %d:\n%s", target, count, data)
+	}
+}

--- a/site/content/guides/flux-workflow.md
+++ b/site/content/guides/flux-workflow.md
@@ -200,6 +200,65 @@ In `FluxSeparate` placement, all Kustomization CRs (the umbrella's own plus
 every descendant) are written to the shared `flux-system/` directory as a
 flat list.
 
+## Augmenter-Added Child Layouts
+
+A `LayoutAugmenter` can attach sub-`ManifestLayout` children to a per-app layout after resource generation. In `FluxIntegrated` mode kure automatically emits a Flux `Kustomization` CR for each eligible child.
+
+### Eligibility
+
+A child layout receives a CR when:
+- `!child.UmbrellaChild`
+- `child.ApplicationFileMode != AppFileSingle`
+- The ancestor bundle's `SourceRef` has both `Kind` and `Name` set (nil, empty struct, or missing either field is a hard error — a `Kustomization` without `spec.sourceRef` is invalid)
+
+### Ordered reconciliation with DependsOn
+
+Set `ManifestLayout.DependsOn` to a list of sibling layout names to express reconciliation order between hook groups. The integrator translates these into `spec.dependsOn` entries on the emitted CR:
+
+```go
+preInstall := &layout.ManifestLayout{
+    Name: "nginx-00-pre-install",
+    // ...
+}
+hooks := &layout.ManifestLayout{
+    Name:      "nginx-01-hooks",
+    DependsOn: []string{"nginx-00-pre-install"},
+    // ...
+}
+```
+
+This produces a `nginx-01-hooks` Kustomization CR with:
+
+```yaml
+spec:
+  dependsOn:
+    - name: nginx-00-pre-install
+```
+
+Flux reconciles `nginx-01-hooks` only after `nginx-00-pre-install` is healthy.
+
+### Naming uniqueness
+
+The child layout `Name` becomes the Flux `Kustomization` CR's `metadata.name`. Since all `Kustomization` CRs live in the `flux-system` namespace, names must be **globally unique across the cluster**. The recommended convention is `{appName}-{hookGroupDir}` (e.g. `nginx-00-pre-install`, `nginx-01-hooks`). Augmenters are responsible for enforcing this uniqueness.
+
+### Disk layout
+
+```
+clusters/production/prod/
+  flux-system-kustomization-nginx.yaml      # app CR (placed at node level)
+  kustomization.yaml                        # references nginx CR
+  nginx/
+    flux-system-kustomization-nginx-00-pre-install.yaml
+    flux-system-kustomization-nginx-01-hooks.yaml
+    kustomization.yaml                      # references hook CRs
+    nginx-00-pre-install/
+      workload-*.yaml
+      kustomization.yaml
+    nginx-01-hooks/
+      workload-*.yaml
+      kustomization.yaml
+```
+
 ## Bootstrap
 
 Generate Flux system bootstrap manifests. Two modes are available:


### PR DESCRIPTION
## Summary

- Adds `DependsOn []string` to `ManifestLayout` for ordered reconciliation between hook groups
- Extends `processNodeForIntegratedFlux` to emit Flux `Kustomization` CRs for all eligible non-umbrella, non-AppFileSingle children of each node layout — covering both flat/nodeOnly app layouts and augmenter-added sub-layouts at any depth
- Returns a hard error when eligible children need CRs but the bundle's `SourceRef` is nil or incomplete (missing `Kind`/`Name`) — a Kustomization without `spec.sourceRef` is invalid
- Fixes a duplicate-entry bug in all three writers (`WriteToDisk`, `WriteManifest`, `WriteToTar`) where a CR already in `Resources` AND the same child in `Children` both produced the same `flux-system-kustomization-*.yaml` line

## Test plan

- [ ] `TestAugmenterChildrenGetFluxCRs`: verifies CRs are placed in correct layout Resources with correct DependsOn wiring
- [ ] `TestAugmenterChildrenNoDuplicateInKustomizationYAML`: verifies WriteToDisk produces no duplicate references
- [ ] `TestAugmenterChildrenWriteToTar`: verifies WriteToTar (crane's OCI path) produces no duplicate references
- [ ] `TestAugmenterChildrenErrorWhenNoSourceRef`: verifies hard error for nil/empty/incomplete SourceRef
- [ ] `TestWriteManifest_NoDuplicateFluxEntries` + `TestWriteToDisk_NoDuplicateFluxEntries` + `TestWriteToTar_NoDuplicateFluxEntries`: unit-level duplicate-entry guards for each writer
- [ ] All existing tests pass (`mise run verify`)

## What this does NOT solve

- `spec.path` for nested bundle layouts (pre-existing bug)
- Nested node hierarchies in FluxIntegrated mode (pre-existing)
- Crane hook-group naming (no app prefix) — crane follow-up required before deploying
- SourceRef required at bundle validation time — kure follow-up issue required; this PR enforces at the integrator level only

Closes #571