### PR TITLE
feat(fluxcd): validate bundle SourceRefs early in FluxIntegrated mode (#572)

### DIFF
--- a/pkg/stack/fluxcd/README.md
+++ b/pkg/stack/fluxcd/README.md
@@ -189,6 +189,14 @@ configurations — such as a bundle referenced both by a `Node` and by another
 bundle's `Children`, shared umbrella ownership, or multi-package umbrellas —
 fail fast with a validation error rather than producing malformed output.
 
+`CreateLayoutWithResources` additionally calls `validateSourceRefsForFluxIntegrated`
+when `FluxPlacement == FluxIntegrated`. This checks that every bundle reachable
+from the cluster node tree — node bundles and umbrella child bundles recursively
+— has a complete `SourceRef` with both `Kind` and `Name` set. A nil,
+zero-value, or partially-populated `SourceRef` is rejected before layout walking
+begins. The integrator also enforces this at CR-creation time as defense in
+depth. `FluxSeparate` and non-Flux paths are unaffected.
+
 ## Related Packages
 
 - [stack](../) - Core domain model

--- a/pkg/stack/fluxcd/fluxcd_test.go
+++ b/pkg/stack/fluxcd/fluxcd_test.go
@@ -667,18 +667,22 @@ func TestEndToEndUmbrellaFromCluster_Integrated(t *testing.T) {
 	// output has the right directory shape, kustomization.yaml references, and
 	// the umbrella parent Kustomization CR with HealthChecks.
 	umbrella := &stack.Bundle{
-		Name: "platform",
+		Name:      "platform",
+		SourceRef: testSR(),
 		Children: []*stack.Bundle{
 			{
 				Name:         "Y-infra",
+				SourceRef:    testSR(),
 				Applications: []*stack.Application{fakeUmbrellaApp("infra-app", "cm-infra")},
 			},
 			{
 				Name:         "Y-services",
+				SourceRef:    testSR(),
 				Applications: []*stack.Application{fakeUmbrellaApp("services-app", "cm-services")},
 			},
 			{
 				Name:         "Y-apps",
+				SourceRef:    testSR(),
 				Applications: []*stack.Application{fakeUmbrellaApp("apps-app", "cm-apps")},
 			},
 		},

--- a/pkg/stack/fluxcd/layout_integrator.go
+++ b/pkg/stack/fluxcd/layout_integrator.go
@@ -71,6 +71,12 @@ func (li *LayoutIntegrator) CreateLayoutWithResources(c *stack.Cluster, rules la
 		return nil, err
 	}
 
+	if li.FluxPlacement == layout.FluxIntegrated {
+		if err := validateSourceRefsForFluxIntegrated(c); err != nil {
+			return nil, err
+		}
+	}
+
 	// Generate the base manifest layout first
 	ml, err := layout.WalkCluster(c, rules)
 	if err != nil {

--- a/pkg/stack/fluxcd/layout_integrator_test.go
+++ b/pkg/stack/fluxcd/layout_integrator_test.go
@@ -368,9 +368,9 @@ func TestLayoutIntegrator_SeparateMode_EmptyCluster(t *testing.T) {
 // layout node not found". This matches the shape of examples/demo/clusters/
 // basic/cluster.yaml.
 func TestCreateLayoutWithResources_ClusterNameWithChildNodes(t *testing.T) {
-	rootBundle := &stack.Bundle{Name: "root-bundle"}
-	appsBundle := &stack.Bundle{Name: "apps-bundle"}
-	infraBundle := &stack.Bundle{Name: "infra-bundle"}
+	rootBundle := &stack.Bundle{Name: "root-bundle", SourceRef: testSR()}
+	appsBundle := &stack.Bundle{Name: "apps-bundle", SourceRef: testSR()}
+	infraBundle := &stack.Bundle{Name: "infra-bundle", SourceRef: testSR()}
 
 	appsNode := &stack.Node{Name: "apps", Bundle: appsBundle}
 	infraNode := &stack.Node{Name: "infra", Bundle: infraBundle}
@@ -445,10 +445,11 @@ func TestCreateLayoutWithResources_UmbrellaIntegratedPlacement(t *testing.T) {
 	// lands at the bundle layout (where the bundle-dir kustomization.yaml
 	// references them via UmbrellaChild). Child sub-layouts carry no Flux CRs.
 	umbrella := &stack.Bundle{
-		Name: "platform",
+		Name:      "platform",
+		SourceRef: testSR(),
 		Children: []*stack.Bundle{
-			{Name: "infra"},
-			{Name: "services"},
+			{Name: "infra", SourceRef: testSR()},
+			{Name: "services", SourceRef: testSR()},
 		},
 	}
 	node := &stack.Node{Name: "apps", Bundle: umbrella}
@@ -528,9 +529,10 @@ func TestCreateLayoutWithResources_UmbrellaNodeOnlyPlacement(t *testing.T) {
 	// In nodeOnly (GroupFlat) mode, the umbrella child Flux CRs should land
 	// at the node layout directly (no intermediate bundle layer).
 	umbrella := &stack.Bundle{
-		Name: "platform",
+		Name:      "platform",
+		SourceRef: testSR(),
 		Children: []*stack.Bundle{
-			{Name: "infra"},
+			{Name: "infra", SourceRef: testSR()},
 		},
 	}
 	node := &stack.Node{Name: "apps", Bundle: umbrella}
@@ -579,12 +581,14 @@ func TestCreateLayoutWithResources_UmbrellaNestedIntegratedPlacement(t *testing.
 	// Flux CR should land at the infra umbrella child layout, not the
 	// platform bundle layout or the grandchild sub-layout.
 	umbrella := &stack.Bundle{
-		Name: "platform",
+		Name:      "platform",
+		SourceRef: testSR(),
 		Children: []*stack.Bundle{
 			{
-				Name: "infra",
+				Name:      "infra",
+				SourceRef: testSR(),
 				Children: []*stack.Bundle{
-					{Name: "networking"},
+					{Name: "networking", SourceRef: testSR()},
 				},
 			},
 		},
@@ -667,7 +671,8 @@ func TestCreateLayoutWithResources_UmbrellaChildWithSource(t *testing.T) {
 	// When an umbrella child has a SourceRef with URL, the Source CR should
 	// be placed at the parent layout alongside the child Kustomization.
 	umbrella := &stack.Bundle{
-		Name: "platform",
+		Name:      "platform",
+		SourceRef: testSR(),
 		Children: []*stack.Bundle{
 			{
 				Name: "ext",
@@ -1087,4 +1092,9 @@ func augKeysOf(m map[string]string) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// testSR returns a minimal valid SourceRef for use in FluxIntegrated fixtures.
+func testSR() *stack.SourceRef {
+	return &stack.SourceRef{Kind: "GitRepository", Name: "flux-system", Namespace: "flux-system"}
 }

--- a/pkg/stack/fluxcd/layout_integrator_test.go
+++ b/pkg/stack/fluxcd/layout_integrator_test.go
@@ -1094,6 +1094,38 @@ func augKeysOf(m map[string]string) []string {
 	return keys
 }
 
+func TestCreateLayoutWithResources_FluxIntegrated_RejectsInvalidSourceRef(t *testing.T) {
+	// Validator fires before WalkCluster; no ApplicationConfig needed.
+	c := &stack.Cluster{
+		Name: "test",
+		Node: &stack.Node{
+			Name:   "prod",
+			Bundle: &stack.Bundle{Name: "apps"},
+		},
+	}
+	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegrated}
+
+	if _, err := li.CreateLayoutWithResources(c, rules); err == nil {
+		t.Fatal("expected error for FluxIntegrated with nil SourceRef, got nil")
+	}
+}
+
+func TestCreateLayoutWithResources_FluxSeparate_AllowsMissingSourceRef(t *testing.T) {
+	bundle := &stack.Bundle{Name: "apps"}
+	bundle.Applications = []*stack.Application{fakeUmbrellaApp("myapp", "my-cm")}
+	node := &stack.Node{Name: "prod", Bundle: bundle}
+	c := &stack.Cluster{Node: node, Name: "test-cluster"}
+
+	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	li.SetFluxPlacement(layout.FluxSeparate)
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxSeparate}
+
+	if _, err := li.CreateLayoutWithResources(c, rules); err != nil {
+		t.Fatalf("FluxSeparate: unexpected error for nil SourceRef: %v", err)
+	}
+}
+
 // testSR returns a minimal valid SourceRef for use in FluxIntegrated fixtures.
 func testSR() *stack.SourceRef {
 	return &stack.SourceRef{Kind: "GitRepository", Name: "flux-system", Namespace: "flux-system"}

--- a/pkg/stack/fluxcd/validate.go
+++ b/pkg/stack/fluxcd/validate.go
@@ -1,0 +1,64 @@
+package fluxcd
+
+import (
+	"github.com/go-kure/kure/pkg/errors"
+	"github.com/go-kure/kure/pkg/stack"
+)
+
+// validateSourceRefsForFluxIntegrated checks that every bundle reachable from
+// the cluster node tree has a complete SourceRef before layout walking begins.
+//
+// Coverage:
+//   - node.Bundle for every node in the tree
+//   - umbrella child bundles (bundle.Children) recursively
+//
+// Augmenter-added ManifestLayout children inherit the ancestor bundle's
+// SourceRef; checking node bundles covers them.
+func validateSourceRefsForFluxIntegrated(c *stack.Cluster) error {
+	if c == nil {
+		return nil
+	}
+	return validateNodeSourceRefs(c.Node)
+}
+
+func validateNodeSourceRefs(node *stack.Node) error {
+	if node == nil {
+		return nil
+	}
+	if node.Bundle != nil {
+		if err := validateBundleSourceRefs(node.Bundle); err != nil {
+			return err
+		}
+	}
+	for _, child := range node.Children {
+		if err := validateNodeSourceRefs(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateBundleSourceRefs checks the bundle itself and all umbrella children
+// recursively.
+func validateBundleSourceRefs(b *stack.Bundle) error {
+	if b == nil {
+		return nil
+	}
+	if b.SourceRef == nil || b.SourceRef.Kind == "" || b.SourceRef.Name == "" {
+		return errors.ResourceValidationError(
+			"Bundle", b.Name, "sourceRef",
+			"FluxIntegrated mode requires a SourceRef with Kind and Name; "+
+				"omitting it produces a Kustomization CR without spec.sourceRef, which Flux rejects",
+			nil,
+		)
+	}
+	for _, child := range b.Children {
+		if child == nil {
+			continue
+		}
+		if err := validateBundleSourceRefs(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/stack/fluxcd/validate_test.go
+++ b/pkg/stack/fluxcd/validate_test.go
@@ -1,0 +1,94 @@
+package fluxcd
+
+import (
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+)
+
+func sr() *stack.SourceRef {
+	return &stack.SourceRef{Kind: "GitRepository", Name: "flux-system", Namespace: "flux-system"}
+}
+
+func TestValidateSourceRefsForFluxIntegrated_NilCluster(t *testing.T) {
+	if err := validateSourceRefsForFluxIntegrated(nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateSourceRefsForFluxIntegrated_NilBundle(t *testing.T) {
+	c := &stack.Cluster{Node: &stack.Node{Name: "prod"}}
+	if err := validateSourceRefsForFluxIntegrated(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateSourceRefsForFluxIntegrated_ValidSourceRef(t *testing.T) {
+	c := &stack.Cluster{
+		Node: &stack.Node{Name: "prod", Bundle: &stack.Bundle{Name: "apps", SourceRef: sr()}},
+	}
+	if err := validateSourceRefsForFluxIntegrated(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateSourceRefsForFluxIntegrated_InvalidSourceRef(t *testing.T) {
+	cases := []struct {
+		name string
+		ref  *stack.SourceRef
+	}{
+		{"nil", nil},
+		{"empty struct", &stack.SourceRef{}},
+		{"missing Kind", &stack.SourceRef{Name: "flux-system"}},
+		{"missing Name", &stack.SourceRef{Kind: "GitRepository"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &stack.Cluster{
+				Node: &stack.Node{Name: "prod", Bundle: &stack.Bundle{Name: "apps", SourceRef: tc.ref}},
+			}
+			if err := validateSourceRefsForFluxIntegrated(c); err == nil {
+				t.Fatalf("sourceRef=%v: expected error, got nil", tc.ref)
+			}
+		})
+	}
+}
+
+func TestValidateSourceRefsForFluxIntegrated_MultiNode_OneMissing(t *testing.T) {
+	infra := &stack.Node{Name: "infra", Bundle: &stack.Bundle{Name: "infra-apps", SourceRef: nil}}
+	prod := &stack.Node{
+		Name:     "prod",
+		Bundle:   &stack.Bundle{Name: "apps", SourceRef: sr()},
+		Children: []*stack.Node{infra},
+	}
+	if err := validateSourceRefsForFluxIntegrated(&stack.Cluster{Node: prod}); err == nil {
+		t.Fatal("expected error for child node with nil SourceRef, got nil")
+	}
+}
+
+func TestValidateSourceRefsForFluxIntegrated_UmbrellaChild_MissingSourceRef(t *testing.T) {
+	umbrella := &stack.Bundle{
+		Name:      "platform",
+		SourceRef: sr(),
+		Children:  []*stack.Bundle{{Name: "platform-infra", SourceRef: nil}},
+	}
+	c := &stack.Cluster{Node: &stack.Node{Name: "prod", Bundle: umbrella}}
+	if err := validateSourceRefsForFluxIntegrated(c); err == nil {
+		t.Fatal("expected error for umbrella child with nil SourceRef, got nil")
+	}
+}
+
+func TestValidateSourceRefsForFluxIntegrated_UmbrellaChildren_AllValid(t *testing.T) {
+	umbrella := &stack.Bundle{
+		Name:      "platform",
+		SourceRef: sr(),
+		Children: []*stack.Bundle{
+			{Name: "platform-infra", SourceRef: sr()},
+			{Name: "platform-apps", SourceRef: sr()},
+		},
+	}
+	c := &stack.Cluster{Node: &stack.Node{Name: "prod", Bundle: umbrella}}
+	if err := validateSourceRefsForFluxIntegrated(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/stack/workflow_test.go
+++ b/pkg/stack/workflow_test.go
@@ -73,7 +73,8 @@ func TestWorkflowInterface(t *testing.T) {
 				Node: &stack.Node{
 					Name: "root",
 					Bundle: &stack.Bundle{
-						Name: "test-bundle",
+						Name:      "test-bundle",
+						SourceRef: &stack.SourceRef{Kind: "GitRepository", Name: "flux-system"},
 					},
 				},
 				GitOps: &stack.GitOpsConfig{

--- a/site/content/guides/flux-workflow.md
+++ b/site/content/guides/flux-workflow.md
@@ -211,6 +211,8 @@ A child layout receives a CR when:
 - `child.ApplicationFileMode != AppFileSingle`
 - The ancestor bundle's `SourceRef` has both `Kind` and `Name` set (nil, empty struct, or missing either field is a hard error — a `Kustomization` without `spec.sourceRef` is invalid)
 
+`CreateLayoutWithResources` validates SourceRef completeness for all bundles before layout walking. Both the node bundle and every umbrella child bundle must have `SourceRef.Kind` and `SourceRef.Name` set when `FluxIntegrated` mode is active. `FluxSeparate` and non-Flux callers are unaffected.
+
 ### Ordered reconciliation with DependsOn
 
 Set `ManifestLayout.DependsOn` to a list of sibling layout names to express reconciliation order between hook groups. The integrator translates these into `spec.dependsOn` entries on the emitted CR:


### PR DESCRIPTION
## Summary

- Adds `validateSourceRefsForFluxIntegrated` in `pkg/stack/fluxcd/validate.go`: walks all node bundles and umbrella child bundles recursively and rejects any bundle where `SourceRef` is nil, zero-value, or missing `Kind`/`Name`
- Wires this into `CreateLayoutWithResources` (after `ValidateCluster`) when `li.FluxPlacement == FluxIntegrated`, surfacing the error before layout walking rather than deep inside the integration path
- The existing integrator-level checks in `processNodeForIntegratedFlux` and `generateChildFluxCRs` remain as defense-in-depth
- `FluxSeparate` and non-Flux paths are unaffected

## Test plan

- [ ] White-box unit tests in `pkg/stack/fluxcd/validate_test.go` cover nil cluster, nil bundle, valid SourceRef, all four invalid SourceRef cases (nil, empty struct, missing Kind, missing Name), multi-node with one missing, umbrella child missing, umbrella children all valid
- [ ] Integration tests in `layout_integrator_test.go` confirm: FluxIntegrated rejects nil SourceRef via `CreateLayoutWithResources`; FluxSeparate passes without SourceRef
- [ ] Six existing FluxIntegrated fixtures updated to add SourceRefs (`layout_integrator_test.go` ×5, `workflow_test.go` ×1, `fluxcd_test.go` ×1)
- [ ] `mise run verify` passes clean