### PR TITLE
chore(ci): pin first-party composite actions to a commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Check action pins
-      uses: go-kure/.github/.github/actions/check-action-pins@main
+      uses: go-kure/.github/.github/actions/check-action-pins@16cb56abeb01d7995a15ab8873814ba96c494d7e # main
 
   # =============================================================================
   # Stage 2: Tests and Security (parallel with lint)
@@ -676,7 +676,7 @@ jobs:
       run: echo "$HOME/bin" >> $GITHUB_PATH
 
     - name: Validate docs map (code↔docs sync)
-      uses: go-kure/.github/.github/actions/check-doc-sync@main
+      uses: go-kure/.github/.github/actions/check-doc-sync@16cb56abeb01d7995a15ab8873814ba96c494d7e # main
 
     - name: Inject front matter
       run: bash site/scripts/inject-frontmatter.sh
@@ -726,7 +726,7 @@ jobs:
       run: hugo --baseURL "/" --destination .linkcheck --quiet
 
     - name: Check internal links (rendered site)
-      uses: go-kure/.github/.github/actions/check-links@main
+      uses: go-kure/.github/.github/actions/check-links@16cb56abeb01d7995a15ab8873814ba96c494d7e # main
       with:
         built-dir: site/.linkcheck
 
@@ -821,7 +821,7 @@ jobs:
       run: echo "$HOME/bin" >> $GITHUB_PATH
 
     - name: Enforce docs-with-code (Layer 3)
-      uses: go-kure/.github/.github/actions/check-doc-gate@main
+      uses: go-kure/.github/.github/actions/check-doc-gate@16cb56abeb01d7995a15ab8873814ba96c494d7e # main
       with:
         base-ref: origin/${{ github.base_ref }}
         skip: ${{ contains(github.event.pull_request.labels.*.name, 'docs-skip') }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -111,7 +111,7 @@ jobs:
       run: echo "$HOME/bin" >> $GITHUB_PATH
 
     - name: Validate docs map (code↔docs sync)
-      uses: go-kure/.github/.github/actions/check-doc-sync@main
+      uses: go-kure/.github/.github/actions/check-doc-sync@16cb56abeb01d7995a15ab8873814ba96c494d7e # main
 
     - name: Inject front matter
       run: bash site/scripts/inject-frontmatter.sh


### PR DESCRIPTION
Prerequisite for org-level sha_pinning_required: GitHub's SHA-pinning policy
covers actions from your own organization. Reusable workflows are exempt and
stay on @main.
