### PR TITLE
feat(release): add prerelease bump scope

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -4,12 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       scope:
-        description: 'Version scope to bump'
+        description: 'Version scope to bump (minor/major start a new cycle; prerelease increments the prerelease number)'
         required: true
         type: choice
         options:
           - minor
           - major
+          - prerelease
       dry_run:
         description: 'Dry run (preview only, no changes)'
         required: false

--- a/Makefile
+++ b/Makefile
@@ -363,7 +363,7 @@ changelog-preview: ## Preview unreleased changelog entries
 release: ## Preview release (dry-run)
 	@if [ -z "$(TYPE)" ]; then \
 		echo "Usage: make release TYPE={alpha|beta|rc|stable}"; \
-		echo "       make release TYPE=bump SCOPE={minor|major}"; \
+		echo "       make release TYPE=bump SCOPE={minor|major|prerelease}"; \
 		exit 1; \
 	fi
 	@DRY_RUN=1 ./scripts/release.sh $(TYPE) $(SCOPE)

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -15,7 +15,7 @@ This document provides an overview of all GitHub Actions workflows used in the k
 | [Manage Docs](#manage-docs-workflow) | `manage-docs.yml` | `workflow_dispatch` | Remove, rebuild, or re-point doc versions |
 | [Release / Create](#release--create-workflow) | `release-create.yml` | manual | Auto-infer release type from VERSION, create tag |
 | [Release / Promote](#release--promote-workflow) | `release-promote.yml` | manual | Promote to explicit release type (beta/rc/stable) |
-| [Release / Bump](#release--bump-workflow) | `release-bump.yml` | manual | Advance version cycle (minor/major), no tag |
+| [Release / Bump](#release--bump-workflow) | `release-bump.yml` | manual | Advance version cycle (minor/major/prerelease), no tag |
 | [Release / Publish](#release--publish-workflow) | `release-publish.yml` | tag push | GoReleaser, SBOM, cosign signing, docs deploy, proxy refresh |
 | [PR Review](#pr-review-workflow) | `pr-review.yml` | pull_request | Two-pass AI code review via claude-max-proxy |
 
@@ -197,7 +197,7 @@ Explicit type transition (e.g., beta → rc). The regression guard in `release.s
 
 ### Triggers
 
-- Manual dispatch with inputs: `scope` (minor/major) and `dry_run`
+- Manual dispatch with inputs: `scope` (minor/major/prerelease) and `dry_run`
 
 ### Purpose
 

--- a/scripts/release-trigger.sh
+++ b/scripts/release-trigger.sh
@@ -4,7 +4,7 @@
 # Usage:
 #   ./scripts/release-trigger.sh                         # Preview release (auto-infer from VERSION)
 #   ./scripts/release-trigger.sh promote <rc|beta|stable> # Preview type promotion
-#   ./scripts/release-trigger.sh bump <minor|major>      # Preview version bump
+#   ./scripts/release-trigger.sh bump <minor|major|prerelease> # Preview version bump
 #   ./scripts/release-trigger.sh --do-it                 # Execute release via CI
 #   ./scripts/release-trigger.sh promote rc --do-it      # Execute promotion via CI
 #   ./scripts/release-trigger.sh bump minor --do-it      # Execute bump via CI
@@ -52,9 +52,9 @@ if [ "$SUBCOMMAND" = "promote" ]; then
     esac
 elif [ "$SUBCOMMAND" = "bump" ]; then
     case "$ARG" in
-        minor|major) ;;
-        "") echo "ERROR: 'bump' requires a scope: minor or major" >&2; exit 1 ;;
-        *)  echo "ERROR: invalid bump scope '$ARG' (use: minor, major)" >&2; exit 1 ;;
+        minor|major|prerelease) ;;
+        "") echo "ERROR: 'bump' requires a scope: minor, major, or prerelease" >&2; exit 1 ;;
+        *)  echo "ERROR: invalid bump scope '$ARG' (use: minor, major, prerelease)" >&2; exit 1 ;;
     esac
 fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,7 +10,7 @@
 # Environment:
 #   RELEASE_TYPE   Release type: auto|alpha|beta|rc|stable|bump (or positional arg)
 #                  When unset or 'auto', infers from VERSION file.
-#   RELEASE_SCOPE  Bump scope: minor|major (or positional arg after "bump")
+#   RELEASE_SCOPE  Bump scope: minor|major|prerelease (or positional arg after "bump")
 #   DRY_RUN        1 = preview without changes (default: 0)
 #   CI             Set by CI runners; enables push and git identity setup
 #
@@ -398,7 +398,7 @@ release_stable() {
 
 release_bump() {
     scope="$1"
-    [ -n "$scope" ] || die "bump requires scope: minor or major"
+    [ -n "$scope" ] || die "bump requires scope: minor, major, or prerelease"
 
     current=$(read_version)
     validate_version "$current"
@@ -406,12 +406,26 @@ release_bump() {
     base=$(base_part "$current")
 
     case "$scope" in
-        minor) new_base=$(bump_minor "$base") ;;
-        major) new_base=$(bump_major "$base") ;;
-        *)     die "Invalid bump scope: $scope (use 'minor' or 'major')" ;;
+        minor)
+            next_version=$(start_prerelease "$(bump_minor "$base")" "alpha")
+            commit_msg="chore: start next cycle: $next_version"
+            ;;
+        major)
+            next_version=$(start_prerelease "$(bump_major "$base")" "alpha")
+            commit_msg="chore: start next cycle: $next_version"
+            ;;
+        prerelease)
+            is_prerelease "$current" \
+                || die "Cannot bump prerelease: $current is not a prerelease — use minor or major to start a new cycle."
+            next_version=$(bump_prerelease "$current")
+            commit_msg="chore: bump prerelease: $current -> $next_version"
+            ;;
+        *)
+            die "Invalid bump scope: $scope (use 'minor', 'major', or 'prerelease')"
+            ;;
     esac
 
-    next_version=$(start_prerelease "$new_base" "alpha")
+    validate_version "$next_version"
 
     log_info "Current version:  $current"
     log_info "Next dev version: $next_version"
@@ -419,15 +433,17 @@ release_bump() {
 
     if [ "$DRY_RUN" != "1" ]; then
         validate_git_state
+        # Invariant: a bump must never leave VERSION equal to an existing tag.
+        check_tag_exists "$next_version"
     fi
 
     write_version "$next_version"
     if [ "$DRY_RUN" = "1" ]; then
-        log_info "[DRY_RUN] Would commit: chore: start next cycle: $next_version"
+        log_info "[DRY_RUN] Would commit: $commit_msg"
     else
         git add "$VERSION_FILE"
-        git commit -m "chore: start next cycle: $next_version"
-        log_success "Started $scope version cycle at $next_version"
+        git commit -m "$commit_msg"
+        log_success "Bumped version to $next_version"
     fi
 
     # Bump doesn't create a tag — just push the version commit
@@ -452,11 +468,12 @@ Types:
   beta        Create a beta prerelease
   rc          Create a release candidate
   stable      Create a stable release
-  bump        Bump minor or major version (requires scope)
+  bump        Bump minor, major, or prerelease version (requires scope)
 
 Scope (for bump only):
   minor       Bump minor version and start alpha cycle
   major       Bump major version and start alpha cycle
+  prerelease  Increment the prerelease number (e.g. alpha.7 -> alpha.8)
 
 Environment:
   DRY_RUN=1         Preview changes without making them
@@ -468,6 +485,7 @@ Examples:
   $0 alpha                       # Create alpha release
   DRY_RUN=1 $0 stable            # Preview stable release
   $0 bump minor                  # Start next minor version cycle
+  $0 bump prerelease             # Increment prerelease number (alpha.N -> alpha.N+1)
   RELEASE_TYPE=alpha $0          # CI-style invocation
 EOF
     exit 1


### PR DESCRIPTION
## Change

Add a `prerelease` bump scope to `release.sh bump` that increments the prerelease number within the current cycle (e.g. `beta.6 → beta.7`), preserving the prerelease type, with no tag — reusing the existing `bump_prerelease()` helper.

New invariant, guarded for all bump scopes: a bump never leaves `VERSION` equal to an existing tag (`check_tag_exists` on the computed next version).

Touches: `scripts/release.sh`, `scripts/release-trigger.sh`, `Makefile`, `.github/workflows/release-bump.yml` (choice option), `docs/github-workflows.md`.

## Verification

- `sh -n` + `shellcheck --severity=warning` clean (pre-existing SC2001 warnings unchanged).
- Dry-run: `bump prerelease` on `v0.2.0-beta.6` → `v0.2.0-beta.7`; `bump minor` → `v0.3.0-alpha.0`.
- Guards: non-prerelease `VERSION` aborts; tag-existence guard aborts before any write.

Part of an org-wide rollout (meta templates + standard, launcher, crane, pkg, barge, shared `go-kure/.github` workflow). Mirrors go-kure/launcher#178.