### PR TITLE
build: bump Go to 1.26.6 for stdlib CVE fixes

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -14,7 +14,7 @@ Kure maintains two version concepts for each dependency:
 
 ## Go Version
 
-**Current:** Go 1.26.5
+**Current:** Go 1.26.6
 
 ## Infrastructure Dependencies
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kure/kure
 
-go 1.26.5
+go 1.26.6
 
 // Replace directives: pin all k8s.io packages to the same patch release.
 //

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 # Use exact versions for reproducibility across environments
-go = "1.26.5"
+go = "1.26.6"
 golangci-lint = "2.10.1"
 git-cliff = "2.7.0"
 hugo = "0.155.3"

--- a/versions.yaml
+++ b/versions.yaml
@@ -18,7 +18,7 @@
 
 # Go version (mise.toml is authoritative for tooling)
 go:
-  current: "1.26.5"
+  current: "1.26.6"
   # mise.toml is the source of truth for Go version
 
 # Infrastructure dependencies


### PR DESCRIPTION
## Summary
- Bump Go from 1.26.5 to 1.26.6 in `go.mod`, `mise.toml`, and `versions.yaml`; regenerate `docs/compatibility.md`
- Fixes the scheduled `main CI` Security-gate failure (govulncheck reachable, unallowed): GO-2026-5026, GO-2026-5972, GO-2026-6090, GO-2026-6218 — all four are Go stdlib CVEs (idna, encoding/asn1, crypto/tls, net/url) fixed in 1.26.6, none of which had an allowlist entry
- No dependency or code changes; GO-2026-5377 (external-secrets) remains the only allowlisted advisory, unaffected by this bump

## Test plan
- [x] `GOWORK=off go build ./...` with Go 1.26.6 — passes
- [x] `GOWORK=off go test ./...` with Go 1.26.6 — all packages pass
- [x] `govulncheck -scan symbol -format json ./...` + the repo's `govulncheck-gate.sh` against the allowlist — exit 0, no unallowed reachable vulnerabilities
- [x] `scripts/sync-versions.sh check` — passes (compatibility.md regenerated)