### PR TITLE
fix: make CI safety checks signal correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,7 +497,15 @@ jobs:
           echo "::error::Coverage artifact not available"
           exit 1
         fi
-        COVERAGE=$(go tool cover -func=coverage/coverage.out | tail -1 | awk '{print $3}' | sed 's/%//')
+        if ! COVERAGE_REPORT=$(go tool cover -func=coverage/coverage.out); then
+          echo "::error::Coverage profile is invalid"
+          exit 1
+        fi
+        COVERAGE=$(printf '%s\n' "$COVERAGE_REPORT" | awk 'END { gsub(/%/, "", $3); print $3 }')
+        if ! [[ "$COVERAGE" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+          echo "::error::Could not parse total coverage from coverage profile"
+          exit 1
+        fi
         THRESHOLD=90
         PKG_THRESHOLD=90
         echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,10 +312,10 @@ jobs:
 
     - name: Upload coverage artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-      continue-on-error: true
       with:
         name: coverage
         path: coverage/coverage.out
+        if-no-files-found: error
         retention-days: 7
 
   security:
@@ -457,7 +457,9 @@ jobs:
     - name: Check for sensitive files
       run: |
         # Check for common sensitive patterns
-        if grep -r -i "password\|secret\|token\|key" --include="*.go" --include="*.yaml" --include="*.yml" . | grep -v "test" | grep -v "_test.go" | grep -E "(=|:)" | head -10; then
+        matches=$(grep -r -i "password\|secret\|token\|key" --include="*.go" --include="*.yaml" --include="*.yml" . | grep -v "test" | grep -v "_test.go" | grep -E "(=|:)" | head -10 || true)
+        if [ -n "$matches" ]; then
+          printf '%s\n' "$matches"
           echo "::warning::Potential sensitive information found in code. Please review."
         fi
 
@@ -484,7 +486,6 @@ jobs:
     - name: Download coverage artifact
       id: download-coverage
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-      continue-on-error: true
       with:
         name: coverage
         path: coverage/
@@ -493,9 +494,8 @@ jobs:
       id: coverage
       run: |
         if [ ! -f coverage/coverage.out ]; then
-          echo "::warning::Coverage artifact not available (artifact upload may have failed on runner)"
-          echo "coverage=0" >> $GITHUB_OUTPUT
-          exit 0
+          echo "::error::Coverage artifact not available"
+          exit 1
         fi
         COVERAGE=$(go tool cover -func=coverage/coverage.out | tail -1 | awk '{print $3}' | sed 's/%//')
         THRESHOLD=90

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -117,7 +117,8 @@ temporary branch — the merged result — before the PR is allowed to land.
 - **gotestfmt** - Nice formatted test output
 - **Fail fast** - Jobs depend on validate, so lint failure stops everything
 - **Artifact sharing** - Coverage is uploaded as an artifact and reused by `coverage-check`; upload,
-  download, and missing-file failures are blocking so the coverage gates cannot pass without data
+  download, missing-file, and invalid-profile failures are blocking so the coverage gates cannot
+  pass without valid data
 - **PR comments** - Coverage report comment on PRs
 - **Runs on draft PRs** - no draft gate on any job (see [below](#draft-prs))
 - **Sensitive file check** - Print at most ten potential matches and emit one warning only when

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -116,10 +116,12 @@ temporary branch — the merged result — before the PR is allowed to land.
 
 - **gotestfmt** - Nice formatted test output
 - **Fail fast** - Jobs depend on validate, so lint failure stops everything
-- **Artifact sharing** - Coverage uploaded as artifact, reused by coverage-check; both upload and download use `continue-on-error: true` to tolerate `ACTIONS_RESULTS_URL` failures on in-cluster ARC runners
+- **Artifact sharing** - Coverage is uploaded as an artifact and reused by `coverage-check`; upload,
+  download, and missing-file failures are blocking so the coverage gates cannot pass without data
 - **PR comments** - Coverage report comment on PRs
 - **Runs on draft PRs** - no draft gate on any job (see [below](#draft-prs))
-- **Sensitive file check** - Warn about potential secrets in code
+- **Sensitive file check** - Print at most ten potential matches and emit one warning only when
+  matches exist; this check remains informational and does not block CI
 - **goimports** - Installed as a tool dependency for the formatting check (`goimports -l`)
 - **Matrix fail-fast: false** - Cross-platform builds continue if one fails
 - **Doc-sync checks** - `docs-build` and `docs-check` (`doc-gate` job) run the canonical


### PR DESCRIPTION
## Summary

Make CI fail closed when coverage artifacts cannot be uploaded, downloaded, or found, and make the informational sensitive-file warning reflect actual matches.

The coverage path previously ignored artifact transfer failures and treated a missing coverage file as success. The sensitive-file check tested the final `head` command rather than whether the pipeline produced matches.

## Changes

- require the coverage artifact upload and download to succeed
- fail the coverage check when `coverage/coverage.out` is absent
- emit one warning only when the sensitive-file scan finds matches, printing at most ten
- document strict coverage artifact handling and warning-only sensitive-file reporting

## Test Plan

- [x] `actionlint -ignore 'label "autops-kube-kure" is unknown' -ignore 'SC2162' .github/workflows/ci.yml`
- [x] isolated shell fixtures cover missing and valid coverage data plus empty and matching sensitive-file scans
- [x] `make precommit`
- [x] `mise run site:check`

## Documentation

- [x] `docs/github-workflows.md` updated
- [x] No public API or CLI documentation changes required

## Related Issues

Fixes #674

Issue item 3, the stale documented coverage thresholds, was completed separately by #676.
