### PR TITLE
ci: add merge_group trigger to pr-review.yml

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -3,6 +3,11 @@ name: PR Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+  # Required so this check reports (as `skipped`/success, via the callee's existing draft/fork
+  # `if:`) on the merge queue's temporary ref. A required context that never triggers stays
+  # pending forever and stalls every queue entry for check_response_timeout_minutes (60), then
+  # ejects it — see governance/repository-settings-policy.yaml and dot-github's Phase 2 plan.
+  merge_group:
 
 permissions:
   contents: read

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -2,7 +2,7 @@
 
 This document provides an overview of all GitHub Actions workflows used in the kure project.
 
-**Last Updated:** 2026-07-02
+**Last Updated:** 2026-08-18
 
 ---
 
@@ -17,7 +17,7 @@ This document provides an overview of all GitHub Actions workflows used in the k
 | [Release / Promote](#release--promote-workflow) | `release-promote.yml` | manual | Promote to explicit release type (beta/rc/stable) |
 | [Release / Bump](#release--bump-workflow) | `release-bump.yml` | manual | Advance version cycle (minor/major/prerelease), no tag |
 | [Release / Publish](#release--publish-workflow) | `release-publish.yml` | tag push | GoReleaser, SBOM, cosign signing, docs deploy, proxy refresh |
-| [PR Review](#pr-review-workflow) | `pr-review.yml` | pull_request | Two-pass AI code review via claude-max-proxy |
+| [PR Review](#pr-review-workflow) | `pr-review.yml` | pull_request, merge_group | Two-pass AI code review via claude-max-proxy |
 
 ---
 
@@ -339,6 +339,10 @@ managed centrally in `go-kure/.github` (`governance/repository-settings-policy.y
 ### Triggers
 
 - Pull requests: `opened`, `synchronize`, `ready_for_review`, `reopened`
+- `merge_group` (no filters): required so this check reports on the merge queue's temporary
+  ref once it becomes a required status check — the queue payload has no `pull_request` field,
+  so the existing draft/fork skip below evaluates false and the job reports `skipped`/success
+  as a no-op
 - Skips draft PRs and fork PRs (self-hosted runner security)
 
 ### How It Works


### PR DESCRIPTION
## Summary

Phase 2 Task 3 (dot-github `~/.claude/plans/context-this-session-redesigned-shimmering-lemur.md`)
— adds a `merge_group:` trigger to `pr-review.yml`, no other change. Once
`pr-review / AI Code Review` becomes a required status check (not yet — Task 6), a required
context that never fires on the merge queue's temporary ref stalls every queue entry for
`check_response_timeout_minutes` (60) and then ejects it. On `merge_group`, `github.event.pull_request`
does not exist, so the callee's existing draft/fork `if:` in `go-kure/.github`'s reusable workflow
evaluates false and the job reports `skipped`/success — a correct no-op, no callee change needed.

Also updates `docs/github-workflows.md` (trigger summary row + PR Review triggers section) to
document the new trigger, per a codex-review finding.

## Test plan

- [x] `actionlint .github/workflows/pr-review.yml` — exit 0
- [x] `mise run lint` — 0 issues
- [x] `GOWORK=off mise run verify` — tidy/lint/test all clean
- [x] Codex review (read-only, repo-shell, no-network): one `wording` finding (doc trigger list
      stale) — fixed by amending in the `docs/github-workflows.md` update; zero blocking findings.
      YAML validity, diff scope (1 file), no collateral disturbance to `on:`/`jobs:`/`permissions:`,
      no other repo reference to this workflow file, and no unexpected `secrets: inherit`/
      `permissions:` side effect on `merge_group` all independently confirmed.

Opened as **draft**; undrafts once `/gmr`'s lite-mode termination predicates hold.
