### PR TITLE
test(ci): kure warm-cache confirmation probe (throwaway — do not merge)

### DIFF
--- a/pkg/gvk/conversion_test.go
+++ b/pkg/gvk/conversion_test.go
@@ -309,3 +309,5 @@ func TestConversionRegistryConcurrentAccess(t *testing.T) {
 
 	wg.Wait()
 }
+
+// warm-cache confirmation probe: trivial change to measure fallback restore. Revert.


### PR DESCRIPTION
Throwaway measurement PR for the source-aware build-cache work (#612). Trivial one-package test change; its PR run should fallback-restore main's warm build cache and show `(cached)` for unchanged packages + lower durations vs baseline. **Do not merge** — closed after reading logs.