### PR TITLE
feat(layout)!: add FluxIntegratedPerBundle placement mode

### DIFF
--- a/pkg/stack/fluxcd/README.md
+++ b/pkg/stack/fluxcd/README.md
@@ -197,8 +197,10 @@ bundle's `Children`, shared umbrella ownership, or multi-package umbrellas —
 fail fast with a validation error rather than producing malformed output.
 
 `CreateLayoutWithResources` additionally calls `validateSourceRefsForFluxIntegrated`
-when `rules.FluxPlacement == FluxIntegratedPerLayout` (after normalization — `FluxUnset`
-becomes `FluxSeparate` and skips this gate). This checks that every bundle
+for **both inline placements** (`FluxIntegratedPerLayout` and
+`FluxIntegratedPerBundle`) — both emit bundle/node CRs that carry a `spec.sourceRef`.
+(After normalization `FluxUnset` becomes `FluxSeparate`, which skips this gate.)
+This checks that every bundle
 reachable from the cluster node tree — node bundles and umbrella child bundles
 recursively — has a complete `SourceRef` with both `Kind` and `Name` set. A nil,
 zero-value, or partially-populated `SourceRef` is rejected before layout walking

--- a/pkg/stack/fluxcd/README.md
+++ b/pkg/stack/fluxcd/README.md
@@ -50,7 +50,7 @@ engine := fluxcd.EngineWithConfig(mode)
 engine := fluxcd.NewWorkflowEngine()
 ```
 
-Placement (FluxIntegrated vs FluxSeparate) is configured per call on
+Placement (FluxIntegratedPerLayout vs FluxSeparate) is configured per call on
 `layout.LayoutRules.FluxPlacement`. `FluxUnset` is normalized to
 `FluxSeparate` by `LayoutIntegrator.CreateLayoutWithResources` — matching
 `layout.DefaultLayoutRules()` and the walker. See
@@ -124,8 +124,9 @@ Controls how kustomization.yaml files reference resources:
 
 Controls where Flux Kustomization resources are placed:
 
-- `FluxSeparate` - Flux resources in a separate directory tree
-- `FluxIntegrated` - Flux resources alongside application manifests
+- `FluxSeparate` - Flux resources collected in a separate directory tree; children referenced as directories
+- `FluxIntegratedPerLayout` - a Flux Kustomization CR for **every** layout node (incl. augmenter-added child layouts), placed alongside its manifests; children referenced as `kustomization-<child>.yaml` CR files. Finest granularity.
+- `FluxIntegratedPerBundle` - Flux Kustomization CRs at **bundle/node boundaries only**; a bundle's interior (incl. augmenter-added child layouts) is a single kustomize build, with children referenced as directories. Coarser: Flux reconciles per bundle, kustomize handles the interior.
 
 ## Umbrella Bundles
 
@@ -153,12 +154,12 @@ umbrella contains.
 `LayoutIntegrator` places umbrella child Flux CRs at the **parent** layout
 node:
 
-- **FluxIntegrated, non-nodeOnly**: the walker creates a bundle sub-layout
+- **FluxIntegratedPerLayout, non-nodeOnly**: the walker creates a bundle sub-layout
   under the node layout. Umbrella child Kustomization CRs (and their Source
   CRs, if the child has a `SourceRef.URL`) are appended to the bundle
   sub-layout's `Resources`. Nested umbrella children are placed at their
   enclosing umbrella child's layout node.
-- **FluxIntegrated, nodeOnly (GroupFlat)**: there is no intermediate bundle
+- **FluxIntegratedPerLayout, nodeOnly (GroupFlat)**: there is no intermediate bundle
   layer, so umbrella children become direct sub-layouts of the node layout,
   and their Flux CRs sit at the node layout alongside the umbrella self CR.
 - **FluxSeparate**: `GenerateFromCluster` walks the full umbrella closure, so
@@ -176,7 +177,7 @@ Flux does not double-apply the child's resources.
 
 ## Non-Bundle Child Layout CRs
 
-In `FluxIntegrated` mode the layout integrator generates `Kustomization` CRs for **all eligible children** of each node layout, not only the node's own bundle. A child is eligible when `!UmbrellaChild && ApplicationFileMode != AppFileSingle`.
+In `FluxIntegratedPerLayout` mode the layout integrator generates `Kustomization` CRs for **all eligible children** of each node layout, not only the node's own bundle. A child is eligible when `!UmbrellaChild && ApplicationFileMode != AppFileSingle`.
 
 This covers two cases with the same code path:
 
@@ -196,7 +197,7 @@ bundle's `Children`, shared umbrella ownership, or multi-package umbrellas —
 fail fast with a validation error rather than producing malformed output.
 
 `CreateLayoutWithResources` additionally calls `validateSourceRefsForFluxIntegrated`
-when `rules.FluxPlacement == FluxIntegrated` (after normalization — `FluxUnset`
+when `rules.FluxPlacement == FluxIntegratedPerLayout` (after normalization — `FluxUnset`
 becomes `FluxSeparate` and skips this gate). This checks that every bundle
 reachable from the cluster node tree — node bundles and umbrella child bundles
 recursively — has a complete `SourceRef` with both `Kind` and `Name` set. A nil,

--- a/pkg/stack/fluxcd/fluxcd_test.go
+++ b/pkg/stack/fluxcd/fluxcd_test.go
@@ -663,7 +663,7 @@ func extractTarFilesFluxcd(t *testing.T, buf *bytes.Buffer) map[string][]byte {
 func TestEndToEndUmbrellaFromCluster_Integrated(t *testing.T) {
 	// Build a cluster with a Node whose Bundle is an umbrella with 3 children,
 	// each holding one Application. Use PresetParentDeployedControl equivalent
-	// (GroupFlat + FluxIntegrated) via LayoutRules and assert that the tar
+	// (GroupFlat + FluxIntegratedPerLayout) via LayoutRules and assert that the tar
 	// output has the right directory shape, kustomization.yaml references, and
 	// the umbrella parent Kustomization CR with HealthChecks.
 	umbrella := &stack.Bundle{
@@ -697,7 +697,7 @@ func TestEndToEndUmbrellaFromCluster_Integrated(t *testing.T) {
 	ml, err := integrator.CreateLayoutWithResources(cluster, layout.LayoutRules{
 		BundleGrouping:      layout.GroupFlat,
 		ApplicationGrouping: layout.GroupFlat,
-		FluxPlacement:       layout.FluxIntegrated,
+		FluxPlacement:       layout.FluxIntegratedPerLayout,
 	})
 	if err != nil {
 		t.Fatalf("CreateLayoutWithResources: %v", err)

--- a/pkg/stack/fluxcd/layout_integrator.go
+++ b/pkg/stack/fluxcd/layout_integrator.go
@@ -15,7 +15,7 @@ import (
 // LayoutIntegrator implements the workflow.LayoutIntegrator interface for Flux.
 // It handles integration of Flux resources with manifest layouts.
 //
-// Placement (FluxIntegrated vs FluxSeparate) is configured via
+// Placement (FluxIntegratedPerLayout vs FluxSeparate) is configured via
 // layout.LayoutRules.FluxPlacement on each call. CreateLayoutWithResources
 // normalizes FluxUnset to FluxSeparate before invoking the SourceRef
 // validation gate, WalkCluster, and IntegrateWithLayout, so all three
@@ -52,13 +52,17 @@ func (li *LayoutIntegrator) IntegrateWithLayout(ml *layout.ManifestLayout, c *st
 
 	var err error
 	switch rules.FluxPlacement {
-	case layout.FluxIntegrated:
+	case layout.FluxIntegratedPerLayout, layout.FluxIntegratedPerBundle:
+		// Both place Flux CRs inline. They differ only in granularity, handled
+		// inside addIntegratedFluxToLayout: PerLayout emits a CR for every
+		// layout node (incl. augmenter-added child layouts); PerBundle stops at
+		// bundle/node boundaries and lets kustomize include child directories.
 		err = li.addIntegratedFluxToLayout(ml, c, rules)
 	case layout.FluxSeparate:
 		err = li.addSeparateFluxToLayout(ml, c, rules)
 	default:
 		return errors.NewValidationError("fluxPlacement", string(rules.FluxPlacement), "LayoutRules",
-			[]string{string(layout.FluxIntegrated), string(layout.FluxSeparate)})
+			[]string{string(layout.FluxIntegratedPerLayout), string(layout.FluxIntegratedPerBundle), string(layout.FluxSeparate)})
 	}
 	if err != nil {
 		return err
@@ -87,7 +91,10 @@ func (li *LayoutIntegrator) CreateLayoutWithResources(c *stack.Cluster, rules la
 
 	rules = normalizeRulesPlacement(rules)
 
-	if rules.FluxPlacement == layout.FluxIntegrated {
+	// Both inline modes emit bundle/node Flux CRs that carry a spec.sourceRef,
+	// so both require every reachable bundle to have a valid SourceRef.
+	if rules.FluxPlacement == layout.FluxIntegratedPerLayout ||
+		rules.FluxPlacement == layout.FluxIntegratedPerBundle {
 		if err := validateSourceRefsForFluxIntegrated(c); err != nil {
 			return nil, err
 		}
@@ -110,14 +117,22 @@ func (li *LayoutIntegrator) CreateLayoutWithResources(c *stack.Cluster, rules la
 }
 
 // addIntegratedFluxToLayout places Flux Kustomizations alongside their target manifests.
+//
+// PerLayout emits a Flux Kustomization CR for every eligible layout child
+// (including augmenter-added sub-layouts), so the writer references each child
+// as a CR file. PerBundle emits CRs only at bundle/node boundaries
+// (GenerateFromBundle + umbrella bundle children); non-bundle layout children
+// get no CR and the writer references them as directories — a single kustomize
+// build per bundle.
 func (li *LayoutIntegrator) addIntegratedFluxToLayout(ml *layout.ManifestLayout, c *stack.Cluster, rules layout.LayoutRules) error {
-	return li.processNodeForIntegratedFlux(ml, c.Node, c.Name)
+	emitPerChildCRs := rules.FluxPlacement == layout.FluxIntegratedPerLayout
+	return li.processNodeForIntegratedFlux(ml, c.Node, c.Name, emitPerChildCRs)
 }
 
 // processNodeForIntegratedFlux recursively processes nodes to add integrated Flux resources.
 // The root parameter is always the top-level layout so that path-based lookups
 // resolve against the full tree (node paths are absolute).
-func (li *LayoutIntegrator) processNodeForIntegratedFlux(root *layout.ManifestLayout, node *stack.Node, clusterName string) error {
+func (li *LayoutIntegrator) processNodeForIntegratedFlux(root *layout.ManifestLayout, node *stack.Node, clusterName string, emitPerChildCRs bool) error {
 	// Find the corresponding layout node
 	layoutNode := li.findLayoutNode(root, node)
 	if layoutNode == nil {
@@ -154,7 +169,7 @@ func (li *LayoutIntegrator) processNodeForIntegratedFlux(root *layout.ManifestLa
 		}
 	}
 
-	// In FluxIntegrated mode, emit Kustomization CRs for all eligible direct
+	// In FluxIntegratedPerLayout mode, emit Kustomization CRs for all eligible direct
 	// children of layoutNode and recurse into their subtrees.
 	//
 	// "Eligible" mirrors the writer condition: !UmbrellaChild &&
@@ -168,7 +183,11 @@ func (li *LayoutIntegrator) processNodeForIntegratedFlux(root *layout.ManifestLa
 	//   (b) Augmenter sub-layouts: hook-group children of app layouts;
 	//       generateChildFluxCRs recurses and places those CRs in the app
 	//       layout's Resources.
-	if node.Bundle != nil {
+	//
+	// Skipped entirely in FluxIntegratedPerBundle mode: there, a bundle's
+	// interior is a single kustomize build and the writer references children as
+	// directories, so no per-child CRs are emitted.
+	if emitPerChildCRs && node.Bundle != nil {
 		var eligibleChildren []*layout.ManifestLayout
 		for _, child := range layoutNode.Children {
 			if child.UmbrellaChild || child.ApplicationFileMode == layout.AppFileSingle {
@@ -210,7 +229,7 @@ func (li *LayoutIntegrator) processNodeForIntegratedFlux(root *layout.ManifestLa
 			if len(newCRChildren) > 0 && sr.Kind == "" {
 				return errors.ResourceValidationError(
 					"Bundle", node.Bundle.Name, "sourceRef",
-					"FluxIntegrated mode requires a SourceRef with Kind and Name on bundles "+
+					"FluxIntegratedPerLayout mode requires a SourceRef with Kind and Name on bundles "+
 						"whose layout has eligible children without existing Kustomization CRs; "+
 						"omitting it produces invalid Flux Kustomization CRs",
 					nil,
@@ -236,7 +255,7 @@ func (li *LayoutIntegrator) processNodeForIntegratedFlux(root *layout.ManifestLa
 
 	// Process child nodes — always search from root for path-based matching
 	for _, child := range node.Children {
-		if err := li.processNodeForIntegratedFlux(root, child, clusterName); err != nil {
+		if err := li.processNodeForIntegratedFlux(root, child, clusterName, emitPerChildCRs); err != nil {
 			return err
 		}
 	}
@@ -287,7 +306,7 @@ func (li *LayoutIntegrator) generateChildFluxCRs(
 			if sourceRef.Kind == "" {
 				return errors.ResourceValidationError(
 					"ManifestLayout", child.Name, "sourceRef",
-					"FluxIntegrated mode requires a SourceRef with Kind and Name; "+
+					"FluxIntegratedPerLayout mode requires a SourceRef with Kind and Name; "+
 						"this descendant layout needs a Kustomization CR but the "+
 						"ancestor bundle has no valid SourceRef",
 					nil,

--- a/pkg/stack/fluxcd/layout_integrator.go
+++ b/pkg/stack/fluxcd/layout_integrator.go
@@ -162,7 +162,7 @@ func (li *LayoutIntegrator) processNodeForIntegratedFlux(root *layout.ManifestLa
 			if bl := findBundleLayout(layoutNode, node.Bundle.Name); bl != nil {
 				parentForChildren = bl
 			}
-			if err := li.placeUmbrellaChildrenFlux(parentForChildren, node.Bundle); err != nil {
+			if err := li.placeUmbrellaChildrenFlux(parentForChildren, node.Bundle, emitPerChildCRs); err != nil {
 				return errors.ResourceValidationError("Node", node.Name, "umbrella",
 					fmt.Sprintf("failed to place umbrella child Flux resources: %v", err), err)
 			}
@@ -327,7 +327,7 @@ func (li *LayoutIntegrator) generateChildFluxCRs(
 // SourceRef has a URL) at the PARENT layout node. Nested umbrella
 // grandchildren are placed at their immediate enclosing umbrella child's
 // layout node, which the walker has already marked with UmbrellaChild=true.
-func (li *LayoutIntegrator) placeUmbrellaChildrenFlux(parentLayout *layout.ManifestLayout, umbrella *stack.Bundle) error {
+func (li *LayoutIntegrator) placeUmbrellaChildrenFlux(parentLayout *layout.ManifestLayout, umbrella *stack.Bundle, emitPerChildCRs bool) error {
 	umbrella.InitializeUmbrella()
 	for _, child := range umbrella.Children {
 		if child == nil {
@@ -354,7 +354,7 @@ func (li *LayoutIntegrator) placeUmbrellaChildrenFlux(parentLayout *layout.Manif
 				return errors.ResourceValidationError("Bundle", child.Name, "umbrella",
 					"nested umbrella child layout not found", nil)
 			}
-			if err := li.placeUmbrellaChildrenFlux(childLayoutNode, child); err != nil {
+			if err := li.placeUmbrellaChildrenFlux(childLayoutNode, child, emitPerChildCRs); err != nil {
 				return err
 			}
 		}
@@ -365,7 +365,12 @@ func (li *LayoutIntegrator) placeUmbrellaChildrenFlux(parentLayout *layout.Manif
 		// helmchart augmenter) are invisible to it. Use the child bundle's own
 		// SourceRef so that each CR points to the correct source, not the
 		// parent umbrella's source.
-		if childLayoutNode != nil {
+		//
+		// Skipped in FluxIntegratedPerBundle mode: there the umbrella child's
+		// interior is a single kustomize build and the writer references those
+		// augmenter sub-layouts as directories, so emitting per-child CRs here
+		// would duplicate reconciliation (a CR file ref plus a directory ref).
+		if emitPerChildCRs && childLayoutNode != nil {
 			var childSR kustv1.CrossNamespaceSourceReference
 			if child.SourceRef != nil && child.SourceRef.Kind != "" && child.SourceRef.Name != "" {
 				childSR = kustv1.CrossNamespaceSourceReference{

--- a/pkg/stack/fluxcd/layout_integrator_test.go
+++ b/pkg/stack/fluxcd/layout_integrator_test.go
@@ -1087,6 +1087,52 @@ func TestUmbrellaChildAugmenterSubLayoutGetFluxCR(t *testing.T) {
 	}
 }
 
+// TestUmbrellaChildAugmenterSubLayoutPerBundleNoCR verifies that in
+// FluxIntegratedPerBundle mode an umbrella child's augmenter-added sub-layout
+// gets NO per-child Flux CR and is referenced as a directory exactly once — no
+// duplicate CR-file + directory reference. This guards the per-bundle gating in
+// placeUmbrellaChildrenFlux (the augmenter-emission path).
+func TestUmbrellaChildAugmenterSubLayoutPerBundleNoCR(t *testing.T) {
+	root, _, platformApps, _, cluster := buildUmbrellaAugmenterTree(testSR(), testSR())
+	augStampPlacement(root, layout.FluxIntegratedPerBundle)
+
+	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegratedPerBundle}
+	if err := li.IntegrateWithLayout(root, cluster, rules); err != nil {
+		t.Fatalf("IntegrateWithLayout: %v", err)
+	}
+
+	// No per-child CR for the augmenter sub-layout.
+	if augHasCR(platformApps.Resources, "redis") {
+		t.Errorf("PerBundle: did not expect a Kustomization CR for 'redis' in platform-apps.Resources")
+	}
+
+	dir := t.TempDir()
+	if err := root.WriteToDisk(dir); err != nil {
+		t.Fatalf("WriteToDisk: %v", err)
+	}
+	kustData, err := os.ReadFile(filepath.Join(dir, platformApps.FullRepoPath(), "kustomization.yaml"))
+	if err != nil {
+		t.Fatalf("read platform-apps/kustomization.yaml: %v", err)
+	}
+	var redisEntries []string
+	for line := range strings.SplitSeq(string(kustData), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "- ") && strings.Contains(trimmed, "redis") {
+			redisEntries = append(redisEntries, strings.TrimPrefix(trimmed, "- "))
+		}
+	}
+	if len(redisEntries) != 1 {
+		t.Fatalf("PerBundle: expected exactly 1 redis entry (directory), got %v:\n%s", redisEntries, kustData)
+	}
+	if strings.HasPrefix(redisEntries[0], "kustomization-") {
+		t.Errorf("PerBundle: redis should be a directory reference, got CR file %q", redisEntries[0])
+	}
+	if _, err := os.Stat(filepath.Join(dir, platformApps.FullRepoPath(), redisEntries[0])); os.IsNotExist(err) {
+		t.Errorf("PerBundle: directory reference %q does not resolve on disk", redisEntries[0])
+	}
+}
+
 // TestUmbrellaChildAugmenterSubLayoutNoDanglingReference verifies that
 // WriteToDisk does not produce a dangling reference in
 // platform-apps/kustomization.yaml when redis is an augmenter-added sub-layout.

--- a/pkg/stack/fluxcd/layout_integrator_test.go
+++ b/pkg/stack/fluxcd/layout_integrator_test.go
@@ -104,7 +104,7 @@ func TestLayoutIntegrator_IntegrateWithLayout_Integrated(t *testing.T) {
 	}
 
 	rules := layout.DefaultLayoutRules()
-	rules.FluxPlacement = layout.FluxIntegrated
+	rules.FluxPlacement = layout.FluxIntegratedPerLayout
 	err := integrator.IntegrateWithLayout(ml, cluster, rules)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -284,7 +284,7 @@ func TestLayoutIntegrator_IntegrateWithNestedNodes(t *testing.T) {
 	}
 
 	rules := layout.DefaultLayoutRules()
-	rules.FluxPlacement = layout.FluxIntegrated
+	rules.FluxPlacement = layout.FluxIntegratedPerLayout
 	err := integrator.IntegrateWithLayout(rootLayout, cluster, rules)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -363,7 +363,7 @@ func TestCreateLayoutWithResources_ClusterNameWithChildNodes(t *testing.T) {
 
 	rules := layout.DefaultLayoutRules()
 	rules.ClusterName = "demo"
-	rules.FluxPlacement = layout.FluxIntegrated
+	rules.FluxPlacement = layout.FluxIntegratedPerLayout
 
 	ml, err := integrator.CreateLayoutWithResources(cluster, rules)
 	if err != nil {
@@ -416,7 +416,7 @@ func TestCreateLayoutWithResources_InvalidUmbrellaRejected(t *testing.T) {
 func TestCreateLayoutWithResources_UmbrellaIntegratedPlacement(t *testing.T) {
 	// Integrated placement: the umbrella bundle's own Flux CR goes to the
 	// node layout (existing behavior, referenced via the bundle-named
-	// FluxIntegrated child reference), while each umbrella child's Flux CR
+	// FluxIntegratedPerLayout child reference), while each umbrella child's Flux CR
 	// lands at the bundle layout (where the bundle-dir kustomization.yaml
 	// references them via UmbrellaChild). Child sub-layouts carry no Flux CRs.
 	umbrella := &stack.Bundle{
@@ -437,7 +437,7 @@ func TestCreateLayoutWithResources_UmbrellaIntegratedPlacement(t *testing.T) {
 	ml, err := integrator.CreateLayoutWithResources(cluster, layout.LayoutRules{
 		BundleGrouping:      layout.GroupByName,
 		ApplicationGrouping: layout.GroupByName,
-		FluxPlacement:       layout.FluxIntegrated,
+		FluxPlacement:       layout.FluxIntegratedPerLayout,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -520,7 +520,7 @@ func TestCreateLayoutWithResources_UmbrellaNodeOnlyPlacement(t *testing.T) {
 	ml, err := integrator.CreateLayoutWithResources(cluster, layout.LayoutRules{
 		BundleGrouping:      layout.GroupFlat,
 		ApplicationGrouping: layout.GroupFlat,
-		FluxPlacement:       layout.FluxIntegrated,
+		FluxPlacement:       layout.FluxIntegratedPerLayout,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -578,7 +578,7 @@ func TestCreateLayoutWithResources_UmbrellaNestedIntegratedPlacement(t *testing.
 	ml, err := integrator.CreateLayoutWithResources(cluster, layout.LayoutRules{
 		BundleGrouping:      layout.GroupByName,
 		ApplicationGrouping: layout.GroupByName,
-		FluxPlacement:       layout.FluxIntegrated,
+		FluxPlacement:       layout.FluxIntegratedPerLayout,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -670,7 +670,7 @@ func TestCreateLayoutWithResources_UmbrellaChildWithSource(t *testing.T) {
 	ml, err := integrator.CreateLayoutWithResources(cluster, layout.LayoutRules{
 		BundleGrouping:      layout.GroupByName,
 		ApplicationGrouping: layout.GroupByName,
-		FluxPlacement:       layout.FluxIntegrated,
+		FluxPlacement:       layout.FluxIntegratedPerLayout,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -737,7 +737,7 @@ func TestIntegrateWithLayout_AppliesFlattenPathRewrites(t *testing.T) {
 func TestIntegrateWithLayout_RepeatedCallSucceeds(t *testing.T) {
 	generator := fluxstack.NewResourceGenerator()
 	integrator := fluxstack.NewLayoutIntegrator(generator)
-	integratedRules := layout.LayoutRules{FluxPlacement: layout.FluxIntegrated}
+	integratedRules := layout.LayoutRules{FluxPlacement: layout.FluxIntegratedPerLayout}
 
 	cluster := &stack.Cluster{
 		Name: "arc-runners",
@@ -789,7 +789,7 @@ func TestAugmenterChildrenGetFluxCRs(t *testing.T) {
 	root, nodeLayout, app, preInstall, hooks, cluster := buildAugmenterTestTree()
 
 	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegrated}
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegratedPerLayout}
 	if err := li.IntegrateWithLayout(root, cluster, rules); err != nil {
 		t.Fatalf("IntegrateWithLayout: %v", err)
 	}
@@ -830,7 +830,7 @@ func TestAugmenterChildrenNoDuplicateInKustomizationYAML(t *testing.T) {
 	root, nodeLayout, app, preInstall, _, cluster := buildAugmenterTestTree()
 
 	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegrated}
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegratedPerLayout}
 	if err := li.IntegrateWithLayout(root, cluster, rules); err != nil {
 		t.Fatalf("IntegrateWithLayout: %v", err)
 	}
@@ -854,7 +854,7 @@ func TestAugmenterChildrenWriteToTar(t *testing.T) {
 	root, nodeLayout, app, preInstall, _, cluster := buildAugmenterTestTree()
 
 	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegrated}
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegratedPerLayout}
 	if err := li.IntegrateWithLayout(root, cluster, rules); err != nil {
 		t.Fatalf("IntegrateWithLayout: %v", err)
 	}
@@ -887,6 +887,94 @@ func TestAugmenterChildrenWriteToTar(t *testing.T) {
 	augAssertCount(t, appKust, "flux-system-kustomization-"+preInstall.Name+".yaml", 1)
 }
 
+// TestAugmenterChildrenPerBundleNoChildCRs verifies that FluxIntegratedPerBundle
+// places bundle/node CRs but emits NO per-child CRs for augmenter sub-layouts or
+// for the app layout itself — the bundle's interior is a single kustomize build.
+func TestAugmenterChildrenPerBundleNoChildCRs(t *testing.T) {
+	root, nodeLayout, app, _, _, cluster := buildAugmenterTestTree()
+	augStampPlacement(root, layout.FluxIntegratedPerBundle)
+
+	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegratedPerBundle}
+	if err := li.IntegrateWithLayout(root, cluster, rules); err != nil {
+		t.Fatalf("IntegrateWithLayout: %v", err)
+	}
+
+	// No per-child CRs for the app's augmenter sub-layouts.
+	if len(app.Resources) != 0 {
+		t.Errorf("PerBundle: expected no CRs in app.Resources, got %d", len(app.Resources))
+	}
+	// No CR for the app layout itself at the node level (eligibleChildren skipped).
+	if augHasCR(nodeLayout.Resources, app.Name) {
+		t.Errorf("PerBundle: did not expect a CR for %q in nodeLayout.Resources", app.Name)
+	}
+}
+
+// TestAugmenterChildrenPerBundleWriteToTarUsesDirRefs verifies that in
+// FluxIntegratedPerBundle mode the writer references children as directories
+// (not kustomization-<child>.yaml CR files), and produces no dangling CR-file
+// references. Exercises the tar path that production stack-compile uses.
+func TestAugmenterChildrenPerBundleWriteToTarUsesDirRefs(t *testing.T) {
+	root, nodeLayout, app, preInstall, _, cluster := buildAugmenterTestTree()
+	augStampPlacement(root, layout.FluxIntegratedPerBundle)
+
+	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegratedPerBundle}
+	if err := li.IntegrateWithLayout(root, cluster, rules); err != nil {
+		t.Fatalf("IntegrateWithLayout: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := root.WriteToTar(&buf); err != nil {
+		t.Fatalf("WriteToTar: %v", err)
+	}
+
+	files := map[string]string{}
+	tr := tar.NewReader(&buf)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar.Next: %v", err)
+		}
+		if strings.HasSuffix(hdr.Name, "kustomization.yaml") {
+			data, _ := io.ReadAll(tr)
+			files[hdr.Name] = string(data)
+		}
+	}
+
+	// Node kustomization.yaml references the app as a directory, not a CR file.
+	nodeKust := augFindKust(t, files, nodeLayout.FullRepoPath())
+	augAssertCount(t, nodeKust, "flux-system-kustomization-"+app.Name+".yaml", 0)
+	augAssertCount(t, nodeKust, "- "+app.Name+"\n", 1)
+
+	// App kustomization.yaml references the augmenter sub-layout as a directory.
+	appKust := augFindKust(t, files, app.FullRepoPath())
+	augAssertCount(t, appKust, "flux-system-kustomization-"+preInstall.Name+".yaml", 0)
+	augAssertCount(t, appKust, "- "+preInstall.Name+"\n", 1)
+}
+
+// TestCreateLayoutWithResources_FluxIntegratedPerBundle_RejectsInvalidSourceRef
+// verifies the SourceRef gate fires for PerBundle too — it emits inline bundle
+// CRs that carry a spec.sourceRef.
+func TestCreateLayoutWithResources_FluxIntegratedPerBundle_RejectsInvalidSourceRef(t *testing.T) {
+	c := &stack.Cluster{
+		Name: "test",
+		Node: &stack.Node{
+			Name:   "prod",
+			Bundle: &stack.Bundle{Name: "apps"},
+		},
+	}
+	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegratedPerBundle}
+
+	if _, err := li.CreateLayoutWithResources(c, rules); err == nil {
+		t.Fatal("expected error for FluxIntegratedPerBundle with nil SourceRef, got nil")
+	}
+}
+
 // TestAugmenterChildrenErrorWhenNoSourceRef verifies that IntegrateWithLayout
 // returns a blocking error when augmenter children need CRs but the bundle
 // has a nil, empty, or incomplete SourceRef.
@@ -905,11 +993,11 @@ func TestAugmenterChildrenErrorWhenNoSourceRef(t *testing.T) {
 			appChild := &layout.ManifestLayout{
 				Name:          "myapp",
 				Namespace:     "clusters/prod",
-				FluxPlacement: layout.FluxIntegrated,
+				FluxPlacement: layout.FluxIntegratedPerLayout,
 				Children: []*layout.ManifestLayout{{
 					Name:          "myapp-00-pre-install",
 					Namespace:     "clusters/prod/myapp/myapp-00-pre-install",
-					FluxPlacement: layout.FluxIntegrated,
+					FluxPlacement: layout.FluxIntegratedPerLayout,
 				}},
 			}
 			bundle := &stack.Bundle{Name: "apps", SourceRef: tc.sr}
@@ -917,13 +1005,13 @@ func TestAugmenterChildrenErrorWhenNoSourceRef(t *testing.T) {
 			cluster := &stack.Cluster{Node: node}
 			nodeLayout := &layout.ManifestLayout{
 				Name:          "prod",
-				FluxPlacement: layout.FluxIntegrated,
+				FluxPlacement: layout.FluxIntegratedPerLayout,
 				Children:      []*layout.ManifestLayout{appChild},
 			}
 			root := &layout.ManifestLayout{Children: []*layout.ManifestLayout{nodeLayout}}
 
 			li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-			rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegrated}
+			rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegratedPerLayout}
 			if err := li.IntegrateWithLayout(root, cluster, rules); err == nil {
 				t.Fatalf("sourceRef=%v: expected error, got nil", tc.sr)
 			}
@@ -936,7 +1024,7 @@ func TestAugmenterChildrenErrorWhenNoSourceRef(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // buildUmbrellaAugmenterTree constructs a layout+cluster tree simulating
-// helm-multi-tier with FluxIntegrated: a platform umbrella node with a
+// helm-multi-tier with FluxIntegratedPerLayout: a platform umbrella node with a
 // platform-apps umbrella child layout, which has a redis sub-layout added by
 // Crane's helmchart augmenter (invisible to the bundle model).
 //
@@ -949,13 +1037,13 @@ func buildUmbrellaAugmenterTree(parentSR, childSR *stack.SourceRef) (
 	redis = &layout.ManifestLayout{
 		Name:          "redis",
 		Namespace:     "platform/platform-apps/redis",
-		FluxPlacement: layout.FluxIntegrated,
+		FluxPlacement: layout.FluxIntegratedPerLayout,
 		Mode:          layout.KustomizationExplicit,
 	}
 	platformApps = &layout.ManifestLayout{
 		Name:          "platform-apps",
 		Namespace:     "platform/platform-apps",
-		FluxPlacement: layout.FluxIntegrated,
+		FluxPlacement: layout.FluxIntegratedPerLayout,
 		Mode:          layout.KustomizationExplicit,
 		UmbrellaChild: true,
 		Children:      []*layout.ManifestLayout{redis},
@@ -989,7 +1077,7 @@ func TestUmbrellaChildAugmenterSubLayoutGetFluxCR(t *testing.T) {
 	root, _, platformApps, _, cluster := buildUmbrellaAugmenterTree(testSR(), testSR())
 
 	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegrated}
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegratedPerLayout}
 	if err := li.IntegrateWithLayout(root, cluster, rules); err != nil {
 		t.Fatalf("IntegrateWithLayout: %v", err)
 	}
@@ -1008,7 +1096,7 @@ func TestUmbrellaChildAugmenterSubLayoutNoDanglingReference(t *testing.T) {
 	root, _, platformApps, _, cluster := buildUmbrellaAugmenterTree(testSR(), testSR())
 
 	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegrated}
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegratedPerLayout}
 	if err := li.IntegrateWithLayout(root, cluster, rules); err != nil {
 		t.Fatalf("IntegrateWithLayout: %v", err)
 	}
@@ -1056,7 +1144,7 @@ func TestUmbrellaChildAugmenterSubLayoutUsesChildSourceRef(t *testing.T) {
 	root, _, platformApps, _, cluster := buildUmbrellaAugmenterTree(parentSR, childSR)
 
 	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegrated}
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegratedPerLayout}
 	if err := li.IntegrateWithLayout(root, cluster, rules); err != nil {
 		t.Fatalf("IntegrateWithLayout: %v", err)
 	}
@@ -1089,12 +1177,12 @@ func TestAugmenterGrandchildErrorWhenNoSourceRef(t *testing.T) {
 	grandchild := &layout.ManifestLayout{
 		Name:          "myapp-00-pre-install",
 		Namespace:     "clusters/prod/myapp/myapp-00-pre-install",
-		FluxPlacement: layout.FluxIntegrated,
+		FluxPlacement: layout.FluxIntegratedPerLayout,
 	}
 	appLayout := &layout.ManifestLayout{
 		Name:          "myapp",
 		Namespace:     "clusters/prod",
-		FluxPlacement: layout.FluxIntegrated,
+		FluxPlacement: layout.FluxIntegratedPerLayout,
 		Children:      []*layout.ManifestLayout{grandchild},
 	}
 
@@ -1110,14 +1198,14 @@ func TestAugmenterGrandchildErrorWhenNoSourceRef(t *testing.T) {
 
 	nodeLayout := &layout.ManifestLayout{
 		Name:          "prod",
-		FluxPlacement: layout.FluxIntegrated,
+		FluxPlacement: layout.FluxIntegratedPerLayout,
 		Resources:     []client.Object{existingCR},
 		Children:      []*layout.ManifestLayout{appLayout},
 	}
 	root := &layout.ManifestLayout{Children: []*layout.ManifestLayout{nodeLayout}}
 
 	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegrated}
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegratedPerLayout}
 	if err := li.IntegrateWithLayout(root, cluster, rules); err == nil {
 		t.Fatal("expected error: grandchild needs a CR but ancestor bundle has no SourceRef")
 	}
@@ -1135,18 +1223,18 @@ func buildAugmenterTestTree() (root, nodeLayout, app, preInstall, hooks *layout.
 	preInstall = &layout.ManifestLayout{
 		Name:          "myapp-00-pre-install",
 		Namespace:     "clusters/prod/myapp/myapp-00-pre-install",
-		FluxPlacement: layout.FluxIntegrated,
+		FluxPlacement: layout.FluxIntegratedPerLayout,
 	}
 	hooks = &layout.ManifestLayout{
 		Name:          "myapp-01-hooks",
 		Namespace:     "clusters/prod/myapp/myapp-01-hooks",
-		FluxPlacement: layout.FluxIntegrated,
+		FluxPlacement: layout.FluxIntegratedPerLayout,
 		DependsOn:     []string{"myapp-00-pre-install"},
 	}
 	app = &layout.ManifestLayout{
 		Name:          "myapp",
 		Namespace:     "clusters/prod",
-		FluxPlacement: layout.FluxIntegrated,
+		FluxPlacement: layout.FluxIntegratedPerLayout,
 		Children:      []*layout.ManifestLayout{preInstall, hooks},
 	}
 	sr := &stack.SourceRef{Kind: "GitRepository", Name: "flux-system", Namespace: "flux-system"}
@@ -1155,7 +1243,7 @@ func buildAugmenterTestTree() (root, nodeLayout, app, preInstall, hooks *layout.
 	cluster = &stack.Cluster{Node: node}
 	nodeLayout = &layout.ManifestLayout{
 		Name:          "prod",
-		FluxPlacement: layout.FluxIntegrated,
+		FluxPlacement: layout.FluxIntegratedPerLayout,
 		Children:      []*layout.ManifestLayout{app},
 	}
 	root = &layout.ManifestLayout{Children: []*layout.ManifestLayout{nodeLayout}}
@@ -1219,6 +1307,17 @@ func augKeysOf(m map[string]string) []string {
 	return keys
 }
 
+// augStampPlacement recursively sets FluxPlacement on every layout in the tree,
+// mirroring what WalkCluster does in production (it stamps rules.FluxPlacement
+// onto each ManifestLayout). The writer reads ml.FluxPlacement, so hand-built
+// test trees must stamp the placement they intend to exercise.
+func augStampPlacement(ml *layout.ManifestLayout, p layout.FluxPlacement) {
+	ml.FluxPlacement = p
+	for _, c := range ml.Children {
+		augStampPlacement(c, p)
+	}
+}
+
 func TestCreateLayoutWithResources_FluxIntegrated_RejectsInvalidSourceRef(t *testing.T) {
 	// Validator fires before WalkCluster; no ApplicationConfig needed.
 	c := &stack.Cluster{
@@ -1229,10 +1328,10 @@ func TestCreateLayoutWithResources_FluxIntegrated_RejectsInvalidSourceRef(t *tes
 		},
 	}
 	li := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
-	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegrated}
+	rules := layout.LayoutRules{FluxPlacement: layout.FluxIntegratedPerLayout}
 
 	if _, err := li.CreateLayoutWithResources(c, rules); err == nil {
-		t.Fatal("expected error for FluxIntegrated with nil SourceRef, got nil")
+		t.Fatal("expected error for FluxIntegratedPerLayout with nil SourceRef, got nil")
 	}
 }
 
@@ -1252,8 +1351,8 @@ func TestCreateLayoutWithResources_FluxSeparate_AllowsMissingSourceRef(t *testin
 
 // TestIntegrateWithLayout_RulesFluxSeparate_NoDuplicateChildCRs is a
 // regression guard for #576. Before the fix, IntegrateWithLayout read
-// li.FluxPlacement (constructor default = FluxIntegrated) and ignored
-// rules.FluxPlacement, so the FluxIntegrated emission block ran even when
+// li.FluxPlacement (constructor default = FluxIntegratedPerLayout) and ignored
+// rules.FluxPlacement, so the FluxIntegratedPerLayout emission block ran even when
 // the caller asked for FluxSeparate via rules. That produced duplicate
 // Kustomization CRs for augmenter-added child layouts. After the fix,
 // rules.FluxPlacement is the sole authority and the FluxSeparate path must
@@ -1268,16 +1367,16 @@ func TestIntegrateWithLayout_RulesFluxSeparate_NoDuplicateChildCRs(t *testing.T)
 	}
 
 	// FluxSeparate must not emit augmenter-child CRs into app.Resources
-	// (that emission only fires on the FluxIntegrated code path).
+	// (that emission only fires on the FluxIntegratedPerLayout code path).
 	if augHasCR(app.Resources, preInstall.Name) {
-		t.Errorf("FluxSeparate emitted a Kustomization CR for augmenter child %q at app.Resources; FluxIntegrated leaked into the FluxSeparate path", preInstall.Name)
+		t.Errorf("FluxSeparate emitted a Kustomization CR for augmenter child %q at app.Resources; FluxIntegratedPerLayout leaked into the FluxSeparate path", preInstall.Name)
 	}
 	if augHasCR(app.Resources, hooks.Name) {
-		t.Errorf("FluxSeparate emitted a Kustomization CR for augmenter child %q at app.Resources; FluxIntegrated leaked into the FluxSeparate path", hooks.Name)
+		t.Errorf("FluxSeparate emitted a Kustomization CR for augmenter child %q at app.Resources; FluxIntegratedPerLayout leaked into the FluxSeparate path", hooks.Name)
 	}
 }
 
-// testSR returns a minimal valid SourceRef for use in FluxIntegrated fixtures.
+// testSR returns a minimal valid SourceRef for use in FluxIntegratedPerLayout fixtures.
 func testSR() *stack.SourceRef {
 	return &stack.SourceRef{Kind: "GitRepository", Name: "flux-system", Namespace: "flux-system"}
 }

--- a/pkg/stack/fluxcd/resource_generator.go
+++ b/pkg/stack/fluxcd/resource_generator.go
@@ -310,7 +310,7 @@ func (g *ResourceGenerator) createKustomization(b *stack.Bundle) client.Object {
 }
 
 // createKustomizationForLayout creates a Flux Kustomization CR for a
-// ManifestLayout child in FluxIntegrated mode. The CR name equals ml.Name;
+// ManifestLayout child in FluxIntegratedPerLayout mode. The CR name equals ml.Name;
 // spec.path is ml.FullRepoPath(); spec.dependsOn is populated from ml.DependsOn.
 func (g *ResourceGenerator) createKustomizationForLayout(
 	ml *layout.ManifestLayout,

--- a/pkg/stack/fluxcd/validate.go
+++ b/pkg/stack/fluxcd/validate.go
@@ -47,7 +47,7 @@ func validateBundleSourceRefs(b *stack.Bundle) error {
 	if b.SourceRef == nil || b.SourceRef.Kind == "" || b.SourceRef.Name == "" {
 		return errors.ResourceValidationError(
 			"Bundle", b.Name, "sourceRef",
-			"FluxIntegrated mode requires a SourceRef with Kind and Name; "+
+			"FluxIntegratedPerLayout mode requires a SourceRef with Kind and Name; "+
 				"omitting it produces a Kustomization CR without spec.sourceRef, which Flux rejects",
 			nil,
 		)

--- a/pkg/stack/layout/README.md
+++ b/pkg/stack/layout/README.md
@@ -20,7 +20,7 @@ The layout module transforms Kure's in-memory stack representation (Clusters →
 - **BundleGrouping**: How bundles within nodes are organized  
 - **ApplicationGrouping**: How applications within bundles are organized
 - **FilePer**: How resources are written (FilePerResource vs FilePerKind)
-- **FluxPlacement**: Where Flux Kustomizations go (FluxSeparate vs FluxIntegrated)
+- **FluxPlacement**: Where/at what granularity Flux Kustomizations go — `FluxSeparate`, `FluxIntegratedPerLayout` (a CR per layout node), or `FluxIntegratedPerBundle` (CRs at bundle boundaries; children included as directories)
 - **FileNaming**: Resource file naming pattern (see [File Naming Modes](#file-naming-modes))
 - **ClusterName**: Optional cluster name prefix for cluster-aware directory paths
 
@@ -77,7 +77,7 @@ clusters/
 - Uses `spec.path: ./clusters/cluster-name/node` format
 - Auto-generates kustomization.yaml files
 - Supports recursive discovery of manifests
-- Handles FluxSeparate vs FluxIntegrated placement modes
+- Handles FluxSeparate vs FluxIntegratedPerLayout placement modes
 
 ### ArgoCD Integration  
 - Uses `spec.source.path: clusters/cluster-name/node` format
@@ -128,11 +128,11 @@ When `app.Config` implements it, the walker invokes `AugmentLayout` on the per-a
 
 #### Sub-Layout Children and Flux Integration
 
-Augmenters may attach sub-layouts as `Children` of a per-app `ManifestLayout`. In `FluxIntegrated` mode each such child that is eligible (see below) receives a Flux `Kustomization` CR automatically placed in the parent layout's `Resources`.
+Augmenters may attach sub-layouts as `Children` of a per-app `ManifestLayout`. In `FluxIntegratedPerLayout` mode each such child that is eligible (see below) receives a Flux `Kustomization` CR automatically placed in the parent layout's `Resources`.
 
 **Eligibility for CR generation.** A child layout receives a Flux `Kustomization` CR when ALL of the following hold:
 
-- The ancestor node bundle's layout operates in `FluxIntegrated` mode.
+- The ancestor node bundle's layout operates in `FluxIntegratedPerLayout` mode.
 - `!child.UmbrellaChild`
 - `child.ApplicationFileMode != AppFileSingle`
 - The ancestor bundle has a non-nil, non-empty `SourceRef` with both `Kind` and `Name` set. A nil, empty struct, or incomplete `SourceRef` (missing either field) causes `IntegrateWithLayout` to return a hard error — a `Kustomization` without `spec.sourceRef` is rejected by Flux.
@@ -141,13 +141,13 @@ This rule mirrors exactly what the writers use to emit `flux-system-kustomizatio
 
 #### Naming Constraint
 
-Child layout `Name` is used as the Flux `Kustomization` CR name in `FluxIntegrated` mode (matching the filename emitted by the writers: `flux-system-kustomization-{child.Name}.yaml`). Flux `Kustomization` CRs live in the `flux-system` namespace, so names must be **globally unique across all apps in the cluster** — two CRs with the same `metadata.name` collide.
+Child layout `Name` is used as the Flux `Kustomization` CR name in `FluxIntegratedPerLayout` mode (matching the filename emitted by the writers: `flux-system-kustomization-{child.Name}.yaml`). Flux `Kustomization` CRs live in the `flux-system` namespace, so names must be **globally unique across all apps in the cluster** — two CRs with the same `metadata.name` collide.
 
 Augmenters are responsible for ensuring uniqueness. The recommended convention is to prefix each child name with the app name: `{appName}-{hookGroupDir}` (e.g. `nginx-00-pre-install`).
 
 #### DependsOn
 
-Set `ManifestLayout.DependsOn` to a list of sibling layout names. In `FluxIntegrated` mode the layout integrator translates these into `spec.dependsOn` entries on the child's `Kustomization` CR, enabling ordered reconciliation between hook groups (e.g. pre-install → hooks → post-install).
+Set `ManifestLayout.DependsOn` to a list of sibling layout names. In `FluxIntegratedPerLayout` mode the layout integrator translates these into `spec.dependsOn` entries on the child's `Kustomization` CR, enabling ordered reconciliation between hook groups (e.g. pre-install → hooks → post-install).
 
 ### ClusterName-Aware Layouts
 
@@ -168,7 +168,7 @@ Conservative collapse preconditions — ALL must hold:
 
 Multi-tier apps with sub-Kustomizations are unaffected: the precondition that the child be terminal preserves them. Empty containers (`only-Children`) are also unaffected: the precondition requiring the parent to have no own resources doesn't apply to them.
 
-When the layout participates in Flux integration, the flatten helper records redirect tables (`nodeAliases` for `findLayoutNode` lookups, `pathRewrites` for `Spec.Path` rewriting). `IntegrateWithLayout` consults the aliases during integrated placement and calls `ApplyFlattenPathRewrites(root)` before returning, regardless of placement mode (FluxIntegrated or FluxSeparate). Direct callers using `WalkCluster` + `IntegrateWithLayout` (without going through `CreateLayoutWithResources`) get the rewrite for free.
+When the layout participates in Flux integration, the flatten helper records redirect tables (`nodeAliases` for `findLayoutNode` lookups, `pathRewrites` for `Spec.Path` rewriting). `IntegrateWithLayout` consults the aliases during integrated placement and calls `ApplyFlattenPathRewrites(root)` before returning, regardless of placement mode (FluxIntegratedPerLayout or FluxSeparate). Direct callers using `WalkCluster` + `IntegrateWithLayout` (without going through `CreateLayoutWithResources`) get the rewrite for free.
 
 Scoped to `WalkCluster`. `WalkClusterByPackage` is unaffected — its synthetic unnamed wrappers express package boundaries that the flatten helper would otherwise erroneously collapse.
 
@@ -182,7 +182,7 @@ Three named presets provide pre-configured LayoutRules for common deployment pat
 |--------|---------|---------------|--------------|------------|
 | `CentralizedControlPlane` | A | FluxSeparate | GroupFlat | FileNamingKindName |
 | `SiblingControlPlane` | B | FluxSeparate | GroupByName | FileNamingDefault |
-| `ParentDeployedControl` | C | FluxIntegrated | GroupByName | FileNamingDefault |
+| `ParentDeployedControl` | C | FluxIntegratedPerLayout | GroupByName | FileNamingDefault |
 
 ```go
 rules, err := layout.LayoutRulesForPreset(layout.PresetCentralizedControlPlane)

--- a/pkg/stack/layout/config_test.go
+++ b/pkg/stack/layout/config_test.go
@@ -59,13 +59,13 @@ func TestResolveKustomizationMode_PerFluxPlacement(t *testing.T) {
 	cfg := layout.Config{
 		KustomizationMode: layout.KustomizationExplicit,
 		FluxKustomizationMode: map[layout.FluxPlacement]layout.KustomizationMode{
-			layout.FluxIntegrated: layout.KustomizationRecursive,
+			layout.FluxIntegratedPerLayout: layout.KustomizationRecursive,
 		},
 	}
-	// FluxIntegrated should use the override
-	mode := cfg.ResolveKustomizationMode(layout.FluxIntegrated)
+	// FluxIntegratedPerLayout should use the override
+	mode := cfg.ResolveKustomizationMode(layout.FluxIntegratedPerLayout)
 	if mode != layout.KustomizationRecursive {
-		t.Errorf("expected KustomizationRecursive for FluxIntegrated, got %s", mode)
+		t.Errorf("expected KustomizationRecursive for FluxIntegratedPerLayout, got %s", mode)
 	}
 	// FluxSeparate should fall back to global
 	mode = cfg.ResolveKustomizationMode(layout.FluxSeparate)

--- a/pkg/stack/layout/manifest.go
+++ b/pkg/stack/layout/manifest.go
@@ -43,7 +43,7 @@ type ManifestLayout struct {
 	// the child's own directory.
 	UmbrellaChild bool
 	// DependsOn lists sibling layout names whose Kustomization CRs must reconcile
-	// before this layout's CR. In FluxIntegrated mode the layout integrator
+	// before this layout's CR. In FluxIntegratedPerLayout mode the layout integrator
 	// translates these into spec.dependsOn on the emitted Kustomization CR.
 	// Augmenters (LayoutAugmenter) set this field; the integrator reads it.
 	DependsOn []string
@@ -63,7 +63,7 @@ type ManifestLayout struct {
 // layout-tree paths (cluster-name-prefixed); a single map cannot serve both.
 type flattenInfo struct {
 	// nodeAliases maps node.GetPath() of the collapsed child node to the
-	// absorbing layout. Used by findLayoutNode (FluxIntegrated mode only).
+	// absorbing layout. Used by findLayoutNode (FluxIntegratedPerLayout mode only).
 	nodeAliases map[string]*ManifestLayout
 	// pathRewrites maps pre-collapse layout repo path → post-collapse layout
 	// repo path. Used to rewrite Spec.Path strings on Flux Kustomization
@@ -360,7 +360,7 @@ func (ml *ManifestLayout) WriteToDisk(basePath string) error {
 			if child.UmbrellaChild {
 				// Umbrella children are not referenced from the parent
 				// kustomization.yaml's Children loop:
-				//   - FluxIntegrated: the child's Kustomization CR is
+				//   - FluxIntegratedPerLayout: the child's Kustomization CR is
 				//     already in ml.Resources (placed there by the
 				//     LayoutIntegrator), so the Resources loop above
 				//     emits the filename exactly once.
@@ -374,8 +374,8 @@ func (ml *ManifestLayout) WriteToDisk(basePath string) error {
 			}
 			if child.ApplicationFileMode == AppFileSingle {
 				writeStr(fmt.Sprintf("  - %s.yaml\n", child.Name))
-			} else if ml.FluxPlacement == FluxIntegrated {
-				// FluxIntegrated: reference Flux Kustomization YAML files.
+			} else if ml.FluxPlacement == FluxIntegratedPerLayout {
+				// FluxIntegratedPerLayout: reference Flux Kustomization YAML files.
 				// Use FilePerResource to force per-resource naming even when
 				// the parent directory uses FilePerKind.
 				nameFn := ml.resolveManifestFileName()

--- a/pkg/stack/layout/preset.go
+++ b/pkg/stack/layout/preset.go
@@ -57,7 +57,7 @@ func LayoutRulesForPreset(p LayoutPreset) (LayoutRules, error) {
 			ApplicationGrouping: GroupFlat,
 			ApplicationFileMode: AppFilePerResource,
 			FilePer:             FilePerResource,
-			FluxPlacement:       FluxIntegrated,
+			FluxPlacement:       FluxIntegratedPerLayout,
 		}, nil
 
 	default:

--- a/pkg/stack/layout/preset_test.go
+++ b/pkg/stack/layout/preset_test.go
@@ -55,8 +55,8 @@ func TestLayoutRulesForPreset_ParentDeployedControl(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if rules.FluxPlacement != FluxIntegrated {
-		t.Errorf("expected FluxPlacement=%s, got %s", FluxIntegrated, rules.FluxPlacement)
+	if rules.FluxPlacement != FluxIntegratedPerLayout {
+		t.Errorf("expected FluxPlacement=%s, got %s", FluxIntegratedPerLayout, rules.FluxPlacement)
 	}
 
 	if err := rules.Validate(); err != nil {

--- a/pkg/stack/layout/tar.go
+++ b/pkg/stack/layout/tar.go
@@ -125,7 +125,7 @@ func (ml *ManifestLayout) writeToTarRecursive(tw *tar.Writer, basePath string) e
 			if child.UmbrellaChild {
 				// Umbrella children are not referenced from the parent
 				// kustomization.yaml's Children loop:
-				//   - FluxIntegrated: the child's Kustomization CR is
+				//   - FluxIntegratedPerLayout: the child's Kustomization CR is
 				//     already in ml.Resources (placed there by the
 				//     LayoutIntegrator), so the Resources loop above
 				//     emits the filename exactly once.
@@ -139,8 +139,8 @@ func (ml *ManifestLayout) writeToTarRecursive(tw *tar.Writer, basePath string) e
 			}
 			if child.ApplicationFileMode == AppFileSingle {
 				kustomBuf.WriteString(fmt.Sprintf("  - %s.yaml\n", child.Name))
-			} else if ml.FluxPlacement == FluxIntegrated {
-				// FluxIntegrated: reference Flux Kustomization YAML files.
+			} else if ml.FluxPlacement == FluxIntegratedPerLayout {
+				// FluxIntegratedPerLayout: reference Flux Kustomization YAML files.
 				// Always use FilePerResource here — each child must have a
 				// unique filename; FilePerKind would drop child.Name.
 				fluxKustName := nameFn("flux-system", "kustomization", child.Name, FilePerResource)

--- a/pkg/stack/layout/tar_test.go
+++ b/pkg/stack/layout/tar_test.go
@@ -158,7 +158,7 @@ func TestWriteToTar_FluxIntegrated(t *testing.T) {
 	root := &ManifestLayout{
 		Name:          "flux-root",
 		Namespace:     "cl/flux-system",
-		FluxPlacement: FluxIntegrated,
+		FluxPlacement: FluxIntegratedPerLayout,
 		FilePer:       FilePerResource,
 		Mode:          KustomizationExplicit,
 		Children:      []*ManifestLayout{child},
@@ -182,7 +182,7 @@ func TestWriteToTar_FluxIntegrated(t *testing.T) {
 
 func TestWriteToTar_UmbrellaChild(t *testing.T) {
 	// Mirrors the layout produced by the Flux LayoutIntegrator in
-	// FluxIntegrated mode: the umbrella parent carries the child's
+	// FluxIntegratedPerLayout mode: the umbrella parent carries the child's
 	// Kustomization CR in Resources (placed there by placeUmbrellaChildrenFlux),
 	// and an UmbrellaChild sub-layout in Children (carrying the child's
 	// workloads). Verifies:
@@ -341,7 +341,7 @@ func TestWriteToTar_FileNamingKindName_FluxIntegrated(t *testing.T) {
 	root := &ManifestLayout{
 		Name:          "flux-root",
 		Namespace:     "cl/flux-system",
-		FluxPlacement: FluxIntegrated,
+		FluxPlacement: FluxIntegratedPerLayout,
 		FilePer:       FilePerResource,
 		FileNaming:    FileNamingKindName,
 		Mode:          KustomizationExplicit,
@@ -372,7 +372,7 @@ func TestWriteToTar_FileNamingKindName_FluxIntegrated(t *testing.T) {
 }
 
 func TestWriteToTar_FilePerKind_FluxIntegrated(t *testing.T) {
-	// Regression: FilePerKind must not collapse FluxIntegrated kustomization
+	// Regression: FilePerKind must not collapse FluxIntegratedPerLayout kustomization
 	// references — each child needs a unique filename including child.Name.
 	childA := &ManifestLayout{
 		Name:      "team-a",
@@ -402,7 +402,7 @@ func TestWriteToTar_FilePerKind_FluxIntegrated(t *testing.T) {
 	root := &ManifestLayout{
 		Name:          "flux-root",
 		Namespace:     "cl/flux-system",
-		FluxPlacement: FluxIntegrated,
+		FluxPlacement: FluxIntegratedPerLayout,
 		FilePer:       FilePerKind,
 		Mode:          KustomizationExplicit,
 		Children:      []*ManifestLayout{childA, childB},
@@ -751,12 +751,12 @@ func TestWriteToTar_NoDuplicateFluxEntries(t *testing.T) {
 	child := &ManifestLayout{
 		Name:          "myapp",
 		Namespace:     "prod/apps/myapp",
-		FluxPlacement: FluxIntegrated,
+		FluxPlacement: FluxIntegratedPerLayout,
 	}
 	parent := &ManifestLayout{
 		Name:          "prod",
 		Namespace:     "cl",
-		FluxPlacement: FluxIntegrated,
+		FluxPlacement: FluxIntegratedPerLayout,
 		Resources:     []client.Object{cr},
 		Children:      []*ManifestLayout{child},
 	}

--- a/pkg/stack/layout/types.go
+++ b/pkg/stack/layout/types.go
@@ -79,8 +79,19 @@ type FluxPlacement string
 const (
 	// FluxSeparate places all Flux Kustomizations in a separate directory.
 	FluxSeparate FluxPlacement = "separate"
-	// FluxIntegrated distributes Flux Kustomizations across their target nodes.
-	FluxIntegrated FluxPlacement = "integrated"
+	// FluxIntegratedPerLayout places a Flux Kustomization CR inline for every
+	// layout node, including augmenter-added child layouts. Children are
+	// referenced from the parent kustomization.yaml as kustomization-<child>.yaml
+	// CR files. Finest granularity; use when each child should be reconciled by
+	// its own Flux Kustomization (e.g. hook-group dependsOn).
+	FluxIntegratedPerLayout FluxPlacement = "integrated"
+	// FluxIntegratedPerBundle places Flux Kustomization CRs inline at bundle/node
+	// boundaries only; a bundle's interior (including augmenter-added child
+	// layouts) is a single kustomize build, with children referenced as
+	// directories. Coarser than PerLayout: Flux reconciles per bundle, kustomize
+	// handles the interior. Use when the unit of Flux reconciliation is the
+	// bundle, not each layout node.
+	FluxIntegratedPerBundle FluxPlacement = "integrated-per-bundle"
 	// FluxUnset indicates no flux placement preference.
 	FluxUnset FluxPlacement = ""
 )
@@ -187,10 +198,10 @@ func (lr LayoutRules) Validate() error {
 	}
 
 	switch lr.FluxPlacement {
-	case FluxSeparate, FluxIntegrated, FluxUnset:
+	case FluxSeparate, FluxIntegratedPerLayout, FluxIntegratedPerBundle, FluxUnset:
 		// valid
 	default:
-		return errors.NewValidationError("FluxPlacement", string(lr.FluxPlacement), "LayoutRules", []string{string(FluxSeparate), string(FluxIntegrated)})
+		return errors.NewValidationError("FluxPlacement", string(lr.FluxPlacement), "LayoutRules", []string{string(FluxSeparate), string(FluxIntegratedPerLayout), string(FluxIntegratedPerBundle)})
 	}
 
 	switch lr.FileNaming {

--- a/pkg/stack/layout/types_test.go
+++ b/pkg/stack/layout/types_test.go
@@ -44,7 +44,7 @@ func TestLayoutRules_Validate(t *testing.T) {
 				ApplicationGrouping: layout.GroupByName,
 				ApplicationFileMode: layout.AppFileSingle,
 				FilePer:             layout.FilePerKind,
-				FluxPlacement:       layout.FluxIntegrated,
+				FluxPlacement:       layout.FluxIntegratedPerLayout,
 			},
 			wantErr: false,
 		},

--- a/pkg/stack/layout/write.go
+++ b/pkg/stack/layout/write.go
@@ -154,7 +154,7 @@ func WriteManifest(basePath string, cfg Config, ml *ManifestLayout) error {
 			if child.UmbrellaChild {
 				// Umbrella children are not referenced from the parent
 				// kustomization.yaml's Children loop:
-				//   - FluxIntegrated: the child's Kustomization CR is
+				//   - FluxIntegratedPerLayout: the child's Kustomization CR is
 				//     already in ml.Resources (placed there by the
 				//     LayoutIntegrator), so the Resources loop above
 				//     emits the filename exactly once.
@@ -169,9 +169,9 @@ func WriteManifest(basePath string, cfg Config, ml *ManifestLayout) error {
 			if child.ApplicationFileMode == AppFileSingle {
 				writeStr(fmt.Sprintf("  - %s.yaml\n", child.Name))
 			} else {
-				// For FluxIntegrated mode, reference Flux Kustomization YAML files instead of directories.
+				// For FluxIntegratedPerLayout mode, reference Flux Kustomization YAML files instead of directories.
 				// Always use FilePerResource — each child must have a unique filename.
-				if ml.FluxPlacement == FluxIntegrated {
+				if ml.FluxPlacement == FluxIntegratedPerLayout {
 					fluxKustName := manifestFileName("flux-system", "kustomization", child.Name, FilePerResource)
 					if _, dup := listedInResources[fluxKustName]; !dup {
 						writeStr(fmt.Sprintf("  - %s\n", fluxKustName))

--- a/pkg/stack/layout/write_test.go
+++ b/pkg/stack/layout/write_test.go
@@ -449,7 +449,7 @@ func TestWriteManifest_FluxIntegrated(t *testing.T) {
 	root := &ManifestLayout{
 		Name:          "flux-root",
 		Namespace:     "cl/flux-system",
-		FluxPlacement: FluxIntegrated,
+		FluxPlacement: FluxIntegratedPerLayout,
 		Children:      []*ManifestLayout{childA, childB},
 	}
 
@@ -467,7 +467,7 @@ func TestWriteManifest_FluxIntegrated(t *testing.T) {
 	}
 
 	content := string(data)
-	// FluxIntegrated: children referenced as flux-system-kustomization-<name>.yaml
+	// FluxIntegratedPerLayout: children referenced as flux-system-kustomization-<name>.yaml
 	if !strings.Contains(content, "flux-system-kustomization-team-a.yaml") {
 		t.Errorf("expected flux kustomization reference for team-a, got:\n%s", content)
 	}
@@ -537,7 +537,7 @@ func TestWriteToDisk_FluxIntegrated(t *testing.T) {
 	root := &ManifestLayout{
 		Name:          "flux-root",
 		Namespace:     "cl/flux-system",
-		FluxPlacement: FluxIntegrated,
+		FluxPlacement: FluxIntegratedPerLayout,
 		Children:      []*ManifestLayout{childA, childB},
 	}
 
@@ -553,7 +553,7 @@ func TestWriteToDisk_FluxIntegrated(t *testing.T) {
 	}
 
 	content := string(data)
-	// FluxIntegrated: children referenced as flux-system-kustomization-<name>.yaml
+	// FluxIntegratedPerLayout: children referenced as flux-system-kustomization-<name>.yaml
 	if !strings.Contains(content, "flux-system-kustomization-team-a.yaml") {
 		t.Errorf("expected flux kustomization reference for team-a, got:\n%s", content)
 	}
@@ -743,7 +743,7 @@ func TestWriteManifest_FileNamingDefault_Unchanged(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestWriteManifest_FluxKustomizationMode_PerPlacement(t *testing.T) {
-	// Parent with FluxIntegrated, child with resources
+	// Parent with FluxIntegratedPerLayout, child with resources
 	child := &ManifestLayout{
 		Name:      "team-a",
 		Namespace: "cl/ns/root/team-a",
@@ -756,14 +756,14 @@ func TestWriteManifest_FluxKustomizationMode_PerPlacement(t *testing.T) {
 	root := &ManifestLayout{
 		Name:          "root",
 		Namespace:     "cl/ns",
-		FluxPlacement: FluxIntegrated,
+		FluxPlacement: FluxIntegratedPerLayout,
 		Resources:     []client.Object{testObject("v1", "ConfigMap", "root-cfg", "ns")},
 		Children:      []*ManifestLayout{child},
 	}
 
 	cfg := DefaultLayoutConfig()
 	cfg.FluxKustomizationMode = map[FluxPlacement]KustomizationMode{
-		FluxIntegrated: KustomizationRecursive,
+		FluxIntegratedPerLayout: KustomizationRecursive,
 	}
 	dir := t.TempDir()
 
@@ -815,7 +815,7 @@ func TestWriteManifest_FluxKustomizationMode_NoOverride(t *testing.T) {
 
 	cfg := DefaultLayoutConfig()
 	cfg.FluxKustomizationMode = map[FluxPlacement]KustomizationMode{
-		FluxIntegrated: KustomizationRecursive,
+		FluxIntegratedPerLayout: KustomizationRecursive,
 	}
 	dir := t.TempDir()
 
@@ -951,7 +951,7 @@ func TestWriteToDisk_KustomizationGenerated(t *testing.T) {
 
 func TestWriteManifest_UmbrellaChild(t *testing.T) {
 	// Mirrors the layout produced by the Flux LayoutIntegrator in
-	// FluxIntegrated mode: the parent carries the child's Kustomization CR
+	// FluxIntegratedPerLayout mode: the parent carries the child's Kustomization CR
 	// in Resources (via placeUmbrellaChildrenFlux) and an UmbrellaChild
 	// sub-layout in Children. Asserts the parent kustomization.yaml
 	// references the child CR filename exactly once (no duplication), and
@@ -1036,7 +1036,7 @@ func TestWriteManifest_FileNamingKindName_FluxIntegrated(t *testing.T) {
 	root := &ManifestLayout{
 		Name:          "flux-root",
 		Namespace:     "cl/flux-system",
-		FluxPlacement: FluxIntegrated,
+		FluxPlacement: FluxIntegratedPerLayout,
 		FileNaming:    FileNamingKindName,
 		Children:      []*ManifestLayout{child},
 	}
@@ -1222,7 +1222,7 @@ func TestWriteToDisk_FileNamingKindName_FluxIntegrated(t *testing.T) {
 	root := &ManifestLayout{
 		Name:          "flux-root",
 		Namespace:     "cl/flux-system",
-		FluxPlacement: FluxIntegrated,
+		FluxPlacement: FluxIntegratedPerLayout,
 		FilePer:       FilePerResource,
 		FileNaming:    FileNamingKindName,
 		Mode:          KustomizationExplicit,
@@ -1257,11 +1257,11 @@ func TestWriteManifest_NoDuplicateFluxEntries(t *testing.T) {
 	child := &ManifestLayout{
 		Name:          "myapp",
 		Namespace:     "clusters/prod/apps/myapp",
-		FluxPlacement: FluxIntegrated,
+		FluxPlacement: FluxIntegratedPerLayout,
 	}
 	parent := &ManifestLayout{
 		Name:          "prod",
-		FluxPlacement: FluxIntegrated,
+		FluxPlacement: FluxIntegratedPerLayout,
 		Resources:     []client.Object{cr},
 		Children:      []*ManifestLayout{child},
 	}
@@ -1290,12 +1290,12 @@ func TestWriteToDisk_NoDuplicateFluxEntries(t *testing.T) {
 	child := &ManifestLayout{
 		Name:          "myapp",
 		Namespace:     "prod/apps/myapp",
-		FluxPlacement: FluxIntegrated,
+		FluxPlacement: FluxIntegratedPerLayout,
 	}
 	parent := &ManifestLayout{
 		Name:          "prod",
 		Namespace:     "cl",
-		FluxPlacement: FluxIntegrated,
+		FluxPlacement: FluxIntegratedPerLayout,
 		Resources:     []client.Object{cr},
 		Children:      []*ManifestLayout{child},
 	}

--- a/site/content/guides/flux-workflow.md
+++ b/site/content/guides/flux-workflow.md
@@ -115,7 +115,7 @@ The [Layout Engine](/api-reference/layout) supports multiple grouping and file o
 | BundleGrouping | `GroupByName`, `GroupFlat` | Create subdirectories per bundle or flatten |
 | ApplicationGrouping | `GroupByName`, `GroupFlat` | Create subdirectories per app or flatten |
 | FilePer | `FilePerResource`, `FilePerKind` | One file per resource or group by kind |
-| FluxPlacement | `FluxSeparate`, `FluxIntegratedPerLayout` | Separate or inline Flux resources |
+| FluxPlacement | `FluxSeparate`, `FluxIntegratedPerLayout`, `FluxIntegratedPerBundle` | Separate dir; a Flux CR per layout node; or Flux CRs at bundle boundaries with children as directories |
 
 ## Umbrella Bundles — Readiness Aggregation
 
@@ -213,7 +213,7 @@ A child layout receives a CR when:
 - `child.ApplicationFileMode != AppFileSingle`
 - The ancestor bundle's `SourceRef` has both `Kind` and `Name` set (nil, empty struct, or missing either field is a hard error — a `Kustomization` without `spec.sourceRef` is invalid)
 
-`CreateLayoutWithResources` validates SourceRef completeness for all bundles before layout walking. Both the node bundle and every umbrella child bundle must have `SourceRef.Kind` and `SourceRef.Name` set when `FluxIntegratedPerLayout` mode is active. `FluxSeparate` and non-Flux callers are unaffected.
+`CreateLayoutWithResources` validates SourceRef completeness for all bundles before layout walking. Both the node bundle and every umbrella child bundle must have `SourceRef.Kind` and `SourceRef.Name` set when either inline mode (`FluxIntegratedPerLayout` or `FluxIntegratedPerBundle`) is active — both emit bundle/node CRs carrying a `spec.sourceRef`. `FluxSeparate` and non-Flux callers are unaffected.
 
 ### Ordered reconciliation with DependsOn
 

--- a/site/content/guides/flux-workflow.md
+++ b/site/content/guides/flux-workflow.md
@@ -115,7 +115,7 @@ The [Layout Engine](/api-reference/layout) supports multiple grouping and file o
 | BundleGrouping | `GroupByName`, `GroupFlat` | Create subdirectories per bundle or flatten |
 | ApplicationGrouping | `GroupByName`, `GroupFlat` | Create subdirectories per app or flatten |
 | FilePer | `FilePerResource`, `FilePerKind` | One file per resource or group by kind |
-| FluxPlacement | `FluxSeparate`, `FluxIntegrated` | Separate or inline Flux resources |
+| FluxPlacement | `FluxSeparate`, `FluxIntegratedPerLayout` | Separate or inline Flux resources |
 
 ## Umbrella Bundles — Readiness Aggregation
 
@@ -174,7 +174,7 @@ the `Bundle` of a `stack.Node` and appear in another bundle's `Children`.
 
 ### Disk layout
 
-In `FluxIntegrated` placement, the umbrella children's Flux Kustomization CRs
+In `FluxIntegratedPerLayout` placement, the umbrella children's Flux Kustomization CRs
 live alongside the parent's, and the parent's `kustomization.yaml` references
 each child via the CR file (not the child subdirectory):
 
@@ -204,7 +204,7 @@ flat list.
 
 ## Augmenter-Added Child Layouts
 
-A `LayoutAugmenter` can attach sub-`ManifestLayout` children to a per-app layout after resource generation. In `FluxIntegrated` mode kure automatically emits a Flux `Kustomization` CR for each eligible child.
+A `LayoutAugmenter` can attach sub-`ManifestLayout` children to a per-app layout after resource generation. In `FluxIntegratedPerLayout` mode kure automatically emits a Flux `Kustomization` CR for each eligible child.
 
 ### Eligibility
 
@@ -213,7 +213,7 @@ A child layout receives a CR when:
 - `child.ApplicationFileMode != AppFileSingle`
 - The ancestor bundle's `SourceRef` has both `Kind` and `Name` set (nil, empty struct, or missing either field is a hard error — a `Kustomization` without `spec.sourceRef` is invalid)
 
-`CreateLayoutWithResources` validates SourceRef completeness for all bundles before layout walking. Both the node bundle and every umbrella child bundle must have `SourceRef.Kind` and `SourceRef.Name` set when `FluxIntegrated` mode is active. `FluxSeparate` and non-Flux callers are unaffected.
+`CreateLayoutWithResources` validates SourceRef completeness for all bundles before layout walking. Both the node bundle and every umbrella child bundle must have `SourceRef.Kind` and `SourceRef.Name` set when `FluxIntegratedPerLayout` mode is active. `FluxSeparate` and non-Flux callers are unaffected.
 
 ### Ordered reconciliation with DependsOn
 


### PR DESCRIPTION
## Summary

Adds a third `FluxPlacement` value, `FluxIntegratedPerBundle`, that places Flux Kustomization CRs at **bundle/node boundaries only**. A bundle's interior (including augmenter-added child layouts) becomes a single kustomize build, with children referenced as **directories** — coarser than `FluxIntegratedPerLayout`, which emits a Flux CR for every layout node.

## Why

Consumers that assemble layouts in two phases — e.g. crane's stack-compile, which reparents app payloads and renames the inner CRs (`patchInnerKustomizations`) *after* the integrator runs — cannot use per-layout granularity: the integrator's per-child CRs get collapsed onto the app's umbrella name, producing duplicate CRs and dangling `kustomization-<child>.yaml` references that `kustomize build` rejects. Per-bundle restores the directory-include shape that works cleanly.

Full analysis: crane `docs/design/fluxcd-layout-integration.md`.

## Changes

- `types.go`: new `FluxIntegratedPerBundle` value; `LayoutRules.Validate` accepts it; `DefaultLayoutRules` stays `FluxSeparate`.
- `layout_integrator.go`: route the new value to integrated (inline) placement but **skip** the per-child CR emission (`eligibleChildren` + the #578 umbrella-children loop). The SourceRef validation gate now fires for **both** inline modes (both emit bundle CRs carrying a `sourceRef`).
- writers (`manifest.go`/`write.go`/`tar.go`): no new branching — any non-`PerLayout` value falls through to directory references.
- docs: package READMEs + flux-workflow guide updated with the three-mode contract.

## BREAKING CHANGE

`FluxPlacement` value `FluxIntegrated` is renamed to `FluxIntegratedPerLayout` (string value `"integrated"` unchanged). No external consumers besides crane (verified). Update `layout.FluxIntegrated` → `layout.FluxIntegratedPerLayout`.

## Test plan

- [x] New PerBundle tests: no per-child CRs emitted; writer references children as directories (incl. `WriteToTar`); SourceRef gate rejects missing SourceRef in PerBundle.
- [x] Existing FluxIntegrated(PerLayout) tests unchanged and green.
- [x] `mise run test` passes; coverage: layout 90.4%, fluxcd 92.8% (above the 90% gate).
- [x] `mise run lint` clean.
- [x] Validated end-to-end against crane via go.work: stack-compile dangling refs eliminated (0), app.compile unaffected.