### PR TITLE
docs: correct the go.work ignore rationale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,9 +45,9 @@ release-notes.md
 **/temp/
 
 # Go workspace files are local development state, never repository content.
-# A go.work here carries ../ replace paths that do not exist in CI, and the
-# go.work.sum beside it can supply an h1: hash missing from this repo's own
-# go.sum — masking a broken standalone build until CI (which runs GOWORK=off)
-# fails on "missing go.sum entry".
+# A go.work here can carry ../ replace paths that do not exist outside this
+# machine, and the go.work.sum beside it can supply an h1: hash missing from
+# this repo's own go.sum — masking a broken standalone build until CI, which
+# has no go.work, fails on "missing go.sum entry".
 go.work
 go.work.sum


### PR DESCRIPTION
The `go.work` ignore comment added in the recent batch is wrong on two counts. Both were caught in review after that change had already merged, so this corrects them on `main`.

**1. CI does not run `GOWORK=off`.**

The comment said the trap goes unnoticed "until CI (which runs `GOWORK=off`)". That is not the mechanism. Across the shared CI templates, `GOWORK` is set in exactly one place, and there only inside an `echo` string. The real reason a committed `go.work` breaks CI is simpler: CI has no `go.work` at all.

This repo's own `ci.yml` does pass `GOWORK=off` explicitly on a few Go invocations, but that is belt-and-braces on top of there being no `go.work` to find — so the corrected wording is accurate here too.

**2. The `../` replace paths were stated as an invariant.**

A module with no sibling dependency in the same local workspace gets a generated `go.work` with no `replace` line at all — which is the case for this repo. Weakened to "can carry".

Comment text only; no behaviour change. The replacement text is byte-identical across the sibling repos that carry the same block.
