### PR TITLE
docs: remove stale references to removed generators package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,6 @@ kure/
 │   └── stack/        # Core domain model
 │       ├── argocd/   # ArgoCD workflow
 │       ├── fluxcd/   # FluxCD workflow
-│       ├── generators/  # Application generators
 │       └── layout/   # Manifest organization
 ├── examples/         # Sample configurations
 ├── docs/             # Documentation
@@ -379,7 +378,6 @@ Links to pkg.go.dev. Updated automatically when the module is published.
 |-----------------|---------------------|------------------|
 | `pkg/stack/` | `api-reference/stack` | `guides/flux-workflow`, `concepts/domain-model` |
 | `pkg/stack/fluxcd/` | `api-reference/flux-engine` | `guides/flux-workflow` |
-| `pkg/stack/generators/` | `api-reference/generators` | `guides/generators` |
 | `pkg/stack/layout/` | `api-reference/layout` | `guides/flux-workflow` |
 | `pkg/io/` | `api-reference/io` | `guides/library-usage` |
 | `pkg/errors/` | `api-reference/errors` | — |

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,7 +9,6 @@ This directory contains examples for Kure, organized by purpose.
 These directories have documentation mounted to the docs site:
 
 - [`patches/`](patches/) — Declarative patching with TOML and YAML formats
-- [`generators/`](generators/) — Resource generation using the GVK system
 - [`kurel/frigate/`](kurel/frigate/) — Building a complete kurel package
 
 ### Go API Tutorial

--- a/pkg/stack/README.md
+++ b/pkg/stack/README.md
@@ -188,5 +188,4 @@ node.SetPackageRef(&stack.SourceRef{
 ## Related Packages
 
 - [stack/fluxcd](/api-reference/flux-engine/) - FluxCD workflow engine implementation
-- [stack/generators](/api-reference/generators/) - Application generator system
 - [stack/layout](/api-reference/layout/) - Manifest directory organization


### PR DESCRIPTION
## What

The docs link checker reported a 404: `/kure/dev/api-reference/stack/` links to `/kure/dev/api-reference/generators/`, which does not exist.

`pkg/stack/generators` and `examples/generators` were removed in `695953a` (v0.2.0-beta.2), but several references were left behind. This removes all live stale references:

- `pkg/stack/README.md` — Related Packages link to generators
- `AGENTS.md` — repo-tree `generators/` line and reverse-map row
- `examples/README.md` — removed `generators/` example link

## Verification

Clean Hugo rebuild produces no generators pages and zero references to them. Remaining matches are confined to historical `CHANGELOG.md` and archival `docs/` review files.

The corrupted `site/scripts/check-unmapped-docs.sh` is addressed separately in the docs-map enforcement work (stacked PR).