### PR TITLE
ci: bump govulncheck to v1.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ permissions:
 
 env:
   GOLANGCI_LINT_VERSION: 'v2.10.1'
-  # Kept in step with the Wharf-side pin (meta/versions.env REQUIRED_GOVULNCHECK_VERSION,
-  # ci-templates/go-vuln.yml). Nothing checks the two forges against each other, so a
-  # bump on one side has to be mirrored here by hand.
+  # Several repos across both forges install this same scanner and share the
+  # govulncheck-gate action, but nothing compares their pins. A bump therefore has
+  # to be mirrored by hand in each workflow that installs it, this one included.
   GOVULNCHECK_VERSION: 'v1.7.0'
   # The runner binary patch (Runner.Worker.dll) renames all occurrences of
   # ACTIONS_RESULTS_URL to ACTIONS_RESULTS_ORL, including the name the Worker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,10 @@ permissions:
 
 env:
   GOLANGCI_LINT_VERSION: 'v2.10.1'
-  GOVULNCHECK_VERSION: 'v1.3.0'
+  # Kept in step with the Wharf-side pin (meta/versions.env REQUIRED_GOVULNCHECK_VERSION,
+  # ci-templates/go-vuln.yml). Nothing checks the two forges against each other, so a
+  # bump on one side has to be mirrored here by hand.
+  GOVULNCHECK_VERSION: 'v1.7.0'
   # The runner binary patch (Runner.Worker.dll) renames all occurrences of
   # ACTIONS_RESULTS_URL to ACTIONS_RESULTS_ORL, including the name the Worker
   # injects into step process environments.  Workflow env overrides runner-injected

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -94,7 +94,7 @@ temporary branch — the merged result — before the PR is allowed to land.
 | `validate` | `lint` | 15 min | changes | Go fmt, tidy, vet, lint; caches goimports + yq binaries |
 | `action-pins` | `action-pins` | 2 min | — | Fails if any third-party `uses:` ref is not pinned to a 40-char commit SHA (`go-kure/.github` canonical checker) |
 | `test` | `test` | 20 min | changes | Unit tests with race detection and coverage; `-race` compilation takes ~5 min on the in-cluster runner, so 20 min allows compilation + 15 min for test execution |
-| `security` | `Security` | 15 min | changes | govulncheck (`-scan symbol`, v1.3.0), gated on reachable advisories via the canonical `govulncheck-gate` action from `go-kure/.github` — blocking, not informational |
+| `security` | `Security` | 15 min | changes | govulncheck (`-scan symbol`, v1.7.0), gated on reachable advisories via the canonical `govulncheck-gate` action from `go-kure/.github` — blocking, not informational |
 | `coverage-check` | `Coverage Check` | 5 min | test | 85% threshold, Codecov upload, PR comment |
 | `build` | `build` | 1 min | validate, test, docs-build, coverage-check, doc-gate, action-pins, security | Aggregation gate — fails if any required job failed |
 | `analyze-changes` | `Analyze Changes` | 5 min | - | Changed files analysis, breaking change warnings (PR only) |
@@ -106,7 +106,7 @@ temporary branch — the merged result — before the PR is allowed to land.
 
 - Go Version: read from `go.mod` (`go-version-file: go.mod`)
 - Golangci-lint Version: `v2.10.1`
-- govulncheck Version: `v1.3.0` (pinned, cached binary, `-scan symbol` mode)
+- govulncheck Version: `v1.7.0` (pinned, cached binary, `-scan symbol` mode)
 - Coverage Threshold: `85%`
 
 ### Features
@@ -572,7 +572,7 @@ in launcher: warmed cycles cut `test` ~50%, `build`/`lint` ~30%.
 Tool binaries are also cached to avoid reinstalling on every run:
 - `goimports` — keyed by `go.sum` hash (tied to `golang.org/x/tools` version)
 - `yq` — keyed by pinned version (`4.44.6`)
-- `govulncheck` — keyed by pinned version (`v1.3.0`)
+- `govulncheck` — keyed by pinned version (`v1.7.0`)
 
 Cache and artifact traffic is routed through an in-cluster falcondev cache server backed by
 Garage S3. Two layers work together:


### PR DESCRIPTION
## Why

This scanner is pinned in several places across two forges, and nothing compares those pins against each other. The other side moved to **1.7.0**, so this mirrors it. The reason is now stated at the pin itself, since the mirror is manual.

## Not a behaviour change here

`v1.7.0` reports `GO-2026-5377` in this module — exactly as `v1.3.0` does — and the existing allowlist entry already covers it. Verified by scanning this module locally with both scanner versions before making the change, and confirmed by the `Security` job passing on this PR.

Every other Go module that shares this pin was scanned with 1.7.0 first: no new findings anywhere, and the one advisory that does appear is pre-existing under 1.3.0 and already allowlisted wherever it is reachable.

## Docs

Updated in the same PR, as required.