### PR TITLE
fix(docs): resolve section-nav links under the version slot

### DIFF
--- a/site/content/api-reference/_index.md
+++ b/site/content/api-reference/_index.md
@@ -16,37 +16,37 @@ For full Go API documentation, see [pkg.go.dev/github.com/go-kure/kure](https://
 
 | Package | Description | Reference |
 |---------|-------------|-----------|
-| [Stack](stack) | Cluster, Node, Bundle, Application domain model | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/stack) |
-| [Flux Engine](flux-engine) | FluxCD workflow implementation | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/stack/fluxcd) |
-| [Layout Engine](layout) | Manifest directory organization | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/stack/layout) |
+| [Stack](/api-reference/stack/) | Cluster, Node, Bundle, Application domain model | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/stack) |
+| [Flux Engine](/api-reference/flux-engine/) | FluxCD workflow implementation | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/stack/fluxcd) |
+| [Layout Engine](/api-reference/layout/) | Manifest directory organization | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/stack/layout) |
 
 ## Resource Operations
 
 | Package | Description | Reference |
 |---------|-------------|-----------|
-| [IO](io) | YAML/JSON serialization and resource printing | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/io) |
-| [Manifest Classification](manifest) | CRD recognition and object scope classification | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/manifest) |
-| [Kubernetes Builders](kubernetes-builders) | Core K8s resource constructors (GVK, HPA, PDB) | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes) |
-| [Cert-Manager Builders](certmanager-builders) | cert-manager CRD constructors (Certificate, Issuer, ClusterIssuer) | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/certmanager) |
-| [Cilium Builders](cilium-builders) | Cilium CRD constructors (network policies and related resources) | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/cilium) |
-| [CloudNativePG Builders](cnpg-builders) | CloudNativePG and Barman Cloud CRD constructors | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/cnpg) |
-| [External Secrets Builders](externalsecrets-builders) | External Secrets Operator constructors (ExternalSecret, SecretStore) | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/externalsecrets) |
-| [FluxCD Builders](fluxcd-builders) | Low-level Flux resource constructors | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/fluxcd) |
-| [MetalLB Builders](metallb-builders) | MetalLB constructors (IPAddressPool, L2Advertisement) | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/metallb) |
-| [Prometheus Builders](prometheus-builders) | Prometheus Operator CRD constructors (ServiceMonitor, PodMonitor, PrometheusRule) | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/prometheus) |
-| [VolSync Builders](volsync-builders) | VolSync backup/restore CRD constructors | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/volsync) |
+| [IO](/api-reference/io/) | YAML/JSON serialization and resource printing | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/io) |
+| [Manifest Classification](/api-reference/manifest/) | CRD recognition and object scope classification | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/manifest) |
+| [Kubernetes Builders](/api-reference/kubernetes-builders/) | Core K8s resource constructors (GVK, HPA, PDB) | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes) |
+| [Cert-Manager Builders](/api-reference/certmanager-builders/) | cert-manager CRD constructors (Certificate, Issuer, ClusterIssuer) | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/certmanager) |
+| [Cilium Builders](/api-reference/cilium-builders/) | Cilium CRD constructors (network policies and related resources) | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/cilium) |
+| [CloudNativePG Builders](/api-reference/cnpg-builders/) | CloudNativePG and Barman Cloud CRD constructors | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/cnpg) |
+| [External Secrets Builders](/api-reference/externalsecrets-builders/) | External Secrets Operator constructors (ExternalSecret, SecretStore) | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/externalsecrets) |
+| [FluxCD Builders](/api-reference/fluxcd-builders/) | Low-level Flux resource constructors | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/fluxcd) |
+| [MetalLB Builders](/api-reference/metallb-builders/) | MetalLB constructors (IPAddressPool, L2Advertisement) | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/metallb) |
+| [Prometheus Builders](/api-reference/prometheus-builders/) | Prometheus Operator CRD constructors (ServiceMonitor, PodMonitor, PrometheusRule) | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/prometheus) |
+| [VolSync Builders](/api-reference/volsync-builders/) | VolSync backup/restore CRD constructors | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/kubernetes/volsync) |
 
 ## Utilities
 
 | Package | Description | Reference |
 |---------|-------------|-----------|
-| [Errors](errors) | Structured error types | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/errors) |
-| [Logger](logger) | Structured logging | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/logger) |
+| [Errors](/api-reference/errors/) | Structured error types | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/errors) |
+| [Logger](/api-reference/logger/) | Structured logging | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/pkg/logger) |
 <!-- END GENERATED: api-reference-nav -->
 
 ## Compatibility
 
-- [Compatibility Matrix](compatibility) - Supported Kubernetes and dependency versions
+- [Compatibility Matrix](/api-reference/compatibility/) - Supported Kubernetes and dependency versions
 
 ## ArgoCD
 

--- a/site/content/changelog/_index.md
+++ b/site/content/changelog/_index.md
@@ -7,4 +7,4 @@ weight = 70
 
 Track changes across Kure releases.
 
-- [Releases](releases) - Version history and release notes
+- [Releases](/changelog/releases/) - Version history and release notes

--- a/site/content/concepts/_index.md
+++ b/site/content/concepts/_index.md
@@ -7,6 +7,6 @@ weight = 20
 
 Understand the ideas behind Kure's design.
 
-- [Architecture](architecture) - System architecture and component overview
-- [Domain Model](domain-model) - The Cluster, Node, Bundle, Application hierarchy
-- [Design Philosophy](design-philosophy) - Type-safe builders, no templating, GitOps-native
+- [Architecture](/concepts/architecture/) - System architecture and component overview
+- [Domain Model](/concepts/domain-model/) - The Cluster, Node, Bundle, Application hierarchy
+- [Design Philosophy](/concepts/design-philosophy/) - Type-safe builders, no templating, GitOps-native

--- a/site/content/contributing/_index.md
+++ b/site/content/contributing/_index.md
@@ -7,8 +7,8 @@ weight = 70
 
 Resources for contributing to Kure.
 
-- [Development Guide](guide) - Setup, testing, code quality, and CI/CD workflows
-- [GitHub Workflows](github-workflows) - CI/CD pipeline documentation
+- [Development Guide](/contributing/guide/) - Setup, testing, code quality, and CI/CD workflows
+- [GitHub Workflows](/contributing/github-workflows/) - CI/CD pipeline documentation
 
 ## Quick Start
 

--- a/site/content/examples/_index.md
+++ b/site/content/examples/_index.md
@@ -11,7 +11,7 @@ Practical examples of using Kure to generate Kubernetes configurations.
 
 These examples include full documentation:
 
-- [Patches](patches) - Declarative patching with TOML and YAML formats
+- [Patches](/examples/patches/) - Declarative patching with TOML and YAML formats
 
 ## Additional Examples
 

--- a/site/content/getting-started/_index.md
+++ b/site/content/getting-started/_index.md
@@ -27,7 +27,7 @@ import (
 
 ## Next Steps
 
-- Follow the [Quickstart](quickstart) guide
+- Follow the [Quickstart](/getting-started/quickstart/) guide
 - Read about the [Domain Model](/concepts/domain-model) and [Design Philosophy](/concepts/design-philosophy)
 - Explore the [Guides](/guides) for common workflows
 - Try the [Examples](/examples)

--- a/site/content/guides/_index.md
+++ b/site/content/guides/_index.md
@@ -7,6 +7,6 @@ weight = 30
 
 Step-by-step guides for common Kure workflows.
 
-- [Using Kure as a Library](library-usage) - Import paths, creating resources, generating YAML
-- [Generating Flux Manifests](flux-workflow) - End-to-end cluster definition to disk
-- [Patching Resources](patching) - JSONPath patching and TOML patch format
+- [Using Kure as a Library](/guides/library-usage/) - Import paths, creating resources, generating YAML
+- [Generating Flux Manifests](/guides/flux-workflow/) - End-to-end cluster definition to disk
+- [Patching Resources](/guides/patching/) - JSONPath patching and TOML patch format

--- a/site/scripts/gen-docs-tables.sh
+++ b/site/scripts/gen-docs-tables.sh
@@ -63,8 +63,7 @@ build_nav() {
     yq ".packages[] | select(.mount and .mount.group == \"${group}\") | [.path, .mount.target, .mount.title, .mount.weight, .mount.desc] | @tsv" "$DOCS_MAP" \
     | sort -t"$(printf '\t')" -k4 -n \
     | while IFS=$'\t' read -r path target title weight desc; do
-        local base="${target#api-reference/}"; base="${base%.md}"
-        echo "| [${title}](${base}) | ${desc} | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/${path}) |"
+        echo "| [${title}](/${target%.md}/) | ${desc} | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/kure/${path}) |"
       done
   done
 }


### PR DESCRIPTION
## Problem

A crawler over the docs site reported 21 `/kure/dev/<slug>` URLs as 404 (e.g. `/kure/dev/logger`, `/kure/dev/kubernetes-builders`, `/kure/dev/library-usage`). None of the target content is missing — these are structural link bugs.

Section index pages linked to their children with **bare, section-relative** targets like `[Stack](stack)`. The site deploys under `/kure/<slot>/` and the render-link hook only version-corrects links that start with `/`, so bare links were resolved by the live server relative to the section page, dropping the `api-reference/` / `guides/` / `examples/` segment → `/kure/dev/<slug>` 404.

## Fix

Emit root-absolute, section-qualified links so the render-link hook rewrites them to `/kure/dev/<section>/<slug>/`:

- `site/scripts/gen-docs-tables.sh` `build_nav()` now emits `/${target%.md}/`; regenerated the api-reference nav block.
- Converted the hand-authored bare links in the section `_index.md` pages — the crawled ones (api-reference, guides, examples) plus the same latent pattern in concepts, getting-started, changelog, contributing (pre-empting future 404s).

`check-links.sh` builds with `--baseURL "/"`, which masks this bug class (bare links resolve fine filesystem-relative), so CI never caught it.

## Verification

- `bash site/scripts/gen-docs-tables.sh --check` → in sync.
- Real-baseURL build (`hugo --baseURL https://www.gokure.dev/kure/dev/`): every previously-broken link renders as `/kure/dev/<section>/<slug>/`, all targets exist.
- `bash site/scripts/check-links.sh` → 0 errors.

Docs-only change; no `pkg/` source touched.