### PR TITLE
fix(docs): make README cross-package links root-absolute

### DIFF
--- a/pkg/io/README.md
+++ b/pkg/io/README.md
@@ -144,5 +144,5 @@ err := io.ValidateOutputFormat("table")
 
 ## Related Packages
 
-- [errors](../errors/) - Error types for parse failures
+- [errors](/api-reference/errors/) - Error types for parse failures
 - [kubernetes](/api-reference/kubernetes-builders/) - Scheme registration for type-aware parsing

--- a/pkg/kubernetes/README.md
+++ b/pkg/kubernetes/README.md
@@ -326,4 +326,4 @@ kubernetes.SetConfigMapAnnotations(cm, map[string]string{"managed-by": "crane"})
 
 - [fluxcd](/api-reference/fluxcd-builders/) - FluxCD resource constructors
 - [prometheus](/api-reference/prometheus-builders/) - Prometheus Operator CRD builders
-- [errors](../errors/) - Structured error types used for nil-check sentinels
+- [errors](/api-reference/errors/) - Structured error types used for nil-check sentinels

--- a/pkg/logger/README.md
+++ b/pkg/logger/README.md
@@ -40,4 +40,4 @@ log = logger.Noop()
 
 ## Related Packages
 
-All Kure packages use this logger. See the [errors](../errors/) package for error handling patterns.
+All Kure packages use this logger. See the [errors](/api-reference/errors/) package for error handling patterns.

--- a/pkg/stack/argocd/README.md
+++ b/pkg/stack/argocd/README.md
@@ -65,6 +65,6 @@ err = engine.IntegrateWithLayout(ml, cluster, layout.LayoutRules{})
 
 ## Related Packages
 
-- [stack/fluxcd](../fluxcd/) — full-featured FluxCD engine including bootstrap
-- [stack](../) — domain model and Workflow interface
-- [stack/layout](../layout/) — manifest layout generation
+- [stack/fluxcd](/api-reference/flux-engine/) — full-featured FluxCD engine including bootstrap
+- [stack](/api-reference/stack/) — domain model and Workflow interface
+- [stack/layout](/api-reference/layout/) — manifest layout generation

--- a/pkg/stack/fluxcd/README.md
+++ b/pkg/stack/fluxcd/README.md
@@ -214,6 +214,6 @@ depth. `FluxSeparate` and non-Flux paths are unaffected.
 
 ## Related Packages
 
-- [stack](../) - Core domain model
-- [stack/layout](../layout/) - Manifest directory organization
+- [stack](/api-reference/stack/) - Core domain model
+- [stack/layout](/api-reference/layout/) - Manifest directory organization
 - [kubernetes/fluxcd](/api-reference/fluxcd-builders/) - Low-level Flux resource builders


### PR DESCRIPTION
## Problem

Follow-up to #621. After that fix, two crawler 404s remained:

- `https://www.gokure.dev/kure/dev/errors/`
- `https://www.gokure.dev/kure/dev/layout/`

These have a **trailing slash** and came from a *different* source than the nav links #621 fixed: the mounted package READMEs cross-referenced the `errors` and `layout` packages with **relative** links (`../errors/`, `../layout/`, and also `../`, `../fluxcd/`). A relative link isn't rewritten by the render-link hook (it doesn't start with `/`), so a client resolves it against the referring page URL — and when that URL lacks a trailing slash it overshoots to `/kure/dev/errors/` and `/kure/dev/layout/`, which 404. `errors` and `layout` were the only packages linked this relative way, which is exactly why they were the sole remaining failures. `[stack](../)` additionally pointed at the section index rather than the stack page.

## Fix

Convert every relative `../` cross-link in the mounted READMEs to root-absolute `/api-reference/<slug>/` (which the hook rewrites deterministically to `/kure/dev/api-reference/<slug>/`), matching the correct links already present in the same "Related Packages" lists:

- `pkg/io/README.md`, `pkg/logger/README.md`, `pkg/kubernetes/README.md` → `[errors](/api-reference/errors/)`
- `pkg/stack/fluxcd/README.md` → `[stack](/api-reference/stack/)`, `[stack/layout](/api-reference/layout/)`
- `pkg/stack/argocd/README.md` (not mounted; fixed for consistency) → stack / flux-engine / layout

## Verification

- Rebuild (`hugo --baseURL https://www.gokure.dev/kure/dev/`) emits **no** relative `../` hrefs and **no** bare `/kure/dev/<pkg>/` links; the cross-links resolve to `/kure/dev/api-reference/<slug>/`.
- `bash site/scripts/check-links.sh` → 0 errors.