### PR TITLE
chore: git-ignore go.work and go.work.sum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,11 @@ release-notes.md
 
 # Temporary test output
 **/temp/
+
+# Go workspace files are local development state, never repository content.
+# A go.work here carries ../ replace paths that do not exist in CI, and the
+# go.work.sum beside it can supply an h1: hash missing from this repo's own
+# go.sum — masking a broken standalone build until CI (which runs GOWORK=off)
+# fails on "missing go.sum entry".
+go.work
+go.work.sum


### PR DESCRIPTION
## Why

`go.work` and `go.work.sum` are local development state, never repository content. A `go.work` carries `../` replace paths that do not exist in CI, and the `go.work.sum` beside it can supply an `h1:` hash that is missing from this repo's own `go.sum` — so a build passes locally in workspace mode and fails in CI, which runs `GOWORK=off`, with `missing go.sum entry`.

That is not hypothetical: it hid a real defect in a sibling repo during a dependency bump, where a stray tracked `go.work.sum` had been committed.

## What

Two lines in `.gitignore`, with the reason stated inline. No code changes.

## Why now

Prerequisite for a multi-repo workspace generator change that writes a per-repo `go.work` so each module builds from its own directory (today a module that another workspace module imports is `replace`d rather than `use`d, so `go`/`govulncheck` run from inside it fail with "directory ... is outside module roots"). Without this ignore rule, that generated file shows up as untracked and is one `git add -A` away from being committed.

## Evidence

Creating `go.work` and `go.work.sum` in the worktree leaves `git status --porcelain` showing only the `.gitignore` edit — neither file appears as untracked.