### PR TITLE
chore(deps): group the cloudnative-pg modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,16 @@ updates:
         update-types:
           - "patch"
 
+      # CloudNativePG — the operator, machinery, barman-cloud and the
+      # plugin move together upstream. Minor is included because no ignore:
+      # entry below blocks CNPG minors, unlike the k8s and fluxcd groups.
+      cnpg-ecosystem:
+        patterns:
+          - "github.com/cloudnative-pg/*"
+        update-types:
+          - "minor"
+          - "patch"
+
       # FluxCD ecosystem — the controller API modules are released together and
       # kure imports them as one surface, so they must be reviewed and bumped as
       # one unit. Ungrouped, a single upstream release arrives as five separate


### PR DESCRIPTION
Adds a `cnpg-ecosystem` group to Dependabot config so `github.com/cloudnative-pg/*` (operator, machinery, barman-cloud, plugin) move together, matching the existing k8s-ecosystem/fluxcd-ecosystem grouping. Minor+patch included since no `ignore:` entry blocks CNPG minors, unlike the other groups. Part of autops/wharf/meta#53.