### PR TITLE
fix(fluxcd)!: rules.FluxPlacement is the sole controller of placement

### DIFF
--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -20,7 +20,9 @@ be reused to create divergent cluster configurations.
 ### 2. Create a Workflow Engine (`FluxCD`)
 
 Kure supports pluggable workflow engines. This example uses `fluxcd.NewWorkflowEngineWithConfig`
-to create a FluxCD engine with explicit Kustomization mode and separate Flux resource placement.
+to create a FluxCD engine with explicit Kustomization mode. Flux resource placement
+(integrated vs separate) is configured per call on `layout.LayoutRules.FluxPlacement`
+in Step 3, not on the engine.
 
 ### 3. Generate a Layout (`CreateLayoutWithResources`)
 

--- a/examples/getting-started/main.go
+++ b/examples/getting-started/main.go
@@ -81,16 +81,14 @@ func run() error {
 	// ---------------------------------------------------------------
 	// Step 2: Create the FluxCD workflow engine.
 	//
-	// NewWorkflowEngineWithConfig lets us set the Kustomization mode
-	// and Flux placement strategy. FluxSeparate places Flux resources
-	// in a dedicated directory rather than alongside manifests.
+	// NewWorkflowEngineWithConfig sets the Kustomization mode.
+	// Placement is configured on layout.LayoutRules.FluxPlacement at
+	// call time (see Step 3); FluxSeparate places Flux resources in a
+	// dedicated directory rather than alongside manifests.
 	// ---------------------------------------------------------------
 	log.Info("Step 2: Creating FluxCD workflow engine...")
 
-	wf := fluxcd.NewWorkflowEngineWithConfig(
-		layout.KustomizationExplicit,
-		layout.FluxSeparate,
-	)
+	wf := fluxcd.NewWorkflowEngineWithConfig(layout.KustomizationExplicit)
 
 	// ---------------------------------------------------------------
 	// Step 3: Run the workflow to produce a ManifestLayout.
@@ -103,6 +101,7 @@ func run() error {
 
 	rules := layout.DefaultLayoutRules()
 	rules.ClusterName = cluster.Name
+	rules.FluxPlacement = layout.FluxSeparate
 
 	result, err := wf.CreateLayoutWithResources(cluster, rules)
 	if err != nil {

--- a/pkg/stack/fluxcd/README.md
+++ b/pkg/stack/fluxcd/README.md
@@ -27,11 +27,11 @@ engine := fluxcd.Engine()
 // Generate all Flux resources for a cluster
 objects, err := engine.GenerateFromCluster(cluster)
 
-// Or with custom configuration
-engine = fluxcd.EngineWithConfig(
-    layout.KustomizationExplicit,
-    layout.FluxSeparate,
-)
+// Or with a specific kustomization mode
+engine = fluxcd.EngineWithConfig(layout.KustomizationExplicit)
+
+// Placement is set on the LayoutRules passed to the layout call,
+// not on the engine — see Layout Integration below.
 ```
 
 ## Engine Construction
@@ -43,12 +43,18 @@ engine := fluxcd.Engine()
 // Engine with specific kustomization mode
 engine := fluxcd.EngineWithMode(layout.KustomizationExplicit)
 
-// Engine with full configuration
-engine := fluxcd.EngineWithConfig(mode, placement)
+// Engine with a specific kustomization mode (alias)
+engine := fluxcd.EngineWithConfig(mode)
 
 // Engine with custom components
 engine := fluxcd.NewWorkflowEngine()
 ```
+
+Placement (FluxIntegrated vs FluxSeparate) is configured per call on
+`layout.LayoutRules.FluxPlacement`. `FluxUnset` is normalized to
+`FluxSeparate` by `LayoutIntegrator.CreateLayoutWithResources` — matching
+`layout.DefaultLayoutRules()` and the walker. See
+[Layout Integration](#layout-integration).
 
 ## Resource Generation
 
@@ -190,9 +196,10 @@ bundle's `Children`, shared umbrella ownership, or multi-package umbrellas —
 fail fast with a validation error rather than producing malformed output.
 
 `CreateLayoutWithResources` additionally calls `validateSourceRefsForFluxIntegrated`
-when `FluxPlacement == FluxIntegrated`. This checks that every bundle reachable
-from the cluster node tree — node bundles and umbrella child bundles recursively
-— has a complete `SourceRef` with both `Kind` and `Name` set. A nil,
+when `rules.FluxPlacement == FluxIntegrated` (after normalization — `FluxUnset`
+becomes `FluxSeparate` and skips this gate). This checks that every bundle
+reachable from the cluster node tree — node bundles and umbrella child bundles
+recursively — has a complete `SourceRef` with both `Kind` and `Name` set. A nil,
 zero-value, or partially-populated `SourceRef` is rejected before layout walking
 begins. The integrator also enforces this at CR-creation time as defense in
 depth. `FluxSeparate` and non-Flux paths are unaffected.

--- a/pkg/stack/fluxcd/fluxcd.go
+++ b/pkg/stack/fluxcd/fluxcd.go
@@ -25,7 +25,9 @@ func EngineWithMode(mode layout.KustomizationMode) *WorkflowEngine {
 	return engine
 }
 
-// EngineWithConfig returns a WorkflowEngine with custom configuration.
-func EngineWithConfig(mode layout.KustomizationMode, placement layout.FluxPlacement) *WorkflowEngine {
-	return NewWorkflowEngineWithConfig(mode, placement)
+// EngineWithConfig returns a WorkflowEngine with a specific kustomization
+// mode. Placement is no longer a constructor argument; set it on
+// layout.LayoutRules.FluxPlacement at call time.
+func EngineWithConfig(mode layout.KustomizationMode) *WorkflowEngine {
+	return NewWorkflowEngineWithConfig(mode)
 }

--- a/pkg/stack/fluxcd/fluxcd_test.go
+++ b/pkg/stack/fluxcd/fluxcd_test.go
@@ -693,11 +693,11 @@ func TestEndToEndUmbrellaFromCluster_Integrated(t *testing.T) {
 	cluster := &stack.Cluster{Name: "demo", Node: root}
 
 	integrator := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	integrator.SetFluxPlacement(layout.FluxIntegrated)
 
 	ml, err := integrator.CreateLayoutWithResources(cluster, layout.LayoutRules{
 		BundleGrouping:      layout.GroupFlat,
 		ApplicationGrouping: layout.GroupFlat,
+		FluxPlacement:       layout.FluxIntegrated,
 	})
 	if err != nil {
 		t.Fatalf("CreateLayoutWithResources: %v", err)
@@ -836,11 +836,11 @@ func TestEndToEndUmbrellaFromCluster_Separate(t *testing.T) {
 	cluster := &stack.Cluster{Name: "demo", Node: root}
 
 	integrator := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	integrator.SetFluxPlacement(layout.FluxSeparate)
 
 	ml, err := integrator.CreateLayoutWithResources(cluster, layout.LayoutRules{
 		BundleGrouping:      layout.GroupFlat,
 		ApplicationGrouping: layout.GroupFlat,
+		FluxPlacement:       layout.FluxSeparate,
 	})
 	if err != nil {
 		t.Fatalf("CreateLayoutWithResources: %v", err)

--- a/pkg/stack/fluxcd/layout_integrator.go
+++ b/pkg/stack/fluxcd/layout_integrator.go
@@ -14,22 +14,29 @@ import (
 
 // LayoutIntegrator implements the workflow.LayoutIntegrator interface for Flux.
 // It handles integration of Flux resources with manifest layouts.
+//
+// Placement (FluxIntegrated vs FluxSeparate) is configured via
+// layout.LayoutRules.FluxPlacement on each call. CreateLayoutWithResources
+// normalizes FluxUnset to FluxSeparate before invoking the SourceRef
+// validation gate, WalkCluster, and IntegrateWithLayout, so all three
+// observers agree on the effective placement.
 type LayoutIntegrator struct {
 	// ResourceGenerator generates the Flux resources
 	Generator *ResourceGenerator
-	// FluxPlacement controls where Flux resources are placed in the layout
-	FluxPlacement layout.FluxPlacement
 }
 
 // NewLayoutIntegrator creates a FluxCD layout integrator.
 func NewLayoutIntegrator(generator *ResourceGenerator) *LayoutIntegrator {
 	return &LayoutIntegrator{
-		Generator:     generator,
-		FluxPlacement: layout.FluxIntegrated,
+		Generator: generator,
 	}
 }
 
 // IntegrateWithLayout adds Flux resources to an existing manifest layout.
+//
+// Placement is driven by rules.FluxPlacement. FluxUnset is treated as
+// FluxSeparate to match DefaultLayoutRules and the walker's normalization
+// in pkg/stack/layout/walker.go:42-44.
 //
 // If the layout was post-processed by FlattenSingleTier (recorded as
 // flattenInfo on the absorbing layouts), this method consults nodeAliases
@@ -41,14 +48,16 @@ func (li *LayoutIntegrator) IntegrateWithLayout(ml *layout.ManifestLayout, c *st
 		return nil
 	}
 
+	rules = normalizeRulesPlacement(rules)
+
 	var err error
-	switch li.FluxPlacement {
+	switch rules.FluxPlacement {
 	case layout.FluxIntegrated:
 		err = li.addIntegratedFluxToLayout(ml, c, rules)
 	case layout.FluxSeparate:
 		err = li.addSeparateFluxToLayout(ml, c, rules)
 	default:
-		return errors.NewValidationError("fluxPlacement", string(li.FluxPlacement), "LayoutIntegrator",
+		return errors.NewValidationError("fluxPlacement", string(rules.FluxPlacement), "LayoutRules",
 			[]string{string(layout.FluxIntegrated), string(layout.FluxSeparate)})
 	}
 	if err != nil {
@@ -60,6 +69,11 @@ func (li *LayoutIntegrator) IntegrateWithLayout(ml *layout.ManifestLayout, c *st
 }
 
 // CreateLayoutWithResources creates a new layout that includes Flux resources.
+//
+// rules.FluxPlacement is normalized once at the top of this method
+// (FluxUnset -> FluxSeparate) and the normalized rules are passed to the
+// SourceRef validation gate, WalkCluster, and IntegrateWithLayout. This
+// guarantees a single placement authority per call.
 func (li *LayoutIntegrator) CreateLayoutWithResources(c *stack.Cluster, rules layout.LayoutRules) (*layout.ManifestLayout, error) {
 	if c == nil {
 		return nil, nil
@@ -71,7 +85,9 @@ func (li *LayoutIntegrator) CreateLayoutWithResources(c *stack.Cluster, rules la
 		return nil, err
 	}
 
-	if li.FluxPlacement == layout.FluxIntegrated {
+	rules = normalizeRulesPlacement(rules)
+
+	if rules.FluxPlacement == layout.FluxIntegrated {
 		if err := validateSourceRefsForFluxIntegrated(c); err != nil {
 			return nil, err
 		}
@@ -418,7 +434,14 @@ func (li *LayoutIntegrator) findLayoutNodeByPath(ml *layout.ManifestLayout, targ
 	return nil
 }
 
-// SetFluxPlacement configures where Flux resources should be placed in layouts.
-func (li *LayoutIntegrator) SetFluxPlacement(placement layout.FluxPlacement) {
-	li.FluxPlacement = placement
+// normalizeRulesPlacement returns a copy of rules with FluxPlacement set to
+// FluxSeparate when it was FluxUnset. The integrator, the SourceRef
+// validation gate, and the walker all read from this normalized value so
+// they cannot disagree on what "unset" means. Mirrors the walker behaviour
+// in pkg/stack/layout/walker.go:42-44.
+func normalizeRulesPlacement(rules layout.LayoutRules) layout.LayoutRules {
+	if rules.FluxPlacement == layout.FluxUnset {
+		rules.FluxPlacement = layout.FluxSeparate
+	}
+	return rules
 }

--- a/pkg/stack/fluxcd/layout_integrator_test.go
+++ b/pkg/stack/fluxcd/layout_integrator_test.go
@@ -29,27 +29,6 @@ func TestNewLayoutIntegrator(t *testing.T) {
 	if integrator.Generator != generator {
 		t.Error("generator not set correctly")
 	}
-
-	if integrator.FluxPlacement != layout.FluxIntegrated {
-		t.Errorf("expected FluxIntegrated placement, got %s", integrator.FluxPlacement)
-	}
-}
-
-func TestLayoutIntegrator_SetFluxPlacement(t *testing.T) {
-	generator := fluxstack.NewResourceGenerator()
-	integrator := fluxstack.NewLayoutIntegrator(generator)
-
-	// Test setting to separate
-	integrator.SetFluxPlacement(layout.FluxSeparate)
-	if integrator.FluxPlacement != layout.FluxSeparate {
-		t.Errorf("expected FluxSeparate, got %s", integrator.FluxPlacement)
-	}
-
-	// Test setting to integrated
-	integrator.SetFluxPlacement(layout.FluxIntegrated)
-	if integrator.FluxPlacement != layout.FluxIntegrated {
-		t.Errorf("expected FluxIntegrated, got %s", integrator.FluxPlacement)
-	}
 }
 
 func TestLayoutIntegrator_IntegrateWithLayout_NilInputs(t *testing.T) {
@@ -80,16 +59,15 @@ func TestLayoutIntegrator_IntegrateWithLayout_InvalidPlacement(t *testing.T) {
 	generator := fluxstack.NewResourceGenerator()
 	integrator := fluxstack.NewLayoutIntegrator(generator)
 
-	// Set invalid placement
-	integrator.FluxPlacement = layout.FluxPlacement("invalid")
-
 	ml := &layout.ManifestLayout{Name: "test"}
 	cluster := &stack.Cluster{
 		Name: "test-cluster",
 		Node: &stack.Node{Name: "root"},
 	}
 
-	err := integrator.IntegrateWithLayout(ml, cluster, layout.LayoutRules{})
+	// Set invalid placement on the rules (the sole authority).
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxPlacement("invalid")}
+	err := integrator.IntegrateWithLayout(ml, cluster, rules)
 	if err == nil {
 		t.Error("expected error for invalid placement")
 	}
@@ -98,7 +76,6 @@ func TestLayoutIntegrator_IntegrateWithLayout_InvalidPlacement(t *testing.T) {
 func TestLayoutIntegrator_IntegrateWithLayout_Integrated(t *testing.T) {
 	generator := fluxstack.NewResourceGenerator()
 	integrator := fluxstack.NewLayoutIntegrator(generator)
-	integrator.SetFluxPlacement(layout.FluxIntegrated)
 
 	// Create a simple cluster with a bundle
 	bundle := &stack.Bundle{
@@ -127,6 +104,7 @@ func TestLayoutIntegrator_IntegrateWithLayout_Integrated(t *testing.T) {
 	}
 
 	rules := layout.DefaultLayoutRules()
+	rules.FluxPlacement = layout.FluxIntegrated
 	err := integrator.IntegrateWithLayout(ml, cluster, rules)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -141,7 +119,6 @@ func TestLayoutIntegrator_IntegrateWithLayout_Integrated(t *testing.T) {
 func TestLayoutIntegrator_IntegrateWithLayout_Separate(t *testing.T) {
 	generator := fluxstack.NewResourceGenerator()
 	integrator := fluxstack.NewLayoutIntegrator(generator)
-	integrator.SetFluxPlacement(layout.FluxSeparate)
 
 	// Create a cluster with bundles
 	bundle := &stack.Bundle{
@@ -238,7 +215,6 @@ func TestLayoutIntegrator_CreateLayoutWithResources(t *testing.T) {
 func TestLayoutIntegrator_IntegrateWithNestedNodes(t *testing.T) {
 	generator := fluxstack.NewResourceGenerator()
 	integrator := fluxstack.NewLayoutIntegrator(generator)
-	integrator.SetFluxPlacement(layout.FluxIntegrated)
 
 	// Create a nested hierarchy
 	grandchildBundle := &stack.Bundle{
@@ -308,6 +284,7 @@ func TestLayoutIntegrator_IntegrateWithNestedNodes(t *testing.T) {
 	}
 
 	rules := layout.DefaultLayoutRules()
+	rules.FluxPlacement = layout.FluxIntegrated
 	err := integrator.IntegrateWithLayout(rootLayout, cluster, rules)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -328,7 +305,6 @@ func TestLayoutIntegrator_IntegrateWithNestedNodes(t *testing.T) {
 func TestLayoutIntegrator_SeparateMode_EmptyCluster(t *testing.T) {
 	generator := fluxstack.NewResourceGenerator()
 	integrator := fluxstack.NewLayoutIntegrator(generator)
-	integrator.SetFluxPlacement(layout.FluxSeparate)
 
 	// Create a cluster without bundles
 	node := &stack.Node{
@@ -384,7 +360,6 @@ func TestCreateLayoutWithResources_ClusterNameWithChildNodes(t *testing.T) {
 	cluster := &stack.Cluster{Name: "demo", Node: rootNode}
 
 	integrator := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	integrator.SetFluxPlacement(layout.FluxIntegrated)
 
 	rules := layout.DefaultLayoutRules()
 	rules.ClusterName = "demo"
@@ -458,11 +433,11 @@ func TestCreateLayoutWithResources_UmbrellaIntegratedPlacement(t *testing.T) {
 	cluster := &stack.Cluster{Name: "demo", Node: root}
 
 	integrator := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	integrator.SetFluxPlacement(layout.FluxIntegrated)
 
 	ml, err := integrator.CreateLayoutWithResources(cluster, layout.LayoutRules{
 		BundleGrouping:      layout.GroupByName,
 		ApplicationGrouping: layout.GroupByName,
+		FluxPlacement:       layout.FluxIntegrated,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -541,11 +516,11 @@ func TestCreateLayoutWithResources_UmbrellaNodeOnlyPlacement(t *testing.T) {
 	cluster := &stack.Cluster{Name: "demo", Node: root}
 
 	integrator := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	integrator.SetFluxPlacement(layout.FluxIntegrated)
 
 	ml, err := integrator.CreateLayoutWithResources(cluster, layout.LayoutRules{
 		BundleGrouping:      layout.GroupFlat,
 		ApplicationGrouping: layout.GroupFlat,
+		FluxPlacement:       layout.FluxIntegrated,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -599,11 +574,11 @@ func TestCreateLayoutWithResources_UmbrellaNestedIntegratedPlacement(t *testing.
 	cluster := &stack.Cluster{Name: "demo", Node: root}
 
 	integrator := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	integrator.SetFluxPlacement(layout.FluxIntegrated)
 
 	ml, err := integrator.CreateLayoutWithResources(cluster, layout.LayoutRules{
 		BundleGrouping:      layout.GroupByName,
 		ApplicationGrouping: layout.GroupByName,
+		FluxPlacement:       layout.FluxIntegrated,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -691,11 +666,11 @@ func TestCreateLayoutWithResources_UmbrellaChildWithSource(t *testing.T) {
 	cluster := &stack.Cluster{Name: "demo", Node: root}
 
 	integrator := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	integrator.SetFluxPlacement(layout.FluxIntegrated)
 
 	ml, err := integrator.CreateLayoutWithResources(cluster, layout.LayoutRules{
 		BundleGrouping:      layout.GroupByName,
 		ApplicationGrouping: layout.GroupByName,
+		FluxPlacement:       layout.FluxIntegrated,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -721,7 +696,6 @@ func TestCreateLayoutWithResources_UmbrellaChildWithSource(t *testing.T) {
 func TestIntegrateWithLayout_AppliesFlattenPathRewrites(t *testing.T) {
 	generator := fluxstack.NewResourceGenerator()
 	integrator := fluxstack.NewLayoutIntegrator(generator)
-	integrator.SetFluxPlacement(layout.FluxSeparate)
 
 	cluster := &stack.Cluster{
 		Name: "arc-runners",
@@ -763,7 +737,7 @@ func TestIntegrateWithLayout_AppliesFlattenPathRewrites(t *testing.T) {
 func TestIntegrateWithLayout_RepeatedCallSucceeds(t *testing.T) {
 	generator := fluxstack.NewResourceGenerator()
 	integrator := fluxstack.NewLayoutIntegrator(generator)
-	integrator.SetFluxPlacement(layout.FluxIntegrated)
+	integratedRules := layout.LayoutRules{FluxPlacement: layout.FluxIntegrated}
 
 	cluster := &stack.Cluster{
 		Name: "arc-runners",
@@ -790,13 +764,13 @@ func TestIntegrateWithLayout_RepeatedCallSucceeds(t *testing.T) {
 		t.Fatalf("WalkCluster: %v", err)
 	}
 
-	if err := integrator.IntegrateWithLayout(walked, cluster, layout.LayoutRules{}); err != nil {
+	if err := integrator.IntegrateWithLayout(walked, cluster, integratedRules); err != nil {
 		t.Fatalf("first IntegrateWithLayout: %v", err)
 	}
 
 	// Second call must still resolve the collapsed "apps" node via the
 	// alias fallback rather than failing with "layout node not found".
-	if err := integrator.IntegrateWithLayout(walked, cluster, layout.LayoutRules{}); err != nil {
+	if err := integrator.IntegrateWithLayout(walked, cluster, integratedRules); err != nil {
 		t.Fatalf("second IntegrateWithLayout: %v (alias state was destroyed by the first pass)", err)
 	}
 }
@@ -815,7 +789,8 @@ func TestAugmenterChildrenGetFluxCRs(t *testing.T) {
 	root, nodeLayout, app, preInstall, hooks, cluster := buildAugmenterTestTree()
 
 	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	if err := li.IntegrateWithLayout(root, cluster, layout.LayoutRules{}); err != nil {
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegrated}
+	if err := li.IntegrateWithLayout(root, cluster, rules); err != nil {
 		t.Fatalf("IntegrateWithLayout: %v", err)
 	}
 
@@ -855,7 +830,8 @@ func TestAugmenterChildrenNoDuplicateInKustomizationYAML(t *testing.T) {
 	root, nodeLayout, app, preInstall, _, cluster := buildAugmenterTestTree()
 
 	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	if err := li.IntegrateWithLayout(root, cluster, layout.LayoutRules{}); err != nil {
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegrated}
+	if err := li.IntegrateWithLayout(root, cluster, rules); err != nil {
 		t.Fatalf("IntegrateWithLayout: %v", err)
 	}
 
@@ -878,7 +854,8 @@ func TestAugmenterChildrenWriteToTar(t *testing.T) {
 	root, nodeLayout, app, preInstall, _, cluster := buildAugmenterTestTree()
 
 	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	if err := li.IntegrateWithLayout(root, cluster, layout.LayoutRules{}); err != nil {
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegrated}
+	if err := li.IntegrateWithLayout(root, cluster, rules); err != nil {
 		t.Fatalf("IntegrateWithLayout: %v", err)
 	}
 
@@ -946,7 +923,8 @@ func TestAugmenterChildrenErrorWhenNoSourceRef(t *testing.T) {
 			root := &layout.ManifestLayout{Children: []*layout.ManifestLayout{nodeLayout}}
 
 			li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-			if err := li.IntegrateWithLayout(root, cluster, layout.LayoutRules{}); err == nil {
+			rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegrated}
+			if err := li.IntegrateWithLayout(root, cluster, rules); err == nil {
 				t.Fatalf("sourceRef=%v: expected error, got nil", tc.sr)
 			}
 		})
@@ -993,7 +971,8 @@ func TestAugmenterGrandchildErrorWhenNoSourceRef(t *testing.T) {
 	root := &layout.ManifestLayout{Children: []*layout.ManifestLayout{nodeLayout}}
 
 	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	if err := li.IntegrateWithLayout(root, cluster, layout.LayoutRules{}); err == nil {
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegrated}
+	if err := li.IntegrateWithLayout(root, cluster, rules); err == nil {
 		t.Fatal("expected error: grandchild needs a CR but ancestor bundle has no SourceRef")
 	}
 }
@@ -1118,11 +1097,37 @@ func TestCreateLayoutWithResources_FluxSeparate_AllowsMissingSourceRef(t *testin
 	c := &stack.Cluster{Node: node, Name: "test-cluster"}
 
 	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	li.SetFluxPlacement(layout.FluxSeparate)
 	rules := layout.LayoutRules{FluxPlacement: layout.FluxSeparate}
 
 	if _, err := li.CreateLayoutWithResources(c, rules); err != nil {
 		t.Fatalf("FluxSeparate: unexpected error for nil SourceRef: %v", err)
+	}
+}
+
+// TestIntegrateWithLayout_RulesFluxSeparate_NoDuplicateChildCRs is a
+// regression guard for #576. Before the fix, IntegrateWithLayout read
+// li.FluxPlacement (constructor default = FluxIntegrated) and ignored
+// rules.FluxPlacement, so the FluxIntegrated emission block ran even when
+// the caller asked for FluxSeparate via rules. That produced duplicate
+// Kustomization CRs for augmenter-added child layouts. After the fix,
+// rules.FluxPlacement is the sole authority and the FluxSeparate path must
+// not emit any of those per-child CRs.
+func TestIntegrateWithLayout_RulesFluxSeparate_NoDuplicateChildCRs(t *testing.T) {
+	root, _, app, preInstall, hooks, cluster := buildAugmenterTestTree()
+
+	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxSeparate}
+	if err := li.IntegrateWithLayout(root, cluster, rules); err != nil {
+		t.Fatalf("IntegrateWithLayout (FluxSeparate): %v", err)
+	}
+
+	// FluxSeparate must not emit augmenter-child CRs into app.Resources
+	// (that emission only fires on the FluxIntegrated code path).
+	if augHasCR(app.Resources, preInstall.Name) {
+		t.Errorf("FluxSeparate emitted a Kustomization CR for augmenter child %q at app.Resources; FluxIntegrated leaked into the FluxSeparate path", preInstall.Name)
+	}
+	if augHasCR(app.Resources, hooks.Name) {
+		t.Errorf("FluxSeparate emitted a Kustomization CR for augmenter child %q at app.Resources; FluxIntegrated leaked into the FluxSeparate path", hooks.Name)
 	}
 }
 

--- a/pkg/stack/fluxcd/workflow_engine.go
+++ b/pkg/stack/fluxcd/workflow_engine.go
@@ -37,12 +37,15 @@ func NewWorkflowEngine() *WorkflowEngine {
 }
 
 // NewWorkflowEngineWithConfig creates a workflow engine with custom configuration.
-func NewWorkflowEngineWithConfig(mode layout.KustomizationMode, placement layout.FluxPlacement) *WorkflowEngine {
+//
+// Placement is no longer a constructor argument; set it on
+// layout.LayoutRules.FluxPlacement at call time. See LayoutIntegrator for
+// the normalization semantics.
+func NewWorkflowEngineWithConfig(mode layout.KustomizationMode) *WorkflowEngine {
 	resourceGen := NewResourceGenerator()
 	resourceGen.Mode = mode
 
 	layoutInteg := NewLayoutIntegrator(resourceGen)
-	layoutInteg.FluxPlacement = placement
 
 	bootstrapGen := NewBootstrapGenerator()
 
@@ -115,11 +118,6 @@ func (we *WorkflowEngine) GetVersion() string {
 // SetKustomizationMode configures how Kustomization paths are generated.
 func (we *WorkflowEngine) SetKustomizationMode(mode layout.KustomizationMode) {
 	we.ResourceGen.Mode = mode
-}
-
-// SetFluxPlacement configures where Flux resources are placed in layouts.
-func (we *WorkflowEngine) SetFluxPlacement(placement layout.FluxPlacement) {
-	we.LayoutInteg.SetFluxPlacement(placement)
 }
 
 // GetResourceGenerator returns the underlying resource generator for advanced configuration.

--- a/site/content/guides/flux-workflow.md
+++ b/site/content/guides/flux-workflow.md
@@ -50,11 +50,12 @@ import (
 
 engine := fluxcd.EngineWithConfig(
     layout.KustomizationExplicit,  // List files in kustomization.yaml
-    layout.FluxSeparate,           // Flux resources in separate tree
 )
 ```
 
-See the [Flux Engine reference](/api-reference/flux-engine) for configuration options.
+Placement is configured per call on `layout.LayoutRules.FluxPlacement` (see Step 3
+below). `FluxUnset` normalizes to `FluxSeparate`. See the
+[Flux Engine reference](/api-reference/flux-engine) for configuration options.
 
 ## Step 3: Generate Resources with Layout
 
@@ -65,6 +66,7 @@ rules := layout.LayoutRules{
     BundleGrouping:      layout.GroupByName,
     ApplicationGrouping: layout.GroupByName,
     FilePer:             layout.FilePerResource,
+    FluxPlacement:       layout.FluxSeparate, // Flux resources in separate tree
 }
 
 // Generate layout with Flux resources integrated


### PR DESCRIPTION
Closes #576.

## Summary

- Remove `LayoutIntegrator.FluxPlacement` field and `SetFluxPlacement` setter.
- Remove the `placement` parameter from `NewWorkflowEngineWithConfig` and `EngineWithConfig`.
- Normalize `rules.FluxPlacement` once at the top of `CreateLayoutWithResources` (FluxUnset → FluxSeparate, matching `DefaultLayoutRules` and `pkg/stack/layout/walker.go:42-44`).
- Pass the normalized rules to `validateSourceRefsForFluxIntegrated`, `WalkCluster`, and `IntegrateWithLayout` — a single placement authority per call.
- Update tests + docs (`pkg/stack/fluxcd/README.md`, `examples/getting-started/`, `site/content/guides/flux-workflow.md`) for the new API.
- Add `TestIntegrateWithLayout_RulesFluxSeparate_NoDuplicateChildCRs` as a regression guard for #576.

## Why

`LayoutIntegrator.IntegrateWithLayout` previously read `li.FluxPlacement` (constructor default = FluxIntegrated) and ignored `rules.FluxPlacement`. Internal kure tests passed because they explicitly set `li.FluxPlacement`. Downstream consumers (e.g. [crane stack-compile](https://gitlab.com/autops/wharf/crane)) that set `rules.FluxPlacement = FluxSeparate` and never touched `li.FluxPlacement` silently ran the FluxIntegrated code path.

`v0.2.0-beta.0`'s new "emit Flux CRs for eligible direct children" block in `processNodeForIntegratedFlux` exposed the disconnect: those consumers got duplicate Kustomization CRs in the same file. The validation gate at line 74 was also keyed off `li.FluxPlacement`, so a FluxSeparate caller missing a bundle SourceRef would have hit a spurious FluxIntegrated validation error.

## BREAKING CHANGE

- `LayoutIntegrator.FluxPlacement` field removed.
- `LayoutIntegrator.SetFluxPlacement` method removed.
- `WorkflowEngine.SetFluxPlacement` method removed.
- `NewWorkflowEngineWithConfig` signature: `(mode, placement)` → `(mode)`.
- `EngineWithConfig` signature: `(mode, placement)` → `(mode)`.

Migration: set `rules.FluxPlacement` on the `layout.LayoutRules` passed to `CreateLayoutWithResources` / `IntegrateWithLayout`. `DefaultLayoutRules()` already sets `FluxSeparate`; `FluxUnset` is normalized to `FluxSeparate` by `CreateLayoutWithResources`.

## Test plan

- [x] `make precommit` (fmt + tidy + lint + test) passes locally.
- [x] All existing tests in `pkg/stack/fluxcd/` pass after migrating from `SetFluxPlacement` to `rules.FluxPlacement`.
- [x] Pattern (b) audit: every test that relied on the integrator's `FluxIntegrated` default while passing `layout.LayoutRules{}` (FluxUnset) was updated to set `rules.FluxPlacement = layout.FluxIntegrated` explicitly — otherwise FluxUnset would now normalize to FluxSeparate and the tests would silently stop exercising the integrated path.
- [x] New regression test `TestIntegrateWithLayout_RulesFluxSeparate_NoDuplicateChildCRs` asserts that the augmenter-test tree, passed through `IntegrateWithLayout` with `rules.FluxPlacement = FluxSeparate`, produces no per-child Kustomization CRs in `app.Resources` (which is what would happen if FluxIntegrated leaked into the FluxSeparate path).
- [x] Existing `TestCreateLayoutWithResources_FluxSeparate_AllowsMissingSourceRef` covers the validation-skip case (no spurious FluxIntegrated SourceRef validation on FluxSeparate paths).