### PR TITLE
ci: cap govulncheck memory with GOMEMLIMIT to avoid runner OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,11 @@ jobs:
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       (github.event_name != 'pull_request' || needs.changes.outputs.go == 'true')
 
+    # GOMEMLIMIT keeps Go's GC under the runner pod memory limit so govulncheck (peaks ~3.8Gi
+    # on large module graphs) doesn't get OOMKilled. Pairs with the 6Gi ARC runner limit.
+    env:
+      GOMEMLIMIT: 5GiB
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v6


### PR DESCRIPTION
The `security` job ran `govulncheck -scan package ./...` on the in-cluster ARC runner (`autops-kube-kure`) and was **OOMKilled** (exit 137) when it grew to ~3.8 GiB against the pod's 4 GiB memory limit.

This sets job-level `GOMEMLIMIT: 5GiB` so Go GC keeps govulncheck under the runner memory limit. Paired with the ARC runner memory limit being raised 4Gi→6Gi in the cluster config (opsmaster).

`GOMEMLIMIT` is a soft cap; the runner limit bump is the hard safety net.
