### PR TITLE
ci: add merge_group support ahead of enabling merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, develop, 'release/*']
   pull_request:
     branches: [main, develop]
+  merge_group:  # required: checks must report on the merge queue's temporary branch
   schedule:
     - cron: '0 4 * * *'  # 4am UTC daily - catch external changes
   workflow_dispatch:
@@ -63,13 +64,17 @@ jobs:
     name: detect-changes
     runs-on: autops-kube-kure
     timeout-minutes: 2
+    # On merge_group there is no PR base to diff against; dorny/paths-filter would
+    # error. Skip the filter and force both outputs to 'true' so every gating job
+    # runs in the queue — otherwise required checks never report and merges hang.
     outputs:
-      go: ${{ steps.filter.outputs.go }}
-      docs: ${{ steps.filter.outputs.docs }}
+      go: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.go }}
+      docs: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.docs }}
 
     steps:
     - uses: actions/checkout@v6
     - uses: dorny/paths-filter@v4
+      if: github.event_name != 'merge_group'
       id: filter
       with:
         filters: |


### PR DESCRIPTION
## What

Prepare kure CI to run on the GitHub merge queue's temporary branch, **ahead of** enabling the merge queue itself. This is step 1 of a staged rollout (merge_group support first, enable queue second, remove rebase-check/auto-rebase last) so `main` is never left in an unmergeable state.

## Changes

- Add the `merge_group:` trigger to `ci.yml` so `lint`/`test`/`build` report on queued merges. GitHub requires every *required* status check to report on the `merge_group` event, or queued merges hang forever.
- Harden the `changes` (detect-changes) job for `merge_group`: skip `dorny/paths-filter` (there is no PR base to diff against on a queue branch, which would error) and force the `go`/`docs` outputs to `'true'` so every gating job runs in the queue.

## Not in this PR

- `rebase-check` job and `auto-rebase.yml` stay in place for now — removed in a later cleanup PR once the queue is live.
- Enabling the merge queue itself + auto-merge is done via the `dot-github` settings policy.

## Testing note

No `merge_group` event fires until the queue rule is active, so this is a syntax/CI-compatibility change only. The real merge_group smoke test happens immediately after the queue is enabled in `dot-github`.