### PR TITLE
feat(manifest): add shared CRD/scope classifier

### DIFF
--- a/pkg/manifest/doc.go
+++ b/pkg/manifest/doc.go
@@ -1,0 +1,40 @@
+// Package manifest provides shared classification of Kubernetes manifests:
+// recognizing CustomResourceDefinitions and determining the namespacing
+// (scope) of an arbitrary object. It exists so that independent consumers —
+// a staging engine that must order CRDs ahead of the resources that depend on
+// them, and source components that emit and namespace-stamp raw manifests —
+// classify objects identically rather than maintaining divergent copies.
+//
+// # CRD recognition
+//
+// IsCRD reports whether an object is a CustomResourceDefinition by type or GVK,
+// without requiring spec.group/spec.names to be populated. CRDDefinedGroupKind
+// returns the GroupKind a CRD defines (spec.group + spec.names.kind), and
+// CRDScope additionally returns its declared scope, defaulting to
+// NamespaceScoped when spec.scope is absent (matching Kubernetes):
+//
+//	gk, scope, ok := manifest.CRDScope(obj)
+//
+// # Scope determination
+//
+// Scope determines whether an object is namespaced, cluster-scoped, or unknown.
+// CRDs are cluster-scoped; well-known built-in kinds are resolved from internal
+// namespaced/cluster maps; custom resources are resolved from a caller-supplied
+// map of CRD scopes (the spec.scope of CRDs known in the same context).
+// Anything else is ScopeUnknown — callers are expected to fail closed rather
+// than guess:
+//
+//	switch manifest.Scope(obj, crdScopes) {
+//	case manifest.ScopeNamespaced:
+//	    // must declare metadata.namespace
+//	case manifest.ScopeCluster:
+//	    // cluster-scoped
+//	case manifest.ScopeUnknown:
+//	    // unknown custom resource with no defining CRD in scope
+//	}
+//
+// The package depends only on the Kubernetes API machinery
+// (k8s.io/apiextensions-apiserver, k8s.io/apimachinery,
+// sigs.k8s.io/controller-runtime) and has no dependency on any other Kure
+// package.
+package manifest

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -1,0 +1,163 @@
+package manifest
+
+import (
+	"strings"
+
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IsCRD reports whether o is a CustomResourceDefinition, by type or GVK. Unlike
+// CRDDefinedGroupKind it does not require spec.group/spec.names to be populated —
+// an object is a CRD by virtue of its kind, even if its defined GroupKind can't
+// be read.
+func IsCRD(o client.Object) bool {
+	if _, ok := o.(*apiextv1.CustomResourceDefinition); ok {
+		return true
+	}
+	gvk := o.GetObjectKind().GroupVersionKind()
+	return gvk.Group == "apiextensions.k8s.io" && gvk.Kind == "CustomResourceDefinition"
+}
+
+// CRDDefinedGroupKind returns the GroupKind a CustomResourceDefinition defines
+// (spec.group + spec.names.kind) and whether o is a CRD.
+func CRDDefinedGroupKind(o client.Object) (schema.GroupKind, bool) {
+	switch c := o.(type) {
+	case *apiextv1.CustomResourceDefinition:
+		return schema.GroupKind{Group: c.Spec.Group, Kind: c.Spec.Names.Kind}, true
+	case *unstructured.Unstructured:
+		gvk := c.GroupVersionKind()
+		if gvk.Kind != "CustomResourceDefinition" || gvk.Group != "apiextensions.k8s.io" {
+			return schema.GroupKind{}, false
+		}
+		group, _, _ := unstructured.NestedString(c.Object, "spec", "group")
+		kind, _, _ := unstructured.NestedString(c.Object, "spec", "names", "kind")
+		if group == "" || kind == "" {
+			return schema.GroupKind{}, false
+		}
+		return schema.GroupKind{Group: group, Kind: kind}, true
+	}
+	return schema.GroupKind{}, false
+}
+
+// ObjectGroupKind is the GroupKind of an emitted object.
+func ObjectGroupKind(o client.Object) schema.GroupKind {
+	gvk := o.GetObjectKind().GroupVersionKind()
+	return schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind}
+}
+
+// namespacedBuiltinKinds lists the namespaced (group, kind) pairs we recognize,
+// keyed "<group>/<kind>" (core group is the empty string). A kind not listed
+// here is treated as unknown scope (callers then fail closed unless
+// metadata.namespace is set), rather than being silently widened.
+var namespacedBuiltinKinds = map[string]bool{
+	"/ConfigMap":                            true,
+	"/Secret":                               true,
+	"/Service":                              true,
+	"/ServiceAccount":                       true,
+	"/PersistentVolumeClaim":                true,
+	"/Pod":                                  true,
+	"apps/Deployment":                       true,
+	"apps/DaemonSet":                        true,
+	"apps/StatefulSet":                      true,
+	"apps/ReplicaSet":                       true,
+	"batch/Job":                             true,
+	"batch/CronJob":                         true,
+	"networking.k8s.io/Ingress":             true,
+	"networking.k8s.io/NetworkPolicy":       true,
+	"rbac.authorization.k8s.io/Role":        true,
+	"rbac.authorization.k8s.io/RoleBinding": true,
+}
+
+// clusterScopedBuiltinKinds lists the cluster-scoped built-in kinds we
+// recognize, so an object like a Namespace is treated as cluster-scoped rather
+// than unknown (which would otherwise require an explicit metadata.namespace).
+var clusterScopedBuiltinKinds = map[string]bool{
+	"/Namespace":                            true,
+	"/Node":                                 true,
+	"/PersistentVolume":                     true,
+	"rbac.authorization.k8s.io/ClusterRole": true,
+	"rbac.authorization.k8s.io/ClusterRoleBinding":                true,
+	"apiextensions.k8s.io/CustomResourceDefinition":               true,
+	"storage.k8s.io/StorageClass":                                 true,
+	"scheduling.k8s.io/PriorityClass":                             true,
+	"networking.k8s.io/IngressClass":                              true,
+	"apiregistration.k8s.io/APIService":                           true,
+	"admissionregistration.k8s.io/ValidatingWebhookConfiguration": true,
+	"admissionregistration.k8s.io/MutatingWebhookConfiguration":   true,
+}
+
+func groupKey(apiVersion, kind string) string {
+	group := ""
+	if g, _, ok := strings.Cut(apiVersion, "/"); ok {
+		group = g // "apps/v1" -> "apps"; core "v1" -> ""
+	}
+	return group + "/" + kind
+}
+
+// IsNamespacedBuiltinKind reports whether a (group-aware) apiVersion+kind is a
+// known namespaced built-in type that must declare metadata.namespace.
+func IsNamespacedBuiltinKind(apiVersion, kind string) bool {
+	return namespacedBuiltinKinds[groupKey(apiVersion, kind)]
+}
+
+// ScopeResult is the determined namespacing of an object.
+type ScopeResult int
+
+const (
+	// ScopeUnknown means the object's scope could not be determined (unknown
+	// custom resource with no defining CRD in scope) — callers should fail
+	// closed rather than guess.
+	ScopeUnknown ScopeResult = iota
+	ScopeNamespaced
+	ScopeCluster
+)
+
+// Scope determines whether o is namespaced, cluster-scoped, or unknown. CRDs are
+// cluster-scoped; built-in kinds use the namespaced/cluster maps; custom
+// resources are resolved from crdScopes (the spec.scope of CRDs known in the
+// same context). Anything else is ScopeUnknown.
+func Scope(o client.Object, crdScopes map[schema.GroupKind]apiextv1.ResourceScope) ScopeResult {
+	if IsCRD(o) {
+		return ScopeCluster
+	}
+	gvk := o.GetObjectKind().GroupVersionKind()
+	key := gvk.Group + "/" + gvk.Kind
+	switch {
+	case namespacedBuiltinKinds[key]:
+		return ScopeNamespaced
+	case clusterScopedBuiltinKinds[key]:
+		return ScopeCluster
+	}
+	if scope, ok := crdScopes[schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind}]; ok {
+		if scope == apiextv1.ClusterScoped {
+			return ScopeCluster
+		}
+		return ScopeNamespaced
+	}
+	return ScopeUnknown
+}
+
+// CRDScope returns a CRD's defined GroupKind and declared scope (defaulting to
+// NamespaceScoped when spec.scope is absent, matching Kubernetes). ok is false
+// when o is not a CRD.
+func CRDScope(o client.Object) (schema.GroupKind, apiextv1.ResourceScope, bool) {
+	gk, ok := CRDDefinedGroupKind(o)
+	if !ok {
+		return schema.GroupKind{}, "", false
+	}
+	scope := apiextv1.NamespaceScoped
+	switch c := o.(type) {
+	case *apiextv1.CustomResourceDefinition:
+		if c.Spec.Scope != "" {
+			scope = c.Spec.Scope
+		}
+	case *unstructured.Unstructured:
+		if s, _, _ := unstructured.NestedString(c.Object, "spec", "scope"); s != "" {
+			scope = apiextv1.ResourceScope(s)
+		}
+	}
+	return gk, scope, true
+}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -1,0 +1,118 @@
+package manifest
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func typedCRD(group, kind string) client.Object {
+	crd := &apiextv1.CustomResourceDefinition{
+		TypeMeta:   metav1.TypeMeta{Kind: "CustomResourceDefinition", APIVersion: "apiextensions.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: kind + "s." + group},
+	}
+	crd.Spec.Group = group
+	crd.Spec.Names.Kind = kind
+	return crd
+}
+
+func unstructuredObj(apiVersion, kind, name string) client.Object {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion(apiVersion)
+	u.SetKind(kind)
+	u.SetName(name)
+	return u
+}
+
+func TestIsCRD(t *testing.T) {
+	if !IsCRD(typedCRD("example.com", "Widget")) {
+		t.Error("typed CRD should be recognized")
+	}
+	if !IsCRD(unstructuredObj("apiextensions.k8s.io/v1", "CustomResourceDefinition", "widgets.example.com")) {
+		t.Error("unstructured CRD should be recognized")
+	}
+	if IsCRD(&appsv1.Deployment{TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}}) {
+		t.Error("Deployment is not a CRD")
+	}
+}
+
+func TestCRDDefinedGroupKind(t *testing.T) {
+	gk, ok := CRDDefinedGroupKind(typedCRD("example.com", "Widget"))
+	if !ok || gk != (schema.GroupKind{Group: "example.com", Kind: "Widget"}) {
+		t.Errorf("CRDDefinedGroupKind = %v,%v want example.com/Widget,true", gk, ok)
+	}
+	if _, ok := CRDDefinedGroupKind(&appsv1.Deployment{}); ok {
+		t.Error("non-CRD should return ok=false")
+	}
+}
+
+func TestIsNamespacedBuiltinKind(t *testing.T) {
+	if !IsNamespacedBuiltinKind("apps/v1", "Deployment") {
+		t.Error("apps/v1 Deployment is namespaced")
+	}
+	if !IsNamespacedBuiltinKind("v1", "ConfigMap") {
+		t.Error("core ConfigMap is namespaced")
+	}
+	if IsNamespacedBuiltinKind("v1", "Namespace") {
+		t.Error("Namespace is cluster-scoped, not in the namespaced set")
+	}
+}
+
+func TestCRDScope(t *testing.T) {
+	// typed CRD with no spec.scope defaults to NamespaceScoped.
+	gk, scope, ok := CRDScope(typedCRD("example.com", "Widget"))
+	if !ok || gk.Kind != "Widget" || scope != apiextv1.NamespaceScoped {
+		t.Errorf("typed CRD scope = %v,%v,%v want Widget,Namespaced,true", gk, scope, ok)
+	}
+	// unstructured CRD declaring Cluster scope.
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("apiextensions.k8s.io/v1")
+	u.SetKind("CustomResourceDefinition")
+	u.SetName("clusters.example.com")
+	_ = unstructured.SetNestedField(u.Object, "example.com", "spec", "group")
+	_ = unstructured.SetNestedField(u.Object, "Cluster", "spec", "names", "kind")
+	_ = unstructured.SetNestedField(u.Object, "Cluster", "spec", "scope")
+	if _, scope, ok := CRDScope(u); !ok || scope != apiextv1.ClusterScoped {
+		t.Errorf("unstructured CRD scope = %v,%v want Cluster,true", scope, ok)
+	}
+	if _, _, ok := CRDScope(&appsv1.Deployment{}); ok {
+		t.Error("non-CRD should return ok=false")
+	}
+}
+
+func TestObjectGroupKind(t *testing.T) {
+	gk := ObjectGroupKind(unstructuredObj("example.com/v1", "Widget", "w"))
+	if gk != (schema.GroupKind{Group: "example.com", Kind: "Widget"}) {
+		t.Errorf("ObjectGroupKind = %v", gk)
+	}
+}
+
+func TestScope(t *testing.T) {
+	crdScopes := map[schema.GroupKind]apiextv1.ResourceScope{
+		{Group: "example.com", Kind: "Widget"}:  apiextv1.NamespaceScoped,
+		{Group: "example.com", Kind: "Cluster"}: apiextv1.ClusterScoped,
+	}
+	cases := []struct {
+		name string
+		obj  client.Object
+		want ScopeResult
+	}{
+		{"crd-is-cluster", typedCRD("example.com", "Widget"), ScopeCluster},
+		{"builtin-namespaced", &appsv1.Deployment{TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}}, ScopeNamespaced},
+		{"builtin-cluster", &corev1.Namespace{TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}}, ScopeCluster},
+		{"cr-namespaced-from-crd", unstructuredObj("example.com/v1", "Widget", "w1"), ScopeNamespaced},
+		{"cr-cluster-from-crd", unstructuredObj("example.com/v1", "Cluster", "c1"), ScopeCluster},
+		{"unknown-gvk", unstructuredObj("unknown.io/v1", "Mystery", "m1"), ScopeUnknown},
+	}
+	for _, tc := range cases {
+		if got := Scope(tc.obj, crdScopes); got != tc.want {
+			t.Errorf("%s: Scope = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds `pkg/manifest`, a pure classifier for Kubernetes manifests:

- **CRD recognition** — `IsCRD`, `CRDDefinedGroupKind`, `CRDScope`
- **Scope determination** — `Scope` / `ScopeResult` (`ScopeUnknown`/`ScopeNamespaced`/`ScopeCluster`), `IsNamespacedBuiltinKind`, `ObjectGroupKind`, plus the built-in namespaced/cluster kind maps.

## Why

Crane's stack-compile staging engine (orders CRDs ahead of dependent resources) and its `crd`/`manifests` OAM source components (emit + namespace-stamp raw manifests) need to classify objects **identically**. Today that logic lives in a crane-internal package. Promoting it to kure makes it the single source of truth so the staging engine and the (soon launcher-hosted) source components can't diverge.

This is **Phase A** of crane#237 (promote `crd`/`manifests` to launcher; classifier → kure). Launcher (Phase B) and crane (Phase C) consume this package once released.

## Notes

- Verbatim extraction of crane's existing classifier — same funcs, signatures, constants, and maps. Tests ported as-is.
- Zero new dependencies: only `k8s.io/apiextensions-apiserver`, `k8s.io/apimachinery`, `sigs.k8s.io/controller-runtime` (already in `go.mod`). No dependency on any other kure package; no import cycles.
- `GOWORK=off go test ./...` green.

After merge, cut a release (e.g. `v0.2.0-beta.5`) so crane/launcher can bump to it.