### PR TITLE
ci: re-trigger CI when a draft PR is marked ready for review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main, develop, 'release/*']
   pull_request:
     branches: [main, develop]
+    # ready_for_review is NOT in the default set (opened, synchronize, reopened).
+    # Several jobs below gate on `pull_request.draft == false`, so a PR opened as a
+    # draft skips lint/test/Security; without this type, `gh pr ready` then fires no
+    # event at all and those checks stay un-run while `build` shows green — which
+    # reads as a pass but never compiled a test file.
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:  # required: checks must report on the merge queue's temporary branch
   schedule:
     - cron: '0 4 * * *'  # 4am UTC daily - catch external changes

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -29,10 +29,18 @@ This document provides an overview of all GitHub Actions workflows used in the k
 ### Triggers
 
 - Push to: `main`, `develop`, `release/*`
-- Pull requests to: `main`, `develop`
+- Pull requests to: `main`, `develop`, on types
+  `opened`, `synchronize`, `reopened`, **`ready_for_review`**
 - Merge group (merge queue's temporary branch — required checks must report here)
 - Schedule: 4am UTC daily (catch external changes)
 - Manual dispatch
+
+`ready_for_review` is not in GitHub's default type set. It is declared explicitly
+because several jobs gate on `github.event.pull_request.draft == false`: a PR opened
+as a draft skips `lint`, `test` and `Security`, and without this type `gh pr ready`
+fires no event, so those checks stay un-run indefinitely while `build` shows green.
+That combination reads as a pass but never compiled a test file — see
+[Draft PRs and un-run checks](#draft-prs-and-un-run-checks).
 
 ### Concurrency
 
@@ -109,10 +117,38 @@ temporary branch — the merged result — before the PR is allowed to land.
 - **Fail fast** - Jobs depend on validate, so lint failure stops everything
 - **Artifact sharing** - Coverage uploaded as artifact, reused by coverage-check; both upload and download use `continue-on-error: true` to tolerate `ACTIONS_RESULTS_URL` failures on in-cluster ARC runners
 - **PR comments** - Coverage report comment on PRs
-- **Skip draft PRs** - `if: github.event.pull_request.draft == false`
+- **Skip draft PRs** - `if: github.event.pull_request.draft == false`, re-triggered by the
+  `ready_for_review` type (see [below](#draft-prs-and-un-run-checks))
 - **Sensitive file check** - Warn about potential secrets in code
 - **goimports** - Installed as a tool dependency for the formatting check (`goimports -l`)
 - **Matrix fail-fast: false** - Cross-platform builds continue if one fails
+
+### Draft PRs and un-run checks
+
+`lint`, `test` and `Security` are gated on `github.event.pull_request.draft == false`,
+so a PR opened as a draft runs none of them. `build` still runs, and `build` does **not**
+compile test files — a draft PR can therefore show a green `build` while containing code
+that does not compile under `go test`.
+
+Declaring `ready_for_review` in `on.pull_request.types` makes `gh pr ready` re-trigger the
+full suite. Two related cases are **not** covered, because GitHub emits neither
+`synchronize` nor `ready_for_review` for them:
+
+| Situation | Event GitHub sends | Remedy |
+|---|---|---|
+| PR marked ready for review | `ready_for_review` | covered — CI re-runs |
+| PR **retargeted** to another base branch | `edited` (with `changes.base`) | close and reopen the PR, which sends `reopened` |
+| PR title or body edited | `edited` | none needed — no code changed |
+
+`edited` is deliberately not in the type list: it fires on every title and body edit, which
+would run the full suite for text-only changes. A retarget is rare enough to handle by hand.
+
+Before trusting a green PR, confirm the required checks actually **ran**. A check that was
+skipped reports differently from one that passed:
+
+```bash
+gh pr checks <number>          # look for "skipping", not just the absence of "fail"
+```
 
 ---
 


### PR DESCRIPTION
`on.pull_request` declared no `types:`, so it used GitHub's default set — `opened`, `synchronize`, `reopened`. But `lint`, `test` and `Security` all gate on `github.event.pull_request.draft == false`, so a PR **opened as a draft** runs none of them, and `gh pr ready` then fires **no event at all**. The checks stay un-run while `build` reports green — and `build` does not compile test files.

Not theoretical: **#645** reached the merge queue this way with `pkg/kubernetes/fluxcd` failing to compile. Its `build` was green; `lint` and `test` had never run. Two codex findings were correct and nothing automated caught them.

## Change

```yaml
  pull_request:
    branches: [main, develop]
    types: [opened, synchronize, reopened, ready_for_review]
```

## Why `edited` is deliberately excluded

`edited` is the event GitHub sends when a PR is **retargeted** to a different base branch, which has the same un-run-checks failure mode (hit today on #654: retargeted from a stacked base to `main`, sat `BLOCKED` with `lint`/`test`/`build` never run). But `edited` also fires on every title and body edit, so the full suite would run for text-only changes.

Retargeting is rare enough to handle by hand — close and reopen the PR, which sends `reopened`. That is now documented rather than left to be rediscovered.

| Situation | Event GitHub sends | Covered? |
|---|---|---|
| PR marked ready for review | `ready_for_review` | **yes**, after this PR |
| PR retargeted to another base | `edited` (with `changes.base`) | no — close and reopen |
| PR title/body edited | `edited` | n/a — no code changed |

## Docs

`docs/github-workflows.md`: the CI trigger list now names the types and explains why `ready_for_review` is explicit, plus a new **Draft PRs and un-run checks** section with the table above, the reason `edited` is excluded, and how to tell a skipped required check from a passing one (`gh pr checks` prints `skipping`, which is easy to misread as a pass — I did exactly that earlier today).

Only `ci.yml` has a `draft == false` gate; no other workflow needs this.

## Verification

- `yq '.on.pull_request' .github/workflows/ci.yml` parses, types as intended
- `site/scripts/check-doc-sync.sh` — OK (19 packages mapped)
- `site/scripts/check-links.sh` — OK, 0 errors, 815 unique links (the new anchor resolves)
- `ci.yml` is inside the `go` paths-filter, so this PR runs the full suite on itself