### PR TITLE
test: prove the action-pins gate is wired (throwaway, do not merge)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -92,7 +92,7 @@ jobs:
 
     - name: Cache yq
       id: yq-cache
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      uses: actions/cache@v6
       with:
         path: ~/bin/yq
         key: yq-4.44.6-linux-amd64


### PR DESCRIPTION
Throwaway. Unpins one ref in deploy-docs.yml (a workflow that does not run on PRs, so the org-level sha_pinning_required policy is not what fires here) to prove kure own action-pins job goes red. Verification step 3 of the Supply-Chain Gate plan. Will be closed unmerged.