### PR TITLE
ci: redesign release workflows (Create/Promote/Bump/Publish)

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -1,8 +1,15 @@
-name: Release / Create
+name: Release / Bump
 
 on:
   workflow_dispatch:
     inputs:
+      scope:
+        description: 'Version scope to bump'
+        required: true
+        type: choice
+        options:
+          - minor
+          - major
       dry_run:
         description: 'Dry run (preview only, no changes)'
         required: false
@@ -14,8 +21,9 @@ permissions:
   actions: read
 
 jobs:
-  release-create:
-    uses: go-kure/.github/.github/workflows/release-create.yml@main
+  release-bump:
+    uses: go-kure/.github/.github/workflows/release-bump.yml@main
     with:
+      scope: ${{ inputs.scope }}
       dry_run: ${{ inputs.dry_run }}
     secrets: inherit

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -1,0 +1,30 @@
+name: Release / Promote
+
+on:
+  workflow_dispatch:
+    inputs:
+      to:
+        description: 'Target release type'
+        required: true
+        type: choice
+        options:
+          - beta
+          - rc
+          - stable
+      dry_run:
+        description: 'Dry run (preview only, no changes)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  release-promote:
+    uses: go-kure/.github/.github/workflows/release-promote.yml@main
+    with:
+      to: ${{ inputs.to }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release / Publish
 
 on:
   push:
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   release:
-    uses: go-kure/.github/.github/workflows/release.yml@main
+    uses: go-kure/.github/.github/workflows/release-publish.yml@main
     with:
       go_module: github.com/go-kure/kure
     secrets: inherit

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -2,7 +2,7 @@
 
 This document provides an overview of all GitHub Actions workflows used in the kure project.
 
-**Last Updated:** 2026-05-10
+**Last Updated:** 2026-05-27
 
 ---
 
@@ -14,8 +14,10 @@ This document provides an overview of all GitHub Actions workflows used in the k
 | [Deploy Docs](#deploy-docs-workflow) | `deploy-docs.yml` | push to main (docs paths), `workflow_dispatch` | Multi-version docs deployment |
 | [Manage Docs](#manage-docs-workflow) | `manage-docs.yml` | `workflow_dispatch` | Remove, rebuild, or re-point doc versions |
 | [Auto-Rebase](#auto-rebase-workflow) | `auto-rebase.yml` | push to main | Rebase all open PRs when main is updated |
-| [Release](#release-workflow) | `release.yml` | version tags | Release with versioned docs deploy (shared org workflow) |
-| [Create Release](#create-release-workflow) | `release-create.yml` | `workflow_dispatch` | Pre-release test gate + tag creation |
+| [Release / Create](#release--create-workflow) | `release-create.yml` | manual | Auto-infer release type from VERSION, create tag |
+| [Release / Promote](#release--promote-workflow) | `release-promote.yml` | manual | Promote to explicit release type (beta/rc/stable) |
+| [Release / Bump](#release--bump-workflow) | `release-bump.yml` | manual | Advance version cycle (minor/major), no tag |
+| [Release / Publish](#release--publish-workflow) | `release-publish.yml` | tag push | GoReleaser, SBOM, cosign signing, docs deploy, proxy refresh |
 | [PR Review](#pr-review-workflow) | `pr-review.yml` | pull_request | Two-pass AI code review via ccproxy |
 
 ---
@@ -112,14 +114,114 @@ PR-only jobs (parallel, no blocking):
 
 ---
 
-## Release Workflow
+## Release / Create Workflow
 
-**File:** `.github/workflows/release.yml`
-**Name:** `Release`
+**File:** `.github/workflows/release-create.yml`
+**Name:** `Release / Create`
 
 ### Triggers
 
-- Push tags: `v*` (e.g., v1.0.0, v0.1.0-alpha.0)
+- Manual dispatch with input: `dry_run` (boolean)
+
+### How It Works
+
+The release type is **auto-inferred from the VERSION file** by `release.sh`. No `type` or `scope` inputs are needed. The regression guard in `release.sh` blocks invalid transitions automatically.
+
+### Pre-release Test Gate
+
+The workflow runs a full test suite (with race detection) **before** creating the tag. This prevents tags from being pushed when tests fail.
+
+```
+workflow_dispatch
+  → test job (go test -race ./...)
+    → release job (needs: test)
+      → release.sh (auto-infer type from VERSION) → creates tag + pushes
+        → triggers release-publish.yml (tag push)
+```
+
+If the pre-release test fails, the release job never runs and no tag is created.
+
+### Jobs
+
+1. **test** — Full test run with race detection and CGO enabled (`build-essential` + `CGO_ENABLED=1`)
+2. **release** — Runs `scripts/release.sh` to generate changelog, commit, create tag, and push
+
+### Authentication
+
+Uses a GitHub App token (`RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY`) so that the tag push triggers subsequent workflows (tag-triggered `release-publish.yml`).
+
+### Usage
+
+```bash
+# Preview release (auto-infer from VERSION)
+./scripts/release-trigger.sh
+
+# Create release via CI:
+#   Actions > "Release / Create" > Run workflow (type is auto-inferred)
+```
+
+---
+
+## Release / Promote Workflow
+
+**File:** `.github/workflows/release-promote.yml`
+**Name:** `Release / Promote`
+
+### Triggers
+
+- Manual dispatch with inputs: `to` (beta/rc/stable) and `dry_run`
+
+### Purpose
+
+Explicit type transition (e.g., beta → rc). The regression guard in `release.sh` blocks invalid downgrade transitions (e.g., rc → beta will fail with an error).
+
+### Usage
+
+```bash
+# Preview promotion to rc
+./scripts/release-trigger.sh promote rc
+
+# Execute via CI:
+#   Actions > "Release / Promote" > to=rc > Run workflow
+./scripts/release-trigger.sh promote rc --do-it
+```
+
+---
+
+## Release / Bump Workflow
+
+**File:** `.github/workflows/release-bump.yml`
+**Name:** `Release / Bump`
+
+### Triggers
+
+- Manual dispatch with inputs: `scope` (minor/major) and `dry_run`
+
+### Purpose
+
+Advance the version cycle without creating a tag. Use before starting a new prerelease cycle (e.g., after a stable release, to begin the next minor version's alpha).
+
+### Usage
+
+```bash
+# Preview minor version bump
+./scripts/release-trigger.sh bump minor
+
+# Execute via CI:
+#   Actions > "Release / Bump" > scope=minor > Run workflow
+./scripts/release-trigger.sh bump minor --do-it
+```
+
+---
+
+## Release / Publish Workflow
+
+**File:** `.github/workflows/release-publish.yml`
+**Name:** `Release / Publish`
+
+### Triggers
+
+- Push tags: `v*` (e.g., v1.0.0, v0.1.0-beta.2)
 
 ### Jobs
 
@@ -136,7 +238,7 @@ PR-only jobs (parallel, no blocking):
 
 ### CI Status Check
 
-Release workflow verifies CI passed before releasing:
+Publish workflow verifies CI passed before releasing:
 
 ```yaml
 check-ci:
@@ -156,46 +258,20 @@ check-ci:
 ### Release Management
 
 ```bash
-# Preview release plan locally (dry-run)
-make release TYPE=alpha
+# Preview release (auto-infer from VERSION)
+./scripts/release-trigger.sh
 
-# Create release via CI:
-#   Actions > "Create Release" > type=alpha > Run workflow
+# Preview type promotion
+./scripts/release-trigger.sh promote rc
+
+# Preview version bump
+./scripts/release-trigger.sh bump minor
+
+# Execute via CI (add --do-it to any of the above)
+./scripts/release-trigger.sh --do-it
+./scripts/release-trigger.sh promote rc --do-it
+./scripts/release-trigger.sh bump minor --do-it
 ```
-
----
-
-## Create Release Workflow
-
-**File:** `.github/workflows/release-create.yml`
-**Name:** `Create Release`
-
-### Triggers
-
-- Manual dispatch with inputs: `type` (alpha/beta/rc/stable/bump), `scope` (minor/major), `dry_run`
-
-### Pre-release Test Gate
-
-The workflow runs a full test suite (with race detection) **before** creating the tag. This prevents tags from being pushed when tests fail.
-
-```
-workflow_dispatch
-  → test job (go test -race ./...)
-    → release job (needs: test)
-      → release.sh → creates tag + pushes
-        → triggers release.yml (tag push)
-```
-
-If the pre-release test fails, the release job never runs and no tag is created.
-
-### Jobs
-
-1. **test** — Full test run with race detection and CGO enabled (`build-essential` + `CGO_ENABLED=1`)
-2. **release** — Runs `scripts/release.sh` to generate changelog, commit, create tag, and push
-
-### Authentication
-
-Uses a GitHub App token (`RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY`) so that the tag push triggers subsequent workflows (tag-triggered `release.yml`).
 
 ---
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -227,33 +227,15 @@ Advance the version cycle without creating a tag. Use before starting a new prer
 
 1. **test** - Full test run with race detection
 2. **validate** - Strict tag format, changelog, and version progression validation
-3. **deploy-docs** - Trigger versioned docs deployment (stable tags only)
-4. **post-release** - Go proxy refresh
+3. **goreleaser** - Build release artifacts, generate SBOM, sign with cosign
+4. **deploy-docs** - Trigger versioned docs deployment (stable tags only)
+5. **post-release** - Go proxy refresh
 
 ### Configuration
 
-- Go Version: `1.26.3`
+- Go Version: read from `mise.toml`
 - Tag Format: `^v[0-9]+\.[0-9]+\.[0-9]+(-alpha\.[0-9]+|-beta\.[0-9]+|-rc\.[0-9]+)?$`
-- Changelog: Required (must have `## v0.1.0` section)
-
-### CI Status Check
-
-Publish workflow verifies CI passed before releasing:
-
-```yaml
-check-ci:
-  name: Verify CI passed
-  steps:
-    - name: Check CI status for this commit
-      run: |
-        # Wait up to 5 minutes for CI to complete
-        for i in {1..30}; do
-          STATUS=$(gh api repos/.../commits/$COMMIT_SHA/status --jq '.state')
-          if [ "$STATUS" = "success" ]; then exit 0; fi
-          if [ "$STATUS" = "failure" ]; then exit 1; fi
-          sleep 10
-        done
-```
+- Changelog: Required (must have `## [0.1.0]` section — version without `v` prefix, in square brackets)
 
 ### Release Management
 

--- a/scripts/release-trigger.sh
+++ b/scripts/release-trigger.sh
@@ -2,16 +2,14 @@
 # Release trigger — dry-run by default, --do-it to execute via CI.
 #
 # Usage:
-#   ./scripts/release-trigger.sh                    # Preview current release
-#   ./scripts/release-trigger.sh beta               # Preview promotion to beta
-#   ./scripts/release-trigger.sh stable              # Preview stable release
-#   ./scripts/release-trigger.sh bump minor          # Preview minor version bump
-#   ./scripts/release-trigger.sh --do-it             # Execute release via CI
-#   ./scripts/release-trigger.sh beta --do-it        # Execute beta promotion via CI
-#   ./scripts/release-trigger.sh bump minor --do-it  # Execute minor bump via CI
+#   ./scripts/release-trigger.sh                         # Preview release (auto-infer from VERSION)
+#   ./scripts/release-trigger.sh promote <rc|beta|stable> # Preview type promotion
+#   ./scripts/release-trigger.sh bump <minor|major>      # Preview version bump
+#   ./scripts/release-trigger.sh --do-it                 # Execute release via CI
+#   ./scripts/release-trigger.sh promote rc --do-it      # Execute promotion via CI
+#   ./scripts/release-trigger.sh bump minor --do-it      # Execute bump via CI
 #
-# The script shows a preview of what will happen, then exits. Pass --do-it
-# to trigger the CI pipeline that performs the actual release.
+# The script shows a dry-run preview, then exits. Pass --do-it to trigger CI.
 #
 # See: https://gitlab.com/autops/wharf/meta/-/blob/main/standards/release-process.md
 
@@ -20,65 +18,75 @@ set -eu
 # ── Parse arguments ──────────────────────────────────────────────────────
 
 DO_IT=0
-TYPE=""
-SCOPE=""
-for arg in "$@"; do
-    case "$arg" in
+SUBCOMMAND=""
+ARG=""
+
+for _arg in "$@"; do
+    case "$_arg" in
         --do-it) DO_IT=1 ;;
+        promote|bump)
+            if [ -n "$SUBCOMMAND" ]; then
+                echo "ERROR: unexpected argument: $_arg" >&2; exit 1
+            fi
+            SUBCOMMAND="$_arg"
+            ;;
         *)
-            if [ -z "$TYPE" ]; then
-                TYPE="$arg"
+            if [ -n "$SUBCOMMAND" ] && [ -z "$ARG" ]; then
+                ARG="$_arg"
             else
-                SCOPE="$arg"
+                echo "ERROR: unexpected argument: $_arg" >&2; exit 1
             fi
             ;;
     esac
 done
 
-# ── Auto-detect type from VERSION ────────────────────────────────────────
+# ── Validate subcommand arguments ────────────────────────────────────────
 
-if [ -z "$TYPE" ]; then
-    VERSION=$(cat VERSION 2>/dev/null) || { echo "ERROR: VERSION file not found"; exit 1; }
-    case "$VERSION" in
-        *-alpha.*) TYPE=alpha ;;
-        *-beta.*)  TYPE=beta ;;
-        *-rc.*)    TYPE=rc ;;
-        *)
-            echo "ERROR: VERSION $VERSION has no prerelease suffix."
-            echo "Specify type: mise run release <alpha|beta|rc|stable|bump>"
-            exit 1
-            ;;
+if [ "$SUBCOMMAND" = "promote" ]; then
+    case "$ARG" in
+        beta|rc|stable) ;;
+        "") echo "ERROR: 'promote' requires a target: beta, rc, or stable" >&2; exit 1 ;;
+        *)  echo "ERROR: invalid promote target '$ARG' (use: beta, rc, stable)" >&2; exit 1 ;;
+    esac
+elif [ "$SUBCOMMAND" = "bump" ]; then
+    case "$ARG" in
+        minor|major) ;;
+        "") echo "ERROR: 'bump' requires a scope: minor or major" >&2; exit 1 ;;
+        *)  echo "ERROR: invalid bump scope '$ARG' (use: minor, major)" >&2; exit 1 ;;
     esac
 fi
 
 # ── Show dry-run preview ────────────────────────────────────────────────
 
-if [ "$TYPE" = "bump" ]; then
+if [ "$SUBCOMMAND" = "bump" ]; then
     echo "=== Version Bump Preview ==="
+    echo ""
+    DRY_RUN=1 RELEASE_TYPE=bump RELEASE_SCOPE="$ARG" ./scripts/release.sh
 else
     echo "=== Release Preview ==="
+    echo ""
+    if [ "$SUBCOMMAND" = "promote" ]; then
+        DRY_RUN=1 RELEASE_TYPE="$ARG" ./scripts/release.sh
+    else
+        DRY_RUN=1 ./scripts/release.sh
+    fi
 fi
 echo ""
-DRY_RUN=1 ./scripts/release.sh "$TYPE" $SCOPE
-echo ""
 
-# ── If not --do-it, show how to proceed and exit ────────────────────────
+# ── If not --do-it, show how to proceed and exit ─────────────────────────
 
 if [ "$DO_IT" != "1" ]; then
     echo "---"
-    if [ "$TYPE" = "bump" ]; then
-        CMD="mise run release bump${SCOPE:+ $SCOPE}"
+    if [ "$SUBCOMMAND" = "bump" ]; then
+        echo "To execute, run:"
+        echo "  mise run release bump $ARG -- --do-it"
+    elif [ "$SUBCOMMAND" = "promote" ]; then
+        echo "To execute, run:"
+        echo "  mise run release promote $ARG -- --do-it"
     else
-        # Show type only if it differs from auto-detected
-        AUTO_TYPE=$(sed -n 's/.*-\(alpha\|beta\|rc\).*/\1/p' VERSION 2>/dev/null || true)
-        if [ "$TYPE" = "$AUTO_TYPE" ]; then
-            CMD="mise run release"
-        else
-            CMD="mise run release $TYPE"
-        fi
+        echo "To execute, run:"
+        echo "  mise run release -- --do-it"
     fi
-    echo "To execute, run:"
-    echo "  $CMD -- --do-it"
     exit 0
 fi
 
@@ -89,26 +97,40 @@ echo ""
 
 REMOTE=$(git remote get-url origin 2>/dev/null || true)
 if echo "$REMOTE" | grep -q github.com; then
-    echo "Dispatching GitHub workflow: release-create.yml (type=${TYPE})"
-    if [ -n "$SCOPE" ]; then
-        gh workflow run release-create.yml --field "type=${TYPE}" --field "scope=${SCOPE}"
+    if [ "$SUBCOMMAND" = "bump" ]; then
+        echo "Dispatching GitHub workflow: release-bump.yml (scope=${ARG})"
+        gh workflow run release-bump.yml --field "scope=${ARG}"
+        echo ""
+        echo "Watch progress:"
+        echo "  gh run list --workflow=release-bump.yml"
+    elif [ "$SUBCOMMAND" = "promote" ]; then
+        echo "Dispatching GitHub workflow: release-promote.yml (to=${ARG})"
+        gh workflow run release-promote.yml --field "to=${ARG}"
+        echo ""
+        echo "Watch progress:"
+        echo "  gh run list --workflow=release-promote.yml"
     else
-        gh workflow run release-create.yml --field "type=${TYPE}"
+        echo "Dispatching GitHub workflow: release-create.yml"
+        gh workflow run release-create.yml
+        echo ""
+        echo "Watch progress:"
+        echo "  gh run list --workflow=release-create.yml"
     fi
-    echo ""
-    echo "Watch progress:"
-    echo "  gh run list --workflow=release-create.yml"
 elif echo "$REMOTE" | grep -q gitlab; then
-    echo "Creating GitLab pipeline on main (RELEASE_TYPE=${TYPE})"
-    if [ -n "$SCOPE" ]; then
-        glab ci run --branch main --variables-env "RELEASE_TYPE:${TYPE},RELEASE_SCOPE:${SCOPE}"
+    if [ "$SUBCOMMAND" = "bump" ]; then
+        echo "Creating GitLab pipeline on main (BUMP_SCOPE=${ARG})"
+        glab ci run --branch main --variables-env "BUMP_SCOPE:${ARG}"
+    elif [ "$SUBCOMMAND" = "promote" ]; then
+        echo "Creating GitLab pipeline on main (PROMOTE_TO=${ARG})"
+        glab ci run --branch main --variables-env "PROMOTE_TO:${ARG}"
     else
-        glab ci run --branch main --variables-env "RELEASE_TYPE:${TYPE}"
+        echo "Creating GitLab pipeline on main (RELEASE_CREATE=1)"
+        glab ci run --branch main --variables-env "RELEASE_CREATE:1"
     fi
     echo ""
     echo "Watch progress:"
     echo "  glab ci status"
 else
-    echo "ERROR: unsupported remote: $REMOTE"
+    echo "ERROR: unsupported remote: $REMOTE" >&2
     exit 1
 fi

--- a/scripts/release-trigger.sh
+++ b/scripts/release-trigger.sh
@@ -34,7 +34,9 @@ for _arg in "$@"; do
             if [ -n "$SUBCOMMAND" ] && [ -z "$ARG" ]; then
                 ARG="$_arg"
             else
-                echo "ERROR: unexpected argument: $_arg" >&2; exit 1
+                echo "ERROR: unexpected argument: '$_arg'" >&2
+                echo "       Usage: release-trigger.sh [promote <type>|bump <scope>] [--do-it]" >&2
+                exit 1
             fi
             ;;
     esac

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,7 +8,8 @@
 #   RELEASE_TYPE=alpha ./scripts/release.sh  # Via env var (CI)
 #
 # Environment:
-#   RELEASE_TYPE   Release type: alpha|beta|rc|stable|bump (or positional arg)
+#   RELEASE_TYPE   Release type: auto|alpha|beta|rc|stable|bump (or positional arg)
+#                  When unset or 'auto', infers from VERSION file.
 #   RELEASE_SCOPE  Bump scope: minor|major (or positional arg after "bump")
 #   DRY_RUN        1 = preview without changes (default: 0)
 #   CI             Set by CI runners; enables push and git identity setup
@@ -156,6 +157,15 @@ transition_prerelease() {
     echo "${base}-${target}.0"
 }
 
+type_order() {
+    case "$1" in
+        alpha) echo 0 ;;
+        beta)  echo 1 ;;
+        rc)    echo 2 ;;
+        *)     echo 99 ;;
+    esac
+}
+
 # ── Validation ────────────────────────────────────────────────────────────
 
 validate_version() {
@@ -272,11 +282,23 @@ release_prerelease() {
 
     current_type=$(prerelease_type "$current")
 
-    # Determine release version
+    # Regression guard: block downgrade transitions
+    if [ -n "$current_type" ] && [ "$current_type" != "$target_type" ]; then
+        current_order=$(type_order "$current_type")
+        target_order=$(type_order "$target_type")
+        if [ "$target_order" -lt "$current_order" ]; then
+            die "Requested type '$target_type' is a regression from current type '$current_type'.
+To restart from $target_type, use release-bump to advance to the next cycle first."
+        fi
+    fi
+
+    # Block prerelease creation from stable version
     if [ -z "$current_type" ]; then
-        # No prerelease suffix — start new prerelease cycle
-        release_version=$(start_prerelease "$current" "$target_type")
-    elif [ "$current_type" = "$target_type" ]; then
+        die "No prerelease in VERSION ($current). Use release-bump to start a new cycle."
+    fi
+
+    # Determine release version
+    if [ "$current_type" = "$target_type" ]; then
         # Same type — current version IS the release version
         release_version="$current"
     else
@@ -452,7 +474,19 @@ EOF
 }
 
 main() {
-    [ -n "$RELEASE_TYPE" ] || usage
+    # Auto-infer type from VERSION if not specified
+    if [ -z "$RELEASE_TYPE" ] || [ "$RELEASE_TYPE" = "auto" ]; then
+        current=$(read_version)
+        case "$current" in
+            *-alpha.*) RELEASE_TYPE=alpha ;;
+            *-beta.*)  RELEASE_TYPE=beta ;;
+            *-rc.*)    RELEASE_TYPE=rc ;;
+            *)
+                die "No prerelease in VERSION ($current). Use release-bump to start a new cycle."
+                ;;
+        esac
+        log_info "Auto-detected release type: $RELEASE_TYPE"
+    fi
 
     if [ "$DRY_RUN" = "1" ]; then
         log_warn "DRY_RUN mode — no changes will be made"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -477,6 +477,7 @@ main() {
     # Auto-infer type from VERSION if not specified
     if [ -z "$RELEASE_TYPE" ] || [ "$RELEASE_TYPE" = "auto" ]; then
         current=$(read_version)
+        validate_version "$current"
         case "$current" in
             *-alpha.*) RELEASE_TYPE=alpha ;;
             *-beta.*)  RELEASE_TYPE=beta ;;


### PR DESCRIPTION
Depends on go-kure/.github PR #20.

Changes:
- scripts/release.sh: type_order(), regression guard, stable guard, auto-infer
- scripts/release-trigger.sh: new promote/bump subcommands
- release.yml → release-publish.yml
- release-create.yml: auto-infer (no type/scope inputs)
- New release-promote.yml and release-bump.yml
- docs/github-workflows.md: updated to document new workflow model

Verification:
```bash
DRY_RUN=1 RELEASE_TYPE=alpha ./scripts/release.sh  # should error (regression)
DRY_RUN=1 ./scripts/release.sh                      # should show beta release
```