### PR TITLE
ci: run checks + AI review on draft PRs (GitLab mr-review parity)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,9 @@ on:
     branches: [main, develop, 'release/*']
   pull_request:
     branches: [main, develop]
-    # ready_for_review is NOT in the default set (opened, synchronize, reopened).
-    # Several jobs below gate on `pull_request.draft == false`, so a PR opened as a
-    # draft skips lint/test/Security; without this type, `gh pr ready` then fires no
-    # event at all and those checks stay un-run while `build` shows green — which
-    # reads as a pass but never compiled a test file.
-    types: [opened, synchronize, reopened, ready_for_review]
+    # No draft gate below (2026-08-19, GitLab mr-review parity) — every job runs
+    # on a draft PR the same as a ready one, so ready_for_review buys nothing
+    # here and is left out of the default set (opened, synchronize, reopened).
   merge_group:  # required: checks must report on the merge queue's temporary branch
   schedule:
     - cron: '0 4 * * *'  # 4am UTC daily - catch external changes
@@ -88,9 +85,7 @@ jobs:
     runs-on: autops-kube-kure
     timeout-minutes: 15
     needs: [changes]
-    if: |
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      (github.event_name != 'pull_request' || needs.changes.outputs.go == 'true')
+    if: github.event_name != 'pull_request' || needs.changes.outputs.go == 'true'
 
     steps:
     - name: Checkout code
@@ -240,9 +235,7 @@ jobs:
     runs-on: autops-kube-kure
     timeout-minutes: 20
     needs: [changes]
-    if: |
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      (github.event_name != 'pull_request' || needs.changes.outputs.go == 'true')
+    if: github.event_name != 'pull_request' || needs.changes.outputs.go == 'true'
 
     steps:
     - name: Checkout code
@@ -334,9 +327,7 @@ jobs:
     # expected runtime.
     timeout-minutes: 15
     needs: [changes]
-    if: |
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      (github.event_name != 'pull_request' || needs.changes.outputs.go == 'true')
+    if: github.event_name != 'pull_request' || needs.changes.outputs.go == 'true'
 
     # GOMEMLIMIT keeps Go's GC under the runner pod memory limit so govulncheck (peaks ~3.8Gi
     # on large module graphs) doesn't get OOMKilled. Pairs with the 6Gi ARC runner limit.
@@ -476,7 +467,6 @@ jobs:
     runs-on: autops-kube-kure
     timeout-minutes: 5
     needs: test
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
 
     steps:
     - name: Checkout code
@@ -620,9 +610,7 @@ jobs:
     runs-on: autops-kube-kure
     timeout-minutes: 15
     needs: [changes]
-    if: |
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      (github.event_name != 'pull_request' || needs.changes.outputs.docs == 'true')
+    if: github.event_name != 'pull_request' || needs.changes.outputs.docs == 'true'
 
     steps:
     - name: Checkout code
@@ -767,7 +755,7 @@ jobs:
     name: Analyze Changes
     runs-on: autops-kube-kure
     timeout-minutes: 5
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    if: github.event_name == 'pull_request'
 
     steps:
     - name: Checkout code
@@ -821,7 +809,7 @@ jobs:
     name: doc-gate
     runs-on: autops-kube-kure
     timeout-minutes: 5
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    if: github.event_name == 'pull_request'
 
     steps:
     - name: Checkout code

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,7 +2,13 @@ name: PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # ready_for_review kept (2026-08-19): the callee (pr-review.yml) is pinned @main, so its
+    # no-longer-draft-gated behavior only lands here once that reusable workflow's own PR
+    # merges to main — an async rollout window this caller cannot see. A PR whose own branch
+    # already dropped this type, marked ready with no further push, gets no re-trigger at all
+    # until that merge completes. Cost is one redundant run at ready-time once the rollout is
+    # done; ci.yml has no such gap (self-contained per-branch, not pinned) and correctly omits it.
+    types: [opened, synchronize, reopened, ready_for_review]
   # Required so this check reports (as `skipped`/success, via the callee's existing fork `if:`)
   # on the merge queue's temporary ref. A required context that never triggers stays pending
   # forever and stalls every queue entry for check_response_timeout_minutes (60), then ejects

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,11 +2,11 @@ name: PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-  # Required so this check reports (as `skipped`/success, via the callee's existing draft/fork
-  # `if:`) on the merge queue's temporary ref. A required context that never triggers stays
-  # pending forever and stalls every queue entry for check_response_timeout_minutes (60), then
-  # ejects it — see governance/repository-settings-policy.yaml and dot-github's Phase 2 plan.
+    types: [opened, synchronize, reopened]
+  # Required so this check reports (as `skipped`/success, via the callee's existing fork `if:`)
+  # on the merge queue's temporary ref. A required context that never triggers stays pending
+  # forever and stalls every queue entry for check_response_timeout_minutes (60), then ejects
+  # it — see governance/repository-settings-policy.yaml and dot-github's Phase 2 plan.
   merge_group:
 
 permissions:

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -125,9 +125,9 @@ temporary branch — the merged result — before the PR is allowed to land.
 
 ### Draft PRs
 
-No job carries a `draft == false` condition (removed 2026-08-19 for parity with the GitLab
-original this workflow was ported from, `meta/ci-templates/mr-review.yml` in `autops/wharf`,
-which reviews/tests every merge-request pipeline regardless of draft status). A draft PR gets
+No job carries a `draft == false` condition (removed 2026-08-19 for parity with the downstream
+GitLab CI template this workflow was ported from, which reviews/tests every merge-request
+pipeline regardless of draft status). A draft PR gets
 the identical `lint`/`test`/`Security`/`coverage-check`/`build` run as a ready one; draft blocks
 merge only, via branch protection — it does not change what CI runs.
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -326,13 +326,18 @@ managed centrally in `go-kure/.github` (`governance/repository-settings-policy.y
 
 ### Triggers
 
-- Pull requests: `opened`, `synchronize`, `reopened`
+- Pull requests: `opened`, `synchronize`, `reopened`, `ready_for_review`
 - `merge_group` (no filters): required so this check reports on the merge queue's temporary
   ref once it becomes a required status check — the queue payload has no `pull_request` field,
   so the existing fork skip below evaluates false and the job reports `skipped`/success as a
   no-op
 - Runs on draft PRs (2026-08-19, GitLab `mr-review` parity — see [Draft PRs](#draft-prs));
   skips fork PRs (self-hosted runner security)
+- `ready_for_review` is kept here (unlike `ci.yml`, which omits it) because the reviewer itself
+  lives in `go-kure/.github` and is called `@main`: its no-longer-draft-gated behavior only takes
+  effect once that repo's own parity change merges, an async window this caller can't see. Without
+  the type, a PR whose branch already dropped it and gets marked ready with no further push gets no
+  re-trigger until that merge lands. Costs one redundant run at ready-time once the rollout is done.
 
 ### How It Works
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -331,8 +331,11 @@ managed centrally in `go-kure/.github` (`governance/repository-settings-policy.y
   ref once it becomes a required status check — the queue payload has no `pull_request` field,
   so the existing fork skip below evaluates false and the job reports `skipped`/success as a
   no-op
-- Runs on draft PRs (2026-08-19, GitLab `mr-review` parity — see [Draft PRs](#draft-prs));
-  skips fork PRs (self-hosted runner security)
+- Runs on draft PRs (2026-08-19, GitLab `mr-review` parity — see [Draft PRs](#draft-prs)) —
+  **effective once go-kure/.github#75 merges**; until then the callee (`pr-review.yml@main`)
+  still gates on `draft == false`, so a draft PR here still gets a skipped reviewer job, and
+  `ready_for_review` below is what actually triggers the review; skips fork PRs (self-hosted
+  runner security)
 - `ready_for_review` is kept here (unlike `ci.yml`, which omits it) because the reviewer itself
   lives in `go-kure/.github` and is called `@main`: its no-longer-draft-gated behavior only takes
   effect once that repo's own parity change merges, an async window this caller can't see. Without

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -2,7 +2,7 @@
 
 This document provides an overview of all GitHub Actions workflows used in the kure project.
 
-**Last Updated:** 2026-08-18
+**Last Updated:** 2026-08-19
 
 ---
 
@@ -29,18 +29,15 @@ This document provides an overview of all GitHub Actions workflows used in the k
 ### Triggers
 
 - Push to: `main`, `develop`, `release/*`
-- Pull requests to: `main`, `develop`, on types
-  `opened`, `synchronize`, `reopened`, **`ready_for_review`**
+- Pull requests to: `main`, `develop`, on GitHub's default types
+  `opened`, `synchronize`, `reopened`
 - Merge group (merge queue's temporary branch — required checks must report here)
 - Schedule: 4am UTC daily (catch external changes)
 - Manual dispatch
 
-`ready_for_review` is not in GitHub's default type set. It is declared explicitly
-because several jobs gate on `github.event.pull_request.draft == false`: a PR opened
-as a draft skips `lint`, `test` and `Security`, and without this type `gh pr ready`
-fires no event, so those checks stay un-run indefinitely while `build` shows green.
-That combination reads as a pass but never compiled a test file — see
-[Draft PRs and un-run checks](#draft-prs-and-un-run-checks).
+Every job runs on draft PRs the same as ready ones (2026-08-19, GitLab `mr-review` parity — see
+[Draft PRs](#draft-prs)), so `ready_for_review` is not declared: it would only re-trigger a suite
+that already ran.
 
 ### Concurrency
 
@@ -118,8 +115,7 @@ temporary branch — the merged result — before the PR is allowed to land.
 - **Fail fast** - Jobs depend on validate, so lint failure stops everything
 - **Artifact sharing** - Coverage uploaded as artifact, reused by coverage-check; both upload and download use `continue-on-error: true` to tolerate `ACTIONS_RESULTS_URL` failures on in-cluster ARC runners
 - **PR comments** - Coverage report comment on PRs
-- **Skip draft PRs** - `if: github.event.pull_request.draft == false`, re-triggered by the
-  `ready_for_review` type (see [below](#draft-prs-and-un-run-checks))
+- **Runs on draft PRs** - no draft gate on any job (see [below](#draft-prs))
 - **Sensitive file check** - Warn about potential secrets in code
 - **goimports** - Installed as a tool dependency for the formatting check (`goimports -l`)
 - **Matrix fail-fast: false** - Cross-platform builds continue if one fails
@@ -127,32 +123,24 @@ temporary branch — the merged result — before the PR is allowed to land.
   `check-doc-sync`, `check-links` and `check-doc-gate` actions from `go-kure/.github`; kure no
   longer vendors its own copies under `site/scripts/`
 
-### Draft PRs and un-run checks
+### Draft PRs
 
-`lint`, `test` and `Security` are gated on `github.event.pull_request.draft == false`,
-so a PR opened as a draft runs none of them. `build` still runs, and `build` does **not**
-compile test files — a draft PR can therefore show a green `build` while containing code
-that does not compile under `go test`.
+No job carries a `draft == false` condition (removed 2026-08-19 for parity with the GitLab
+original this workflow was ported from, `meta/ci-templates/mr-review.yml` in `autops/wharf`,
+which reviews/tests every merge-request pipeline regardless of draft status). A draft PR gets
+the identical `lint`/`test`/`Security`/`coverage-check`/`build` run as a ready one; draft blocks
+merge only, via branch protection — it does not change what CI runs.
 
-Declaring `ready_for_review` in `on.pull_request.types` makes `gh pr ready` re-trigger the
-full suite. Two related cases are **not** covered, because GitHub emits neither
-`synchronize` nor `ready_for_review` for them:
+One retargeting case is still **not** covered, because GitHub sends neither `synchronize` nor
+any type in this workflow's list for it:
 
 | Situation | Event GitHub sends | Remedy |
 |---|---|---|
-| PR marked ready for review | `ready_for_review` | covered — CI re-runs |
 | PR **retargeted** to another base branch | `edited` (with `changes.base`) | close and reopen the PR, which sends `reopened` |
 | PR title or body edited | `edited` | none needed — no code changed |
 
 `edited` is deliberately not in the type list: it fires on every title and body edit, which
 would run the full suite for text-only changes. A retarget is rare enough to handle by hand.
-
-Before trusting a green PR, confirm the required checks actually **ran**. A check that was
-skipped reports differently from one that passed:
-
-```bash
-gh pr checks <number>          # look for "skipping", not just the absence of "fail"
-```
 
 ---
 
@@ -338,12 +326,13 @@ managed centrally in `go-kure/.github` (`governance/repository-settings-policy.y
 
 ### Triggers
 
-- Pull requests: `opened`, `synchronize`, `ready_for_review`, `reopened`
+- Pull requests: `opened`, `synchronize`, `reopened`
 - `merge_group` (no filters): required so this check reports on the merge queue's temporary
   ref once it becomes a required status check — the queue payload has no `pull_request` field,
-  so the existing draft/fork skip below evaluates false and the job reports `skipped`/success
-  as a no-op
-- Skips draft PRs and fork PRs (self-hosted runner security)
+  so the existing fork skip below evaluates false and the job reports `skipped`/success as a
+  no-op
+- Runs on draft PRs (2026-08-19, GitLab `mr-review` parity — see [Draft PRs](#draft-prs));
+  skips fork PRs (self-hosted runner security)
 
 ### How It Works
 


### PR DESCRIPTION
## Summary
- Drops `draft == false` from every gated job in `ci.yml`: `validate`(lint), `test`, `security`, `coverage-check`, `docs-build`, `analyze-changes`, `doc-gate`.
- Drops `ready_for_review` from both `ci.yml`'s and `pr-review.yml`'s PR `types:` — it existed only to re-fire checks that didn't run on the draft; now they already ran.
- `docs/github-workflows.md` rewritten to match (the "Draft PRs and un-run checks" section described the hazard this PR removes).

PR 2 of 3 for org-wide GitLab-parity draft handling. Depends on `go-kure/.github#75` for the AI-review half — until that merges, `pr-review.yml@main` still gates on draft, so this PR's own AI review won't run until it's marked ready. The CI half (this repo's own `ci.yml`) is independent and takes effect immediately.

## Why
A draft PR here showed a green `build` (`if: always()`, a required check) while `lint`/`test`/`security` never ran — `build` doesn't compile test files. Matches `meta/ci-templates/mr-review.yml` in `autops/wharf` (GitLab), which runs every job on every merge-request pipeline; draft blocks merge there, not CI.

## Test plan
- [x] `actionlint` on `ci.yml`/`pr-review.yml` — same pre-existing finding count as `main` (11 runner-label + 1 shellcheck, unrelated to this change), no new findings
- [x] doc-sync / doc-gate (via `go-kure/.github`'s canonical scripts) — both OK
- [ ] Live: this PR is itself a draft touching `ci.yml` — confirm `gh pr checks` shows lint/test/security actually ran (not skipped) while `isDraft: true`