### PR TITLE
ci(deps): group the fluxcd ecosystem and fail check on stale compatibility docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,18 @@ updates:
         update-types:
           - "patch"
 
+      # FluxCD ecosystem — the controller API modules are released together and
+      # kure imports them as one surface, so they must be reviewed and bumped as
+      # one unit. Ungrouped, a single upstream release arrives as five separate
+      # PRs whose go.mod changes conflict with each other in the merge queue.
+      # Minor/major are ignored below, so this group only ever carries patches.
+      fluxcd-ecosystem:
+        patterns:
+          - "github.com/fluxcd/*"
+          - "github.com/controlplaneio-fluxcd/*"
+        update-types:
+          - "patch"
+
     ignore:
       # FluxCD ecosystem — cap at current series
       - dependency-name: "github.com/fluxcd/*"
@@ -46,7 +58,7 @@ updates:
       - dependency-name: "github.com/controlplaneio-fluxcd/*"
         update-types: ["version-update:semver-minor", "version-update:semver-major"]
 
-      # cert-manager — allow patch updates within 1.19.x
+      # cert-manager — allow minor and patch, block major
       - dependency-name: "github.com/cert-manager/cert-manager"
         update-types: ["version-update:semver-major"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,13 @@ jobs:
             - 'go.sum'
             - 'Makefile'
             - '.github/workflows/**'
+            # The only `sync-versions.sh check` invocation lives in the `validate`
+            # job, which is gated on this filter. Without these three entries a PR
+            # touching only version metadata skipped the range and drift guards
+            # entirely and still reported success.
+            - 'versions.yaml'
+            - 'docs/compatibility.md'
+            - 'scripts/sync-versions.sh'
           docs:
             - 'site/**'
             - 'docs/**'

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -12,10 +12,25 @@ Kure tracks dependency versions in three places:
 | `versions.yaml` | Version metadata: supported range, dependabot caps, notes (no build version) |
 | `docs/compatibility.md` | Generated from `versions.yaml` + `go.mod` — never edit directly |
 
-The `sync-versions.sh check` command reads each dependency's build version from `go.mod`
-and asserts it falls within the `supported_range` declared in `versions.yaml`; `generate`
-regenerates `docs/compatibility.md`. There is no hand-maintained "current" version to keep
-in sync (see [#593](https://github.com/go-kure/kure/issues/593)).
+The `sync-versions.sh check` command performs two assertions, and CI runs it on every
+change to `go.mod` or `versions.yaml`:
+
+1. **Range** — each dependency's build version, read from `go.mod`, falls within the
+   `supported_range` declared in `versions.yaml`.
+2. **Drift** — the committed `docs/compatibility.md` is byte-identical to what
+   `generate` would produce right now. It regenerates into a temp file and diffs;
+   your working tree is never touched. On failure it prints the diff (`-` is what is
+   committed, `+` is what `versions.yaml` + `go.mod` currently imply) and tells you to
+   run `generate`.
+
+`generate` regenerates `docs/compatibility.md` in place. There is no hand-maintained
+"current" version to keep in sync (see
+[#593](https://github.com/go-kure/kure/issues/593)).
+
+The drift assertion exists because the matrix is generated but committed: before it, any
+bump that moved a build version or a `supported_range` left the committed matrix silently
+stale until someone happened to re-run `generate`, and the staleness was caught only by
+human review — on three separate dependency PRs.
 
 ## Update Risk Levels
 
@@ -67,6 +82,13 @@ All `github.com/fluxcd/*` packages must be upgraded together. Flux releases coor
 - `image-automation-controller/api`
 - `pkg/apis/meta`, `pkg/apis/kustomize`
 
+Dependabot enforces this with the `fluxcd-ecosystem` group in
+`.github/dependabot.yml`, which covers `github.com/fluxcd/*` and
+`github.com/controlplaneio-fluxcd/*`. Ungrouped, one upstream release arrived as five
+separate PRs whose `go.mod` changes conflicted with each other in the merge queue and
+had to be consolidated by hand. Minor and major updates for both patterns are ignored
+(see the `ignore:` block), so the group only ever carries patches.
+
 ### Kubernetes (`k8s.io/*`)
 
 All `k8s.io/` packages must stay at the same patch release. Kure uses `replace` directives in `go.mod` to enforce this. See the comment block in `go.mod` for details.
@@ -108,11 +130,11 @@ When multiple Dependabot PRs accumulate, bundle them into a single PR:
 
 Before merging any dependency update:
 
-- [ ] `./scripts/sync-versions.sh check` — go.mod build versions within `supported_range`
+- [ ] `./scripts/sync-versions.sh check` — build versions within `supported_range`, and
+      `docs/compatibility.md` not stale (run `generate` first if it reports drift)
 - [ ] `make verify` — tidy + lint + test
 - [ ] `make test-race` — race condition detection
 - [ ] k8s.io replace directives unchanged (unless intentionally bumping)
-- [ ] `docs/compatibility.md` regenerated if `versions.yaml` changed
 
 ## See Also
 

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -12,8 +12,10 @@ Kure tracks dependency versions in three places:
 | `versions.yaml` | Version metadata: supported range, dependabot caps, notes (no build version) |
 | `docs/compatibility.md` | Generated from `versions.yaml` + `go.mod` — never edit directly |
 
-The `sync-versions.sh check` command performs two assertions, and CI runs it on every
-change to `go.mod` or `versions.yaml`:
+The `sync-versions.sh check` command performs two assertions. It runs in CI's `validate`
+job, which is gated on the `go` paths-filter in `.github/workflows/ci.yml` — that filter
+includes `versions.yaml`, `docs/compatibility.md` and `scripts/sync-versions.sh` precisely
+so a version-metadata-only PR cannot skip it:
 
 1. **Range** — each dependency's build version, read from `go.mod`, falls within the
    `supported_range` declared in `versions.yaml`.

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -561,7 +561,11 @@ The `docs-build` job uses two separate caches:
 The `changes` job uses `dorny/paths-filter` to skip jobs when unrelated files change:
 
 - `go:` filter — triggers lint/test/security/build jobs. Includes `**.go`, `go.mod`, `go.sum`,
-  `Makefile`, and **`.github/workflows/**`** so that workflow-only PRs are also validated.
+  `Makefile`, and **`.github/workflows/**`** so that workflow-only PRs are also validated,
+  plus `versions.yaml`, `docs/compatibility.md` and `scripts/sync-versions.sh`. Those last
+  three are here because the only `sync-versions.sh check` invocation lives in the
+  `validate` job: without them a PR touching just version metadata skipped both the
+  supported-range guard and the compatibility-matrix drift guard and still reported success.
 - `docs:` filter — triggers docs-build/docs-check jobs. Includes `site/**`, `docs/**`, `*.md`,
   `scripts/**`, and `.github/workflows/ci.yml` (only ci.yml, since other workflows don't affect
   the docs build).

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -231,7 +231,11 @@ validate_dependabot() {
 }
 
 # Generate compatibility documentation
+# $1: output path. The drift check passes a temp file here so it can compare
+# without touching the working tree; `generate` passes $DOCS_FILE itself.
 generate_docs() {
+    local DOCS_FILE="$1"
+
     info "Generating compatibility documentation..."
 
     cat > "$DOCS_FILE" << 'EOF'
@@ -328,6 +332,38 @@ EOF
     success "Generated $DOCS_FILE"
 }
 
+# Assert docs/compatibility.md matches what generate_docs would produce right now.
+#
+# Without this, `check` validated ranges only, so any bump that changed a build
+# version or a supported_range left the committed matrix silently stale until
+# someone happened to re-run `generate`. That drift was reported as a review
+# finding on three separate dependency PRs before this guard existed.
+validate_docs_drift() {
+    info ""
+    info "Validating generated documentation is current..."
+
+    local expected
+    expected=$(mktemp)
+    # shellcheck disable=SC2064  # expand $expected now, not at trap time
+    trap "rm -f '$expected' '$expected.diff'" RETURN
+
+    generate_docs "$expected" >/dev/null
+
+    if diff -u "$DOCS_FILE" "$expected" > "$expected.diff" 2>&1; then
+        success "$(basename "$DOCS_FILE") is up to date"
+        rm -f "$expected.diff"
+        return 0
+    fi
+
+    error "$(basename "$DOCS_FILE") is out of date — run: ./scripts/sync-versions.sh generate"
+    # Label the diff from the reader's point of view: '-' is what is committed,
+    # '+' is what versions.yaml + go.mod currently imply.
+    sed -e "1s|.*|--- committed: ${DOCS_FILE#"$REPO_ROOT"/}|" \
+        -e "2s|.*|+++ expected (regenerated)|" "$expected.diff" >&2
+    rm -f "$expected.diff"
+    return 1
+}
+
 # Main command router
 main() {
     local command="${1:-check}"
@@ -341,6 +377,7 @@ main() {
             local gomod_result=0
             validate_gomod || gomod_result=$?
             validate_dependabot
+            validate_docs_drift || gomod_result=1
 
             if [[ $gomod_result -eq 0 ]]; then
                 info ""
@@ -353,7 +390,7 @@ main() {
             fi
             ;;
         generate)
-            generate_docs
+            generate_docs "$DOCS_FILE"
             success "Documentation generated successfully"
             exit 0
             ;;


### PR DESCRIPTION
Two fixes to the dependency-update pipeline, both from defects that recurred across today's Dependabot batch.

## 1. Dependabot `fluxcd-ecosystem` group

`github.com/fluxcd/*` and `github.com/controlplaneio-fluxcd/*` are released together and kure imports them as one API surface, but Dependabot had no group for them. One upstream release therefore arrived as **five separate PRs** whose `go.mod` changes conflicted with each other in the merge queue, and had to be consolidated by hand into #648.

Minor and major are already ignored for both patterns in the `ignore:` block, so the new group only ever carries patches.

Also corrected a stale comment: the cert-manager ignore rule was labelled *"allow patch updates within 1.19.x"* but only ever blocked **major** — it permits minor too, which is how v1.20 and v1.21 landed.

## 2. `sync-versions.sh check` now fails on `compatibility.md` drift

`check` validated ranges only. `docs/compatibility.md` is generated but committed, so any bump that moved a build version or a `supported_range` left the committed matrix silently stale until someone re-ran `generate`. Reviewers caught it three times; nothing else did.

`validate_docs_drift` regenerates into a `mktemp` file and diffs against the committed copy, so **a check never mutates the working tree**. On failure it relabels the diff headers to `committed` vs `expected (regenerated)` — the raw temp path is noise — and names the fix command. `generate_docs` now takes its output path as a required argument, which is what makes generating-without-clobbering possible.

### Proven, not asserted

| Scenario | Result |
|---|---|
| clean tree | `rc=0` |
| widen gateway-api to `1.0 - 1.7`, do not regenerate | `rc=1`, diff shows the single changed row |
| `docs/compatibility.md` after a failing check | unmodified (`git diff` empty) |
| restore `versions.yaml` | `rc=0` again |
| temp files after both runs | none — `RETURN` trap removes both |

```
ERROR: compatibility.md is out of date — run: ./scripts/sync-versions.sh generate
--- committed: docs/compatibility.md
+++ expected (regenerated)
-| gateway-api | 1.6.1 | 1.0 - 1.6 | ... |
+| gateway-api | 1.6.1 | 1.0 - 1.7 | ... |
```

CI already runs `sync-versions.sh check` (`.github/workflows/ci.yml`), so no workflow change is needed — the new assertion is picked up automatically.

## Docs

`docs/dependency-updates.md` covers both: the two assertions `check` now makes and why the drift one exists, the `fluxcd-ecosystem` group under *Coordinated Upgrade Rules*, and a validation-checklist item that no longer duplicates the "regenerate docs" step now that CI enforces it.

## Verification

- `./scripts/sync-versions.sh check` — pass
- `site/scripts/check-doc-sync.sh` — OK (19 packages mapped)
- `site/scripts/check-links.sh` — OK, 0 errors across 814 unique links
- shellcheck — no new findings (3 pre-existing notes at `:208`, `:214`, `:262` are outside the changed hunks)