### PR TITLE
perf(ci): source-aware Go build cache, split by job purpose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,13 +100,31 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gomod-
 
-    - name: Cache Go build cache
-      uses: actions/cache@v6
+    - name: Read Go version from go.mod
+      id: go-version
+      run: |
+        GO_VER=$(grep '^go ' go.mod | awk '{print $2}')
+        echo "version=$GO_VER" >> $GITHUB_OUTPUT
+        echo "Using Go version: $GO_VER"
+
+    # Source-aware Go build cache (was go.sum-only → froze at an old snapshot). Warmed on
+    # push-to-main, restored by PR + queue via fallback. Split restore/save + matched-key log;
+    # distinct job prefix so lint and test don't overwrite each other's entry.
+    - name: Restore Go build cache
+      id: gocache
+      uses: actions/cache/restore@v6
       with:
         path: ~/.cache/go-build
-        key: ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-validate-deps-${{ hashFiles('go.mod', 'go.sum') }}-src-${{ hashFiles('**/*.go', 'go.mod', 'go.sum', 'Makefile', '**/testdata/**') }}
         restore-keys: |
-          ${{ runner.os }}-gobuild-
+          ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-validate-deps-${{ hashFiles('go.mod', 'go.sum') }}-src-
+          ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-validate-
+
+    - name: Log Go build cache restore
+      run: |
+        echo "cache-hit=${{ steps.gocache.outputs.cache-hit }}"
+        echo "primary-key=${{ steps.gocache.outputs.cache-primary-key }}"
+        echo "matched-key=${{ steps.gocache.outputs.cache-matched-key }}"
 
     - name: Install dependencies
       run: make deps
@@ -183,6 +201,13 @@ jobs:
           make lint
         fi
 
+    - name: Save Go build cache
+      if: success() && steps.gocache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v6
+      with:
+        path: ~/.cache/go-build
+        key: ${{ steps.gocache.outputs.cache-primary-key }}
+
   # =============================================================================
   # Stage 2: Tests and Security (parallel with lint)
   # =============================================================================
@@ -217,13 +242,29 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gomod-
 
-    - name: Cache Go build cache
-      uses: actions/cache@v6
+    - name: Read Go version from go.mod
+      id: go-version
+      run: |
+        GO_VER=$(grep '^go ' go.mod | awk '{print $2}')
+        echo "version=$GO_VER" >> $GITHUB_OUTPUT
+        echo "Using Go version: $GO_VER"
+
+    # Source-aware Go build cache (see the validate job for rationale). Distinct prefix.
+    - name: Restore Go build cache
+      id: gocache
+      uses: actions/cache/restore@v6
       with:
         path: ~/.cache/go-build
-        key: ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-test-race-cover-deps-${{ hashFiles('go.mod', 'go.sum') }}-src-${{ hashFiles('**/*.go', 'go.mod', 'go.sum', 'Makefile', '**/testdata/**') }}
         restore-keys: |
-          ${{ runner.os }}-gobuild-
+          ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-test-race-cover-deps-${{ hashFiles('go.mod', 'go.sum') }}-src-
+          ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-test-race-cover-
+
+    - name: Log Go build cache restore
+      run: |
+        echo "cache-hit=${{ steps.gocache.outputs.cache-hit }}"
+        echo "primary-key=${{ steps.gocache.outputs.cache-primary-key }}"
+        echo "matched-key=${{ steps.gocache.outputs.cache-matched-key }}"
 
     - name: Install dependencies
       run: make deps
@@ -233,6 +274,13 @@ jobs:
         set -euo pipefail
         mkdir -p coverage
         go test -v -race -coverprofile=coverage/coverage.out -covermode=atomic -timeout 15m ./... 2>&1 | tee /tmp/gotest.log
+
+    - name: Save Go build cache
+      if: success() && steps.gocache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v6
+      with:
+        path: ~/.cache/go-build
+        key: ${{ steps.gocache.outputs.cache-primary-key }}
 
     - name: Upload test log
       uses: actions/upload-artifact@v7
@@ -293,6 +341,31 @@ jobs:
         path: ~/go/bin/govulncheck
         key: govulncheck-${{ env.GOVULNCHECK_VERSION }}
 
+    - name: Read Go version from go.mod
+      id: go-version
+      run: |
+        GO_VER=$(grep '^go ' go.mod | awk '{print $2}')
+        echo "version=$GO_VER" >> $GITHUB_OUTPUT
+        echo "Using Go version: $GO_VER"
+
+    # Source-aware Go build cache. govulncheck's scan compiles the module, so a warm cache
+    # helps here too (this job had no build cache before). Distinct prefix.
+    - name: Restore Go build cache
+      id: gocache
+      uses: actions/cache/restore@v6
+      with:
+        path: ~/.cache/go-build
+        key: ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-security-deps-${{ hashFiles('go.mod', 'go.sum') }}-src-${{ hashFiles('**/*.go', 'go.mod', 'go.sum', 'Makefile', '**/testdata/**') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-security-deps-${{ hashFiles('go.mod', 'go.sum') }}-src-
+          ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-security-
+
+    - name: Log Go build cache restore
+      run: |
+        echo "cache-hit=${{ steps.gocache.outputs.cache-hit }}"
+        echo "primary-key=${{ steps.gocache.outputs.cache-primary-key }}"
+        echo "matched-key=${{ steps.gocache.outputs.cache-matched-key }}"
+
     - name: Install govulncheck
       if: steps.govulncheck-cache.outputs.cache-hit != 'true'
       run: go install golang.org/x/vuln/cmd/govulncheck@${{ env.GOVULNCHECK_VERSION }}
@@ -324,6 +397,13 @@ jobs:
         else
           echo ":white_check_mark: **govulncheck** — no vulnerabilities found" >> "$GITHUB_STEP_SUMMARY"
         fi
+
+    - name: Save Go build cache
+      if: success() && steps.gocache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v6
+      with:
+        path: ~/.cache/go-build
+        key: ${{ steps.gocache.outputs.cache-primary-key }}
 
     - name: Check for outdated dependencies
       run: make outdated

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -2,7 +2,7 @@
 
 This document provides an overview of all GitHub Actions workflows used in the kure project.
 
-**Last Updated:** 2026-06-02
+**Last Updated:** 2026-07-02
 
 ---
 
@@ -477,28 +477,56 @@ source of truth (kept in sync with `mise.toml` via `make check-go-version`).
 
 ### Caching
 
-CI jobs use explicit `actions/cache@v5` steps with `cache: false` on `setup-go` to
-control cache keys precisely. Two separate Go caches are maintained:
+CI jobs use explicit `actions/cache` steps with `cache: false` on `setup-go` to control
+cache keys precisely. Two Go caches are maintained.
+
+**Module cache** — dependency-only, one combined step per Go job:
 
 ```yaml
-# Module cache: stable, invalidates only when go.sum changes
 - name: Cache Go modules
-  uses: actions/cache@v5
+  uses: actions/cache@v6
   with:
     path: ~/go/pkg/mod
     key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
     restore-keys: |
       ${{ runner.os }}-gomod-
+```
 
-# Build cache: invalidates when go.sum changes, shared across commits with same deps
-- name: Cache Go build cache
-  uses: actions/cache@v5
+**Go build cache** (`~/.cache/go-build`) — split `actions/cache/restore` + `actions/cache/save`
+so the log shows exact vs fallback restore (`cache-matched-key`). The key is **source-aware**
+(was `go.sum`-only, which froze the cache at an old snapshot and never refreshed as source
+changed) and **split by job purpose** so `validate` (non-race) and `test` (race+coverage) never
+overwrite each other's entry:
+
+```yaml
+- name: Restore Go build cache
+  id: gocache
+  uses: actions/cache/restore@v6
   with:
     path: ~/.cache/go-build
-    key: ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}
+    key: ${{ runner.os }}-${{ runner.arch }}-go-<GOVER>-gocache-<purpose>-deps-<go.sum hash>-src-<source hash>
     restore-keys: |
-      ${{ runner.os }}-gobuild-
+      ${{ runner.os }}-${{ runner.arch }}-go-<GOVER>-gocache-<purpose>-deps-<go.sum hash>-src-
+      ${{ runner.os }}-${{ runner.arch }}-go-<GOVER>-gocache-<purpose>-
+# ... compile / test ...
+- name: Save Go build cache
+  if: success() && steps.gocache.outputs.cache-hit != 'true'
+  uses: actions/cache/save@v6
+  with:
+    path: ~/.cache/go-build
+    key: ${{ steps.gocache.outputs.cache-primary-key }}
 ```
+
+Purpose prefixes: `gocache-validate-`, `gocache-test-race-cover-`, `gocache-security-`. `<GOVER>`
+comes from a `Read Go version from go.mod` step. The source hash covers `**/*.go`, `go.mod`,
+`go.sum`, `Makefile`, `**/testdata/**`. Save runs only on a non-exact (fallback/miss) restore and
+only when the run succeeded, so a broken build never publishes a cache.
+
+**Cross-ref scoping.** GitHub caches are ref-scoped: a `merge_group` (queue) run cannot restore a
+`pull_request` run's cache — only the default branch (`main`) is shared. So these caches are warmed
+by push-to-main and restored by PR + queue via restore-key fallback. This lowers both runs'
+absolute cost but does not deduplicate the PR↔queue build (inherent to the merge queue). Measured
+in launcher: warmed cycles cut `test` ~50%, `build`/`lint` ~30%.
 
 Tool binaries are also cached to avoid reinstalling on every run:
 - `goimports` — keyed by `go.sum` hash (tied to `golang.org/x/tools` version)


### PR DESCRIPTION
Ports the validated launcher change ([go-kure/launcher#179](https://github.com/go-kure/launcher/pull/179)) to kure.

## Problem
kure's `~/.cache/go-build` cache (in `validate` + `test`) was keyed on `go.sum` only:
- `actions/cache` skips the save on an exact-key hit, so the cache froze at an old snapshot and each run recompiled the source delta without saving it.
- `validate` (non-race) and `test` (race+coverage) shared one key, so whichever saved first won and the expensive race-test cache could be lost.
- `security` had no build cache at all (govulncheck compiles the module).

## Change (`.github/workflows/ci.yml`: `validate`, `test`, `security`)
- **Source-aware keys** — hash over `**/*.go, go.mod, go.sum, Makefile, **/testdata/**`, so main-warmed caches refresh per tree.
- **Split by job purpose** — `gocache-validate-` / `-test-race-cover-` / `-security-`; no cross-job overwrite.
- Split `actions/cache/restore` + `save` with matched-key logging; save guarded by `success() && cache-hit != 'true'`.
- Added the build cache to `security`; added a `Read Go version from go.mod` step for readable, aligned keys.
- Module cache (`~/go/pkg/mod`) unchanged (`go.sum`-keyed).

## Scope (proven in launcher)
GitHub caches are ref-scoped: a `merge_group` run **cannot** restore a `pull_request` run's cache (verified). Caches are warmed by **push-to-main** and restored by PR + queue via fallback. This lowers both runs' absolute cost; it does **not** dedupe the PR↔queue build (inherent to the merge queue). Launcher measurement: warmed cycles cut `test` ~50%, `build`/`lint` ~30%.

Docs: `docs/github-workflows.md` Caching section updated in the same commit.