### PR TITLE
chore(go): bump Go to 1.26.5

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -14,7 +14,7 @@ Kure maintains two version concepts for each dependency:
 
 ## Go Version
 
-**Current:** Go 1.26.3
+**Current:** Go 1.26.5
 
 ## Infrastructure Dependencies
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kure/kure
 
-go 1.26.3
+go 1.26.5
 
 // Replace directives: pin all k8s.io packages to the same patch release.
 //

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 # Use exact versions for reproducibility across environments
-go = "1.26.3"
+go = "1.26.5"
 golangci-lint = "2.10.1"
 git-cliff = "2.7.0"
 hugo = "0.155.3"

--- a/versions.yaml
+++ b/versions.yaml
@@ -18,7 +18,7 @@
 
 # Go version (mise.toml is authoritative for tooling)
 go:
-  current: "1.26.3"
+  current: "1.26.5"
   # mise.toml is the source of truth for Go version
 
 # Infrastructure dependencies


### PR DESCRIPTION
Align Go toolchain with the rest of the go-kure/wharf ecosystem (crane and launcher already require 1.26.5). Bumps `go.mod` go directive and `mise.toml` go tool to 1.26.5. No source changes; `go build ./...` passes.