### PR TITLE
fix(layout): collapse cluster-name double-nesting when ClusterName == root node name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
+    rebase-strategy: "auto"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -57,6 +58,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    rebase-strategy: "auto"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/pkg/stack/fluxcd/layout_integrator_test.go
+++ b/pkg/stack/fluxcd/layout_integrator_test.go
@@ -1426,3 +1426,71 @@ func TestIntegrateWithLayout_RulesFluxSeparate_NoDuplicateChildCRs(t *testing.T)
 func testSR() *stack.SourceRef {
 	return &stack.SourceRef{Kind: "GitRepository", Name: "flux-system", Namespace: "flux-system"}
 }
+
+// collectKustPaths walks a layout tree and maps every Flux Kustomization CR's
+// name to its Spec.Path.
+func collectKustPaths(ml *layout.ManifestLayout, out map[string]string) {
+	if ml == nil {
+		return
+	}
+	for _, r := range ml.Resources {
+		if k, ok := r.(*kustv1.Kustomization); ok {
+			out[k.Name] = k.Spec.Path
+		}
+	}
+	for _, c := range ml.Children {
+		collectKustPaths(c, out)
+	}
+}
+
+// TestCreateLayoutWithResources_ClusterNameEqualsNodeName_SpecPath is the
+// crane#239 Flux-integration guard: with ClusterName == root Node.Name and an
+// umbrella bundle (multi-tier app), the emitted Flux Kustomization spec.path
+// values must collapse to a single <name>/ level (not <name>/<name>/), matching
+// the written directories.
+func TestCreateLayoutWithResources_ClusterNameEqualsNodeName_SpecPath(t *testing.T) {
+	umbrella := &stack.Bundle{
+		Name:      "platform",
+		SourceRef: testSR(),
+		Children: []*stack.Bundle{
+			{Name: "platform-services", SourceRef: testSR()},
+			{Name: "platform-apps", SourceRef: testSR()},
+		},
+	}
+	cluster := &stack.Cluster{Name: "platform", Node: &stack.Node{Name: "platform", Bundle: umbrella}}
+
+	integrator := fluxstack.NewLayoutIntegrator(fluxstack.NewResourceGenerator())
+	ml, err := integrator.CreateLayoutWithResources(cluster, layout.LayoutRules{
+		ClusterName:         "platform", // == root Node.Name
+		BundleGrouping:      layout.GroupByName,
+		ApplicationGrouping: layout.GroupByName,
+		FluxPlacement:       layout.FluxIntegratedPerLayout,
+	})
+	if err != nil {
+		t.Fatalf("CreateLayoutWithResources: %v", err)
+	}
+
+	paths := map[string]string{}
+	collectKustPaths(ml, paths)
+
+	want := map[string]string{
+		"platform":          "platform",
+		"platform-services": "platform/platform-services",
+		"platform-apps":     "platform/platform-apps",
+	}
+	for name, exp := range want {
+		got, ok := paths[name]
+		if !ok {
+			t.Errorf("missing Flux Kustomization CR %q (got: %v)", name, paths)
+			continue
+		}
+		if got != exp {
+			t.Errorf("Kustomization %q spec.path = %q, want %q", name, got, exp)
+		}
+	}
+	for name, p := range paths {
+		if p == "platform/platform" || strings.HasPrefix(p, "platform/platform/") {
+			t.Errorf("Kustomization %q has double-nested spec.path %q (crane#239 regression)", name, p)
+		}
+	}
+}

--- a/pkg/stack/layout/walker.go
+++ b/pkg/stack/layout/walker.go
@@ -2,6 +2,7 @@ package layout
 
 import (
 	"path/filepath"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -9,6 +10,19 @@ import (
 	"github.com/go-kure/kure/pkg/errors"
 	"github.com/go-kure/kure/pkg/stack"
 )
+
+// layoutPathSegments splits a layout's canonical repo path into directory
+// segments for use as the ancestor path of its descendants. FullRepoPath()
+// returns slash-normalised paths and already suffix-dedups (so a root whose
+// ClusterName equals its node Name yields a single segment), which avoids the
+// double-counting that occurs when threading raw []string{ClusterName, Name}.
+func layoutPathSegments(ml *ManifestLayout) []string {
+	p := ml.FullRepoPath()
+	if p == "." || p == "" {
+		return nil
+	}
+	return strings.Split(p, "/")
+}
 
 // WalkCluster traverses a stack.Cluster and builds a ManifestLayout tree that
 // mirrors the node and bundle hierarchy. Behaviour is controlled via
@@ -121,19 +135,29 @@ func walkClusterWithClusterName(c *stack.Cluster, rules LayoutRules, nodeOnly bo
 		return clusterLayout, nil
 	}
 
-	// Build the root node layout. Done unconditionally (even when the root
-	// node has no Bundle) so child-node subtrees can be nested underneath it.
+	// Build the root node layout following the walker's path invariant
+	// (Namespace = parent path, Name = this segment). The root's parent is the
+	// cluster layer, so Namespace = ClusterName; FullRepoPath() then appends the
+	// node Name and suffix-dedups when ClusterName == Node.Name (avoiding the
+	// old <cluster>/<node> double-count). Done unconditionally (even when the
+	// root node has no Bundle) so child-node subtrees can be nested underneath.
 	rootLayout := &ManifestLayout{
-		Name:       c.Node.Name,
-		Namespace:  filepath.Join(rules.ClusterName, c.Node.Name),
-		FilePer:    filePer,
-		FileNaming: rules.FileNaming,
-		Children:   []*ManifestLayout{},
+		Name:          c.Node.Name,
+		Namespace:     rules.ClusterName,
+		FilePer:       filePer,
+		FluxPlacement: rules.FluxPlacement,
+		FileNaming:    rules.FileNaming,
+		Children:      []*ManifestLayout{},
 	}
+
+	// Canonical root path segments — descendants derive their ancestor path
+	// from this (not from raw []string{ClusterName, Node.Name}) so they collapse
+	// the duplicate segment exactly as the root does.
+	rootSegments := layoutPathSegments(rootLayout)
 
 	if c.Node.Bundle != nil {
 		// Add only the root node's bundle resources (not child resources)
-		if err := processFlatBundleApps(c.Node.Bundle.Applications, rootLayout, []string{rules.ClusterName, c.Node.Name}, rules.FluxPlacement, rules.FileNaming); err != nil {
+		if err := processFlatBundleApps(c.Node.Bundle.Applications, rootLayout, rootSegments, rules.FluxPlacement, rules.FileNaming); err != nil {
 			return nil, err
 		}
 
@@ -143,7 +167,7 @@ func walkClusterWithClusterName(c *stack.Cluster, rules LayoutRules, nodeOnly bo
 			c.Node.Bundle.InitializeUmbrella()
 			umbrellaChildren, err := walkUmbrellaChildLayouts(
 				c.Node.Bundle.Children,
-				[]string{rules.ClusterName, c.Node.Name},
+				rootSegments,
 				filePer,
 				rules.FluxPlacement,
 				rules.FileNaming,
@@ -160,13 +184,23 @@ func walkClusterWithClusterName(c *stack.Cluster, rules LayoutRules, nodeOnly bo
 	// stack.Node.GetPath() (rootName/childName/...) when the Flux integrator
 	// searches for the corresponding layout node.
 	for _, child := range c.Node.Children {
-		childLayout, err := walkNode(child, []string{rules.ClusterName, c.Node.Name}, nodeOnly, nodeFlat, filePer, nil, rules.FluxPlacement, rules.FileNaming)
+		childLayout, err := walkNode(child, rootSegments, nodeOnly, nodeFlat, filePer, nil, rules.FluxPlacement, rules.FileNaming)
 		if err != nil {
 			return nil, err
 		}
 		if childLayout != nil {
 			rootLayout.Children = append(rootLayout.Children, childLayout)
 		}
+	}
+
+	// Elide the synthetic cluster wrapper when it would occupy the same
+	// directory as the root layout (e.g. ClusterName == Node.Name → both resolve
+	// to "<name>"). Without this, clusterLayout and rootLayout share a
+	// FullRepoPath() and WriteToDisk/WriteToTar emit a duplicate
+	// kustomization.yaml. When the paths differ (e.g. ClusterName="." or a
+	// distinct cluster name), keep the wrapper as before.
+	if clusterLayout.FullRepoPath() == rootLayout.FullRepoPath() {
+		return rootLayout, nil
 	}
 
 	clusterLayout.Children = append(clusterLayout.Children, rootLayout)

--- a/pkg/stack/layout/walker_test.go
+++ b/pkg/stack/layout/walker_test.go
@@ -1,7 +1,10 @@
 package layout_test
 
 import (
+	"archive/tar"
+	"bytes"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -349,8 +352,13 @@ func TestWalkCluster_ClusterNameWithChildNodes(t *testing.T) {
 	if rootLayout.Name != "flux-system" {
 		t.Fatalf("expected root layout name %q, got %q", "flux-system", rootLayout.Name)
 	}
-	if rootLayout.Namespace != "demo/flux-system" {
-		t.Fatalf("expected root layout namespace %q, got %q", "demo/flux-system", rootLayout.Namespace)
+	// Namespace follows the path invariant (parent path = cluster name); the
+	// node Name is appended by FullRepoPath(), which yields "demo/flux-system".
+	if rootLayout.Namespace != "demo" {
+		t.Fatalf("expected root layout namespace %q, got %q", "demo", rootLayout.Namespace)
+	}
+	if got := rootLayout.FullRepoPath(); got != "demo/flux-system" {
+		t.Fatalf("expected root layout repo path %q, got %q", "demo/flux-system", got)
 	}
 
 	// The child node layout must be nested under rootLayout, not under
@@ -1375,5 +1383,229 @@ func TestWalkCluster_ClusterName_NamedRoot_Augmenter(t *testing.T) {
 	}
 	if len(appLayout.ExtraFiles) != 1 {
 		t.Errorf("ExtraFiles missing: %+v", appLayout.ExtraFiles)
+	}
+}
+
+// collectRepoPaths walks a layout tree and returns every node's FullRepoPath.
+func collectRepoPaths(ml *layout.ManifestLayout) []string {
+	if ml == nil {
+		return nil
+	}
+	paths := []string{ml.FullRepoPath()}
+	for _, c := range ml.Children {
+		paths = append(paths, collectRepoPaths(c)...)
+	}
+	return paths
+}
+
+// collectTarNames reads a tar archive and returns all entry names.
+func collectTarNames(t *testing.T, r io.Reader) []string {
+	t.Helper()
+	var names []string
+	tr := tar.NewReader(r)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar read: %v", err)
+		}
+		names = append(names, hdr.Name)
+	}
+	return names
+}
+
+// multiTierUmbrellaCluster builds a single named root node whose bundle is an
+// umbrella with two tier children — the shape crane produces for a multi-tier
+// OAM app (root Node.Name == app name; tiers as umbrella children).
+func multiTierUmbrellaCluster(rootName string) *stack.Cluster {
+	services := &stack.Bundle{Name: "platform-services", Applications: []*stack.Application{makeUmbrellaApp("svc", "cm-svc")}}
+	apps := &stack.Bundle{Name: "platform-apps", Applications: []*stack.Application{makeUmbrellaApp("app", "cm-app")}}
+	umbrella := &stack.Bundle{
+		Name:         rootName,
+		Applications: []*stack.Application{makeUmbrellaApp("root", "cm-root")},
+		Children:     []*stack.Bundle{services, apps},
+	}
+	return &stack.Cluster{Name: rootName, Node: &stack.Node{Name: rootName, Bundle: umbrella}}
+}
+
+// TestWalkCluster_ClusterNameEqualsNodeName_NoDoubleNest is the crane#239
+// regression guard: when ClusterName == root Node.Name the layout must collapse
+// to a single <name>/ level (not <name>/<name>/), the synthetic cluster wrapper
+// must be elided, and WriteToTar must not emit a duplicate kustomization.yaml.
+func TestWalkCluster_ClusterNameEqualsNodeName_NoDoubleNest(t *testing.T) {
+	cluster := multiTierUmbrellaCluster("platform")
+
+	rules := layout.DefaultLayoutRules()
+	rules.ClusterName = "platform" // == root Node.Name
+	rules.FileNaming = layout.FileNamingKindName
+	rules.FluxPlacement = layout.FluxIntegratedPerLayout
+
+	ml, err := layout.WalkCluster(cluster, rules)
+	if err != nil {
+		t.Fatalf("walk cluster: %v", err)
+	}
+
+	// The synthetic cluster wrapper is elided: the returned root IS the node
+	// layout, rooted at a single "platform" level.
+	if ml.Name != "platform" {
+		t.Errorf("expected returned root name %q (wrapper elided), got %q", "platform", ml.Name)
+	}
+	if got := ml.FullRepoPath(); got != "platform" {
+		t.Errorf("expected root repo path %q, got %q", "platform", got)
+	}
+
+	// No layout in the tree may double-nest the app segment.
+	for _, p := range collectRepoPaths(ml) {
+		if p == "platform/platform" || strings.HasPrefix(p, "platform/platform/") {
+			t.Errorf("double-nested layout path %q (crane#239 regression)", p)
+		}
+	}
+
+	// Tier umbrella children live one level under the root.
+	want := map[string]string{
+		"platform-services": "platform/platform-services",
+		"platform-apps":     "platform/platform-apps",
+	}
+	for _, c := range ml.Children {
+		if exp, ok := want[c.Name]; ok {
+			if got := c.FullRepoPath(); got != exp {
+				t.Errorf("tier %q repo path = %q, want %q", c.Name, got, exp)
+			}
+			delete(want, c.Name)
+		}
+	}
+	for name := range want {
+		t.Errorf("missing tier umbrella child %q under root layout", name)
+	}
+
+	// WriteToTar must not duplicate platform/kustomization.yaml and must not
+	// emit any platform/platform/ path.
+	var buf bytes.Buffer
+	if err := ml.WriteToTar(&buf); err != nil {
+		t.Fatalf("WriteToTar: %v", err)
+	}
+	names := collectTarNames(t, &buf)
+	rootKust, hasServicesDir := 0, false
+	for _, n := range names {
+		if n == "platform/kustomization.yaml" {
+			rootKust++
+		}
+		if strings.HasPrefix(n, "platform/platform-services/") {
+			hasServicesDir = true
+		}
+		if n == "platform/platform/" || strings.HasPrefix(n, "platform/platform/") {
+			t.Errorf("tar contains double-nested path %q (crane#239 regression)", n)
+		}
+	}
+	if rootKust != 1 {
+		t.Errorf("expected exactly one platform/kustomization.yaml in tar, got %d (names: %v)", rootKust, names)
+	}
+	if !hasServicesDir {
+		t.Errorf("expected a file under platform/platform-services/ in tar (names: %v)", names)
+	}
+}
+
+// TestWalkCluster_ClusterNameEqualsNodeName_ChildNode covers the equal-path
+// case with a normal child NODE (not an umbrella child): the child node layout
+// must sit at <root>/<child>, not <root>/<root>/<child>, and the root layout
+// carries the requested FluxPlacement.
+func TestWalkCluster_ClusterNameEqualsNodeName_ChildNode(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("v1")
+	obj.SetKind("ConfigMap")
+	obj.SetName("cm")
+	obj.SetNamespace("default")
+	var o client.Object = obj
+
+	app := stack.NewApplication("app", "ns", &fakeConfig{objs: []*client.Object{&o}})
+	appsNode := &stack.Node{Name: "apps", Bundle: &stack.Bundle{Name: "apps-bundle", Applications: []*stack.Application{app}}}
+	rootNode := &stack.Node{Name: "platform", Bundle: &stack.Bundle{Name: "root-bundle"}, Children: []*stack.Node{appsNode}}
+	appsNode.SetParent(rootNode)
+	cluster := &stack.Cluster{Name: "platform", Node: rootNode}
+
+	rules := layout.DefaultLayoutRules()
+	rules.ClusterName = "platform" // == root Node.Name
+	rules.FluxPlacement = layout.FluxIntegratedPerLayout
+
+	ml, err := layout.WalkCluster(cluster, rules)
+	if err != nil {
+		t.Fatalf("walk cluster: %v", err)
+	}
+
+	// Wrapper elided → returned root is the node layout, carrying FluxPlacement.
+	if ml.Name != "platform" {
+		t.Errorf("expected returned root name %q, got %q", "platform", ml.Name)
+	}
+	if ml.FluxPlacement != layout.FluxIntegratedPerLayout {
+		t.Errorf("root layout FluxPlacement = %v, want FluxIntegratedPerLayout", ml.FluxPlacement)
+	}
+
+	for _, p := range collectRepoPaths(ml) {
+		if p == "platform/platform" || strings.HasPrefix(p, "platform/platform/") {
+			t.Errorf("double-nested layout path %q (crane#239 regression)", p)
+		}
+	}
+
+	// The child node layout sits one level under the root.
+	var appsLayout *layout.ManifestLayout
+	for _, c := range ml.Children {
+		if c.Name == "apps" {
+			appsLayout = c
+		}
+	}
+	if appsLayout == nil {
+		t.Fatalf("missing child node layout %q under root (children: %v)", "apps", ml.Children)
+	}
+	if got := appsLayout.FullRepoPath(); got != "platform/apps" {
+		t.Errorf("child node repo path = %q, want %q", got, "platform/apps")
+	}
+}
+
+// TestWalkCluster_ClusterNameDot_ProductionShape proves the fix does NOT alter
+// the production layout shape (crane app.compile uses ClusterName="."): the
+// cluster wrapper is kept (root kustomization.yaml at the archive root), the
+// umbrella roots at platform/, and there is no platform/platform/.
+func TestWalkCluster_ClusterNameDot_ProductionShape(t *testing.T) {
+	cluster := multiTierUmbrellaCluster("platform")
+
+	rules := layout.DefaultLayoutRules()
+	rules.ClusterName = "." // production app.compile
+	rules.FileNaming = layout.FileNamingKindName
+	rules.FluxPlacement = layout.FluxIntegratedPerLayout
+
+	ml, err := layout.WalkCluster(cluster, rules)
+	if err != nil {
+		t.Fatalf("walk cluster: %v", err)
+	}
+
+	// Cluster wrapper kept (its path "." differs from the root layout "platform").
+	if ml.Name != "" {
+		t.Errorf("expected synthetic cluster wrapper (empty Name) at root, got %q", ml.Name)
+	}
+
+	var buf bytes.Buffer
+	if err := ml.WriteToTar(&buf); err != nil {
+		t.Fatalf("WriteToTar: %v", err)
+	}
+	names := collectTarNames(t, &buf)
+	hasRootKust, hasServicesDir := false, false
+	for _, n := range names {
+		if n == "kustomization.yaml" {
+			hasRootKust = true
+		}
+		if strings.HasPrefix(n, "platform/platform-services/") {
+			hasServicesDir = true
+		}
+		if n == "platform/platform/" || strings.HasPrefix(n, "platform/platform/") {
+			t.Errorf("tar contains double-nested path %q", n)
+		}
+	}
+	if !hasRootKust {
+		t.Errorf("expected root kustomization.yaml in tar (names: %v)", names)
+	}
+	if !hasServicesDir {
+		t.Errorf("expected a file under platform/platform-services/ in tar (names: %v)", names)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a layout double-nesting bug in `walkClusterWithClusterName`: when
`rules.ClusterName == root Node.Name`, the layout (and Flux Kustomization
`spec.path`) gained a doubled directory segment — `<app>/<app>/...`.

Root cause: the named-root branch set the root layout's `Namespace` to
`filepath.Join(ClusterName, Node.Name)` and threaded the doubled
`[]string{ClusterName, Node.Name}` into `processFlatBundleApps`,
`walkUmbrellaChildLayouts`, and `walkNode`. When the two are equal this double-counts
the cluster segment. Callers using `ClusterName="."` (or a cluster name distinct
from the root node) were unaffected, so it went unnoticed.

Downstream impact: crane#239 (multi-tier app goldens nested `platform/platform/...`).

## Fix

Make the named-root branch follow the walker's path invariant
(`Namespace = parent path`, `Name = this segment`, `FullRepoPath()` suffix-dedups):

- root layout `Namespace = rules.ClusterName` (also stamps `FluxPlacement` so a
  directly-returned root carries the requested placement);
- derive a canonical root path via `FullRepoPath()` and thread its segments (new
  private `layoutPathSegments` helper) into the three descendant helpers;
- **elide the synthetic cluster wrapper when it would occupy the same directory as
  the root layout** — otherwise `clusterLayout` and `rootLayout` share a
  `FullRepoPath()` and `WriteToDisk`/`WriteToTar` emit a duplicate
  `kustomization.yaml`.

Output and `spec.path` change **only** when `ClusterName == Node.Name` (the dup
collapses). `ClusterName="."` (production) and distinct cluster names are unchanged.

## Tests

- `TestWalkCluster_ClusterNameEqualsNodeName_NoDoubleNest` — single-level layout +
  wrapper elided + `WriteToTar` emits exactly one `platform/kustomization.yaml` and
  no `platform/platform/`.
- `TestWalkCluster_ClusterNameEqualsNodeName_ChildNode` — equal case with a normal
  child node: child sits at `<root>/<child>`, root carries `FluxPlacement`.
- `TestWalkCluster_ClusterNameDot_ProductionShape` — proves the `"."` production
  shape is unchanged.
- `TestCreateLayoutWithResources_ClusterNameEqualsNodeName_SpecPath` — Flux
  `spec.path` = `platform/platform-services` (not double-nested).
- Updated `TestWalkCluster_ClusterNameWithChildNodes`: the internal `.Namespace`
  field assertion moves `demo/flux-system` → `demo` (on-disk `FullRepoPath` is
  unchanged at `demo/flux-system`).

Full `go test ./...` passes. Verified against crane via a temporary `replace`:
only the multi-tier umbrella scenarios collapse one level (identical content),
single-tier and multi-app scenarios unchanged, no data loss.

## Note — unrelated commit bundled

This branch also carries `chore(ci): set dependabot rebase-strategy to auto`
(explicit `rebase-strategy: "auto"` on the gomod + github-actions update blocks).
Unrelated to the layout fix; happy to split into its own PR if preferred.
