### PR TITLE
feat(docs): link-integrity + docs-with-code enforcement (Layers 1 & 3) + agentic cascade

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -125,7 +125,9 @@ mise run verify
 - When updating GitHub workflows, also update docs/github-workflows.md
 - Always use pkg/logger for logging
 - Each pkg/ package has a README.md mounted to the docs site — update it when changing public APIs
-- Code and documentation changes must be in the same PR
+- Code and documentation changes must be in the same PR (mandatory, CI-enforced; org standard in go-kure/.github docs/standards.md)
+- `site/docs-map.yaml` is the single source of code→docs mapping; the AGENTS reverse-map table + site nav are generated from it (`bash site/scripts/gen-docs-tables.sh`) — never hand-edit them
+- Doc-sync is enforced by check-doc-sync.sh (structure), check-links.sh (rendered links), and the doc-gate job (source change must touch its docs; bypass only via maintainer `docs-skip` label)
 - See AGENTS.md "Reverse Mapping" table to know which guides to review when changing a package
 ## Crane Integration
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,7 +460,7 @@ jobs:
     name: build
     runs-on: autops-kube-kure
     timeout-minutes: 1
-    needs: [validate, test, docs-build, coverage-check]
+    needs: [validate, test, docs-build, coverage-check, doc-gate]
     if: always()
     steps:
     - name: Check build results
@@ -469,7 +469,8 @@ jobs:
         tt="${{ needs.test.result }}"
         db="${{ needs.docs-build.result }}"
         cc="${{ needs.coverage-check.result }}"
-        for result in "$vl" "$tt" "$db" "$cc"; do
+        dg="${{ needs.doc-gate.result }}"
+        for result in "$vl" "$tt" "$db" "$cc" "$dg"; do
           if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
             echo "Required job failed or was cancelled (result: $result)"
             exit 1
@@ -592,6 +593,30 @@ jobs:
         path: site/public/
         retention-days: 7
 
+    - name: Cache lychee
+      id: lychee-cache
+      uses: actions/cache@v5
+      with:
+        path: ~/bin/lychee
+        key: lychee-0.24.2-linux-amd64
+
+    - name: Install lychee
+      if: steps.lychee-cache.outputs.cache-hit != 'true'
+      run: |
+        mkdir -p ~/bin
+        curl -fsSL -o /tmp/lychee.tar.gz \
+          https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-x86_64-unknown-linux-gnu.tar.gz
+        tar xzf /tmp/lychee.tar.gz -C /tmp
+        install -m755 /tmp/lychee-x86_64-unknown-linux-gnu/lychee ~/bin/lychee
+        echo "$HOME/bin" >> $GITHUB_PATH
+
+    - name: Add lychee to PATH
+      if: steps.lychee-cache.outputs.cache-hit == 'true'
+      run: echo "$HOME/bin" >> $GITHUB_PATH
+
+    - name: Check internal links (rendered site)
+      run: bash site/scripts/check-links.sh
+
   # =============================================================================
   # PR-only Jobs (parallel, non-blocking)
   # =============================================================================
@@ -645,15 +670,16 @@ jobs:
           echo "::warning::Changes detected in pkg/ directory. Review for potential breaking changes to public API."
         fi
 
-  docs-check:
-    name: Docs Check
+  # Layer 3 change-gate: a mapped package's source change must touch its mapped
+  # docs in the same PR. Always runs on PRs (so a pkg-only change can't skip it);
+  # the maintainer-restricted `docs-skip` label bypasses via the script. On
+  # merge_group this is skipped (the PR already passed it), which the build gate
+  # accepts. Required via the `build` aggregate job.
+  doc-gate:
+    name: doc-gate
     runs-on: autops-kube-kure
     timeout-minutes: 5
-    needs: [changes]
-    if: |
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.draft == false &&
-      needs.changes.outputs.docs == 'true'
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
 
     steps:
     - name: Checkout code
@@ -661,38 +687,30 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Check for documentation updates
-      id: docs-changed
-      uses: tj-actions/changed-files@v47
+    - name: Cache yq
+      id: yq-cache
+      uses: actions/cache@v5
       with:
-        files: |
-          **.md
-          docs/**
-          examples/**
+        path: ~/bin/yq
+        key: yq-4.44.6-linux-amd64
 
-    - name: Validate documentation
-      if: steps.docs-changed.outputs.any_changed == 'true'
+    - name: Install yq
+      if: steps.yq-cache.outputs.cache-hit != 'true'
       run: |
-        echo "Documentation files changed:"
-        echo "${{ steps.docs-changed.outputs.all_changed_files }}"
+        mkdir -p ~/bin
+        curl -fsSL -o ~/bin/yq \
+          https://github.com/mikefarah/yq/releases/download/v4.44.6/yq_linux_amd64
+        chmod +x ~/bin/yq
+        echo "$HOME/bin" >> $GITHUB_PATH
 
-        # Check for broken links in markdown files (basic check)
-        for file in ${{ steps.docs-changed.outputs.all_changed_files }}; do
-          if [[ $file == *.md ]]; then
-            if grep -q "](http" "$file"; then
-              echo "External links found in $file - manual verification recommended"
-            fi
-          fi
-        done
+    - name: Add yq to PATH
+      if: steps.yq-cache.outputs.cache-hit == 'true'
+      run: echo "$HOME/bin" >> $GITHUB_PATH
 
-    - name: Check if public API changes need documentation
+    - name: Enforce docs-with-code (Layer 3)
       run: |
-        # Check if pkg/ changes exist but no documentation updates
-        if git diff --name-only origin/main...HEAD | grep -q "^pkg/"; then
-          if ! git diff --name-only origin/main...HEAD | grep -qE "\.(md|txt)$"; then
-            echo "::warning::Public API changes detected but no documentation updates found. Consider updating README.md or adding examples."
-          fi
-        fi
+        bash site/scripts/check-doc-gate.sh "origin/${{ github.base_ref }}" . \
+          "--skip=${{ contains(github.event.pull_request.labels.*.name, 'docs-skip') }}"
 
   # =============================================================================
   # Stage 5: Mirror to GitLab (main only, after all checks pass)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,23 +354,39 @@ Fluent builders follow an immutable pattern - each `With*` method returns a new 
 
 ## Documentation Synchronization
 
-Kure uses a 4-layer documentation model designed so that most content stays in sync automatically.
+**Documentation sync is mandatory and CI-enforced.** This repo follows the go-kure
+organization documentation-sync standard (`go-kure/.github` → `docs/standards.md`).
 
-### Layer 1: Package READMEs (auto-synced)
+### Single source of truth
 
-Each `pkg/` package has a `README.md` that lives alongside the code. These are automatically mounted to the documentation site via `inject-frontmatter.sh`. When you change a package, update its README in the same PR.
-
-### Layer 2: Cross-cutting guides (manually synced)
-
-Hand-authored guides in `site/content/guides/` describe multi-package workflows. They focus on the flow (which steps, in what order) and link to package READMEs for specifics. Use the reverse mapping table below to know which guides to review.
-
-### Layer 3: API reference (external)
-
-Links to pkg.go.dev. Updated automatically when the module is published.
+`site/docs-map.yaml` is the normative map of code→docs. Every public package appears
+there exactly once (`mount:` to publish, or `mounted: false` + `reason:`). The site
+mounts, the AGENTS reverse-mapping table below, and the `api-reference/_index.md` nav
+are all generated from or validated against it — **never hand-edit them**. To change
+what's published, edit `docs-map.yaml` and run `bash site/scripts/gen-docs-tables.sh`.
 
 ### Rule
 
-**Code and documentation changes must be in the same PR.** If you modify a package's public API, update its README and check the guides listed in the reverse mapping.
+**Code and documentation changes must be in the same PR.** If you change a package,
+update its `README.md` (and any guides listed in the reverse mapping) in the same PR.
+Removing/renaming a package or symbol must repoint every reference; a 404 in the
+rendered site is a CI failure.
+
+### Enforcement
+
+- `site/scripts/check-doc-sync.sh` — every public package is mapped; READMEs and
+  mount targets exist; generated tables are current (blocking, `docs-build` job).
+- `site/scripts/check-links.sh` — all internal links resolve in the rendered site
+  (lychee, blocking, `docs-build` job).
+- `site/scripts/check-doc-gate.sh` — a mapped package's source change must touch its
+  mapped docs (the `doc-gate` job). Bypass only with the maintainer-restricted
+  `docs-skip` label.
+
+### Cross-cutting guides
+
+Hand-authored guides in `site/content/guides/` describe multi-package workflows; use
+the reverse mapping table below to know which to review. Full Go API reference lives
+on pkg.go.dev.
 
 ### Reverse Mapping: Code to Docs
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -17,7 +17,7 @@ This document provides an overview of all GitHub Actions workflows used in the k
 | [Release / Promote](#release--promote-workflow) | `release-promote.yml` | manual | Promote to explicit release type (beta/rc/stable) |
 | [Release / Bump](#release--bump-workflow) | `release-bump.yml` | manual | Advance version cycle (minor/major), no tag |
 | [Release / Publish](#release--publish-workflow) | `release-publish.yml` | tag push | GoReleaser, SBOM, cosign signing, docs deploy, proxy refresh |
-| [PR Review](#pr-review-workflow) | `pr-review.yml` | pull_request | Two-pass AI code review via ccproxy |
+| [PR Review](#pr-review-workflow) | `pr-review.yml` | pull_request | Two-pass AI code review via claude-max-proxy |
 
 ---
 
@@ -303,17 +303,17 @@ managed centrally in `go-kure/.github` (`governance/repository-settings-policy.y
 
 ### How It Works
 
-Uses a two-pass AI review system via ccproxy (ported from the GitLab `mr-review.yml` template):
+Uses a two-pass AI review system via the in-cluster claude-max-proxy (ported from the GitLab `mr-review.yml` template):
 
-1. **Pass 1 — Review:** Sends the PR diff + project context (`AGENTS.md`, `.claude/CLAUDE.md`) to the review model (default: `gpt-5.3-codex`). Anti-hallucination rules prevent the model from inventing standards or referencing code not in the diff. The model returns up to 3 findings ranked by severity in a structured table. Posted as a PR comment.
+1. **Pass 1 — Review:** Sends the PR diff + project context (`AGENTS.md`, `.claude/CLAUDE.md`) to the review model (default: `claude-opus-4`). Anti-hallucination rules prevent the model from inventing standards or referencing code not in the diff. The model returns up to 3 findings ranked by severity in a structured table. Posted as a PR comment.
 
 2. **Pass 2 — Assessment:** If the review found issues (not LGTM), sends the review + diff to an assessment model (default: `claude-sonnet-4-6`) which fact-checks each finding against the actual diff and project context. Includes standards verification — claims about "standards violations" are checked against actually-provided standards. Catches hallucinations and false positives. Posted as a second PR comment.
 
 ### Requirements
 
 - **Self-hosted runner:** Runs on `autops-kube` label (ARC runner with in-cluster access)
-- **ccproxy:** Reachable at `http://openclaw-ccproxy.openclaw.svc:8000` from the runner pod
-- **No API keys needed:** ccproxy handles model authentication
+- **claude-max-proxy:** Reachable at `http://openclaw-claude-proxy.openclaw.svc:3456` from the runner pod
+- **No API keys needed:** the proxy handles model authentication
 
 ### Configuration
 
@@ -321,7 +321,7 @@ Configurable via repository variables or workflow env defaults:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `PR_REVIEW_MODEL` | `gpt-5.3-codex` | Model for code review pass |
+| `PR_REVIEW_MODEL` | `claude-opus-4` | Model for code review pass (cosmetic label; backend ignores the model field) |
 | `PR_REVIEW_MAX_DIFF_CHARS` | `50000` | Truncation threshold for large diffs |
 | `PR_REVIEW_MAX_TOKENS` | `1500` | Max response tokens for review |
 | `PR_REVIEW_CONTEXT` | kure project description | Additional system prompt context |

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,4 +1,6 @@
 .generated/
 public/
+public-lc/
+.linkcheck/
 resources/
 .hugo_build.lock

--- a/site/scripts/check-doc-gate.sh
+++ b/site/scripts/check-doc-gate.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# check-doc-gate.sh — Layer 3 of the documentation-sync standard: when a mapped
+# package's source changes, its mapped docs (README and/or guides) MUST change in
+# the same PR.
+#
+# The trigger is intentionally coarse ("mapped package source changed", not a true
+# public-API diff); the maintainer-restricted `docs-skip` escape hatch handles the
+# false positives (routine private-helper edits).
+#
+# Usage: bash scripts/check-doc-gate.sh <base-ref> [KURE_ROOT] [--skip=true|false]
+#   <base-ref>  ref to diff against (e.g. origin/main)
+#   --skip      when true, bypass the gate (the CI job passes this from the
+#               docs-skip label). Prints a notice and exits 0.
+
+set -euo pipefail
+
+SKIP=false
+ARGS=()
+for a in "$@"; do
+  case "$a" in
+    --skip=*) SKIP="${a#--skip=}" ;;
+    *) ARGS+=("$a") ;;
+  esac
+done
+BASE="${ARGS[0]:?usage: check-doc-gate.sh <base-ref> [KURE_ROOT] [--skip=...]}"
+ROOT="${ARGS[1]:-$(git rev-parse --show-toplevel)}"
+MAP="$ROOT/site/docs-map.yaml"
+
+if [[ "$SKIP" == "true" ]]; then
+  echo "doc-gate: bypassed via maintainer docs-skip label."
+  exit 0
+fi
+
+command -v yq >/dev/null 2>&1 || { echo "ERROR: yq is required" >&2; exit 1; }
+[[ -f "$MAP" ]] || { echo "ERROR: docs map not found: $MAP" >&2; exit 1; }
+
+changed_set="$(git -C "$ROOT" diff --name-only "${BASE}...HEAD")"
+doc_changed() { grep -qxF "$1" <<<"$changed_set"; }
+
+violations=0
+while IFS= read -r path; do
+  [[ -n "$path" ]] || continue
+  # Source files directly in this package dir (not nested subpackages, which are
+  # their own map entries), excluding tests.
+  src="$(grep -E "^${path}/[^/]+\.go$" <<<"$changed_set" | grep -v '_test\.go$' || true)"
+  [[ -n "$src" ]] || continue
+
+  readme="$(yq ".packages[] | select(.path==\"$path\") | .readme" "$MAP")"
+  ok=0
+  [[ -n "$readme" && "$readme" != "null" ]] && doc_changed "$readme" && ok=1
+  while IFS= read -r g; do
+    [[ -n "$g" && "$g" != "null" ]] || continue
+    doc_changed "site/content/${g}.md" && ok=1
+  done < <(yq ".packages[] | select(.path==\"$path\") | .guides[]?" "$MAP")
+
+  if [[ $ok -ne 1 ]]; then
+    echo "FAIL: $path source changed but its docs did not (expected a change to $readme or its mapped guides)"
+    violations=$((violations + 1))
+  fi
+done < <(yq '.packages[].path' "$MAP")
+
+if [[ $violations -gt 0 ]]; then
+  echo "doc-gate: $violations package(s) changed without doc updates." >&2
+  echo "Update the package README/guide in this PR, or apply the maintainer-restricted 'docs-skip' label." >&2
+  exit 1
+fi
+echo "doc-gate: OK"

--- a/site/scripts/check-links.sh
+++ b/site/scripts/check-links.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# check-links.sh — Layer 1 of the documentation-sync standard: verify that every
+# internal link resolves in the *rendered* site.
+#
+# Builds the site with root-relative URLs (so links resolve offline against the
+# output tree) and runs lychee with --root-dir. External links are not checked
+# here (--offline); flaky external checks belong in a separate non-blocking job.
+#
+# Usage: bash scripts/check-links.sh [KURE_ROOT]
+# Requires: hugo, yq, lychee.
+
+set -euo pipefail
+
+SITE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+KURE_ROOT="${1:-$(cd "$SITE_DIR/.." && pwd)}"
+LC_DIR="$SITE_DIR/.linkcheck"
+
+for tool in hugo yq lychee; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "ERROR: $tool is required" >&2; exit 1; }
+done
+
+# Render with root-relative URLs into a throwaway dir. The production baseURL
+# (and version prefix) is irrelevant to internal link integrity; a root-relative
+# build lets lychee resolve every link offline against the output.
+bash "$SITE_DIR/scripts/inject-frontmatter.sh" "$KURE_ROOT" >/dev/null
+rm -rf "$LC_DIR"
+( cd "$SITE_DIR" && hugo --baseURL "/" --destination "$LC_DIR" --quiet )
+
+echo "=== lychee (internal links, offline) ==="
+lychee --offline --root-dir "$LC_DIR" --no-progress "$LC_DIR/**/*.html"
+echo "check-links: OK (internal links resolve)"


### PR DESCRIPTION
## What

Completes kure's enforcement of the documentation-sync standard and cascades the mandatory rule into kure's agentic files (Part C for this repo).

## Layer 1 — link integrity (blocking)
`site/scripts/check-links.sh` renders the site with root-relative URLs and runs `lychee --offline --root-dir` so every internal link is resolved against the output tree. Wired into the `docs-build` job (required). This catches the broken-link class that produced the original generators 404. External links are intentionally not checked here (offline) to avoid flaky CI.

## Layer 3 — docs-with-code change-gate (blocking)
`site/scripts/check-doc-gate.sh`: if a `docs-map.yaml`-mapped package's source changes, its mapped README/guide must change in the same PR. Runs as an **always-on** PR job (`doc-gate`) added to the `build` aggregate, so a pkg-only change can't skip it. Replaces the old non-blocking `::warning::`. Bypass only via the **maintainer-restricted `docs-skip` label** (passed to the script; the job still reports).

## Part C cascade (kure)
`AGENTS.md` + `.claude/CLAUDE.md` now state the mandatory, CI-enforced rule, point to the org standard (`go-kure/.github` → `docs/standards.md`), and describe `docs-map.yaml` as the single source.

## Verification (local)
- `check-doc-sync`, `check-links` (1894 OK / 0 errors), and `check-doc-gate` all pass on a clean tree.
- Tamper tests: a broken rendered link fails lychee; a pkg-source-only change fails the gate; `--skip=true` and the `docs-skip` label bypass it.
- `lychee` v0.24.2 pinned; `docs-build` installs it (cached).