### PR TITLE
feat: release-identity RenderOption for RenderChart

### DIFF
--- a/pkg/stack/helm/README.md
+++ b/pkg/stack/helm/README.md
@@ -83,7 +83,7 @@ manifests, err := helm.RenderChart(
 func RenderChart(chartURL, version string, values map[string]any, opts ...RenderOption) ([]byte, error)
 
 // RenderOption customizes the release identity used to render a chart.
-type RenderOption func(*common.ReleaseOptions)
+type RenderOption func(*renderOptions)
 
 // WithReleaseName sets the release name used during rendering.
 func WithReleaseName(name string) RenderOption

--- a/pkg/stack/helm/README.md
+++ b/pkg/stack/helm/README.md
@@ -50,6 +50,21 @@ The chart name is the last path segment; the rest is the repository base URL.
 HTTP repositories must be publicly accessible — basic auth, client TLS, and
 other credential mechanisms are not supported.
 
+**Release identity (optional):**
+
+By default rendering uses release name `"release"` in namespace `"default"`.
+Pass `RenderOption`s to override either:
+
+```go
+manifests, err := helm.RenderChart(
+    "oci://registry.example.com/charts/cilium",
+    "1.16.5",
+    values,
+    helm.WithReleaseName("my-cilium"),
+    helm.WithNamespace("kube-system"),
+)
+```
+
 ## API
 
 ```go
@@ -64,7 +79,17 @@ other credential mechanisms are not supported.
 //
 // version is the chart version tag (e.g. "1.16.5").
 // values are merged on top of the chart's default values.
-func RenderChart(chartURL, version string, values map[string]any) ([]byte, error)
+// opts customizes the release identity; see WithReleaseName and WithNamespace.
+func RenderChart(chartURL, version string, values map[string]any, opts ...RenderOption) ([]byte, error)
+
+// RenderOption customizes the release identity used to render a chart.
+type RenderOption func(*common.ReleaseOptions)
+
+// WithReleaseName sets the release name used during rendering.
+func WithReleaseName(name string) RenderOption
+
+// WithNamespace sets the release namespace used during rendering.
+func WithNamespace(namespace string) RenderOption
 ```
 
 ## SplitByHookWeight
@@ -115,7 +140,7 @@ func SplitByHookWeight(objects []client.Object) []HookGroup
 - OCI authentication uses the local Docker credential store (`~/.docker/config.json`).
 - The rendered output excludes Helm partial templates (files starting with `_`)
   and any templates that produce empty output.
-- The `.Release.Name` is set to `"release"` and `.Release.Namespace` to
-  `"default"`. Charts that rely on these values will receive those defaults.
+- The `.Release.Name` defaults to `"release"` and `.Release.Namespace` to
+  `"default"`; override either with `WithReleaseName`/`WithNamespace`.
 - Comma-separated hook annotations (e.g. `"pre-install,post-install"`) are
   treated as a single opaque phase and placed in the unknown group.

--- a/pkg/stack/helm/doc.go
+++ b/pkg/stack/helm/doc.go
@@ -3,5 +3,7 @@
 //
 // RenderChart pulls a chart and renders its templates using the Helm template
 // engine — equivalent to `helm template` — returning multi-document YAML.
-// No Kubernetes cluster connection is required.
+// No Kubernetes cluster connection is required. RenderOption (WithReleaseName,
+// WithNamespace) overrides the default release identity ("release" in
+// "default").
 package helm

--- a/pkg/stack/helm/render.go
+++ b/pkg/stack/helm/render.go
@@ -20,23 +20,30 @@ import (
 	"github.com/go-kure/kure/pkg/errors"
 )
 
+// renderOptions holds the release identity used to render a chart. It is
+// kure's own type rather than Helm's common.ReleaseOptions so that the public
+// RenderOption signature stays independent of Helm's package layout (the
+// release-options type already moved once, from v3 chartutil to v4 common).
+type renderOptions struct {
+	releaseName string
+	namespace   string
+}
+
 // RenderOption customizes the release identity used to render a chart.
-// The zero value of common.ReleaseOptions is not a valid Helm release, so
-// RenderChart seeds Name "release" and Namespace "default" before applying
-// options — the defaults renderChart always used prior to this option's
-// introduction.
-type RenderOption func(*common.ReleaseOptions)
+// Without options, rendering uses release "release" in namespace "default" —
+// the defaults renderChart always used prior to this option's introduction.
+type RenderOption func(*renderOptions)
 
 // WithReleaseName sets the release name used during rendering (e.g. for
 // {{ .Release.Name }} and the generated resource name helpers).
 func WithReleaseName(name string) RenderOption {
-	return func(o *common.ReleaseOptions) { o.Name = name }
+	return func(o *renderOptions) { o.releaseName = name }
 }
 
 // WithNamespace sets the release namespace used during rendering (e.g. for
 // {{ .Release.Namespace }}).
 func WithNamespace(namespace string) RenderOption {
-	return func(o *common.ReleaseOptions) { o.Namespace = namespace }
+	return func(o *renderOptions) { o.namespace = namespace }
 }
 
 // RenderChart pulls a Helm chart and renders it client-side (equivalent to `helm template`),
@@ -120,17 +127,20 @@ func renderHTTP(chartURL, version string, values map[string]any, opts ...RenderO
 }
 
 // renderChart renders an already-loaded chart with the given values.
-// Exported for testing without OCI connectivity.
+// Kept as a separate function so tests can render without OCI connectivity.
 func renderChart(chrt chartpkg.Charter, values map[string]any, opts ...RenderOption) ([]byte, error) {
-	releaseOpts := common.ReleaseOptions{
-		Name:      "release",
-		Namespace: "default",
-		IsInstall: true,
+	ro := renderOptions{
+		releaseName: "release",
+		namespace:   "default",
 	}
 	for _, opt := range opts {
-		opt(&releaseOpts)
+		opt(&ro)
 	}
-	renderVals, err := util.ToRenderValues(chrt, values, releaseOpts, common.DefaultCapabilities)
+	renderVals, err := util.ToRenderValues(chrt, values, common.ReleaseOptions{
+		Name:      ro.releaseName,
+		Namespace: ro.namespace,
+		IsInstall: true,
+	}, common.DefaultCapabilities)
 	if err != nil {
 		return nil, errors.Wrap(err, "build render values")
 	}

--- a/pkg/stack/helm/render.go
+++ b/pkg/stack/helm/render.go
@@ -20,6 +20,25 @@ import (
 	"github.com/go-kure/kure/pkg/errors"
 )
 
+// RenderOption customizes the release identity used to render a chart.
+// The zero value of common.ReleaseOptions is not a valid Helm release, so
+// RenderChart seeds Name "release" and Namespace "default" before applying
+// options — the defaults renderChart always used prior to this option's
+// introduction.
+type RenderOption func(*common.ReleaseOptions)
+
+// WithReleaseName sets the release name used during rendering (e.g. for
+// {{ .Release.Name }} and the generated resource name helpers).
+func WithReleaseName(name string) RenderOption {
+	return func(o *common.ReleaseOptions) { o.Name = name }
+}
+
+// WithNamespace sets the release namespace used during rendering (e.g. for
+// {{ .Release.Namespace }}).
+func WithNamespace(namespace string) RenderOption {
+	return func(o *common.ReleaseOptions) { o.Namespace = namespace }
+}
+
 // RenderChart pulls a Helm chart and renders it client-side (equivalent to `helm template`),
 // returning multi-doc YAML.
 //
@@ -33,18 +52,21 @@ import (
 //
 // version is the chart version tag (e.g. "1.16.5").
 // values are merged on top of the chart's default values.
-func RenderChart(chartURL, version string, values map[string]any) ([]byte, error) {
+// opts customizes the release identity (name, namespace); see WithReleaseName
+// and WithNamespace. Without opts, rendering uses release "release" in
+// namespace "default".
+func RenderChart(chartURL, version string, values map[string]any, opts ...RenderOption) ([]byte, error) {
 	switch {
 	case strings.HasPrefix(chartURL, "oci://"):
-		return renderOCI(chartURL, version, values)
+		return renderOCI(chartURL, version, values, opts...)
 	case strings.HasPrefix(chartURL, "http://"), strings.HasPrefix(chartURL, "https://"):
-		return renderHTTP(chartURL, version, values)
+		return renderHTTP(chartURL, version, values, opts...)
 	default:
 		return nil, errors.Errorf("unsupported chart URL %q: must start with oci://, http://, or https://", chartURL)
 	}
 }
 
-func renderOCI(chartURL, version string, values map[string]any) ([]byte, error) {
+func renderOCI(chartURL, version string, values map[string]any, opts ...RenderOption) ([]byte, error) {
 	client, err := registry.NewClient()
 	if err != nil {
 		return nil, errors.Wrap(err, "create registry client")
@@ -57,10 +79,10 @@ func renderOCI(chartURL, version string, values map[string]any) ([]byte, error) 
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart archive")
 	}
-	return renderChart(chrt, values)
+	return renderChart(chrt, values, opts...)
 }
 
-func renderHTTP(chartURL, version string, values map[string]any) ([]byte, error) {
+func renderHTTP(chartURL, version string, values map[string]any, opts ...RenderOption) ([]byte, error) {
 	last := strings.LastIndex(chartURL, "/")
 	if last <= 0 {
 		return nil, errors.Errorf("invalid HTTP chart URL %q: expected https://repo-base/chart-name", chartURL)
@@ -94,17 +116,21 @@ func renderHTTP(chartURL, version string, values map[string]any) ([]byte, error)
 	if err != nil {
 		return nil, errors.Wrap(err, "load chart archive")
 	}
-	return renderChart(chrt, values)
+	return renderChart(chrt, values, opts...)
 }
 
 // renderChart renders an already-loaded chart with the given values.
 // Exported for testing without OCI connectivity.
-func renderChart(chrt chartpkg.Charter, values map[string]any) ([]byte, error) {
-	renderVals, err := util.ToRenderValues(chrt, values, common.ReleaseOptions{
+func renderChart(chrt chartpkg.Charter, values map[string]any, opts ...RenderOption) ([]byte, error) {
+	releaseOpts := common.ReleaseOptions{
 		Name:      "release",
 		Namespace: "default",
 		IsInstall: true,
-	}, common.DefaultCapabilities)
+	}
+	for _, opt := range opts {
+		opt(&releaseOpts)
+	}
+	renderVals, err := util.ToRenderValues(chrt, values, releaseOpts, common.DefaultCapabilities)
 	if err != nil {
 		return nil, errors.Wrap(err, "build render values")
 	}

--- a/pkg/stack/helm/render_test.go
+++ b/pkg/stack/helm/render_test.go
@@ -77,6 +77,56 @@ metadata:
 	}
 }
 
+func TestRenderChart_ReleaseOptions(t *testing.T) {
+	chrt := minimalChart("testchart", []*common.File{
+		{
+			Name: "templates/configmap.yaml",
+			Data: []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}`),
+		},
+	}, nil)
+
+	out, err := renderChart(chrt, nil, WithReleaseName("my-release"), WithNamespace("my-ns"))
+	if err != nil {
+		t.Fatalf("renderChart returned error: %v", err)
+	}
+	yaml := string(out)
+	if !strings.Contains(yaml, "name: my-release") {
+		t.Errorf("expected overridden release name in output, got:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "namespace: my-ns") {
+		t.Errorf("expected overridden release namespace in output, got:\n%s", yaml)
+	}
+}
+
+func TestRenderChart_ReleaseOptions_Defaults(t *testing.T) {
+	chrt := minimalChart("testchart", []*common.File{
+		{
+			Name: "templates/configmap.yaml",
+			Data: []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}`),
+		},
+	}, nil)
+
+	out, err := renderChart(chrt, nil)
+	if err != nil {
+		t.Fatalf("renderChart returned error: %v", err)
+	}
+	yaml := string(out)
+	if !strings.Contains(yaml, "name: release") {
+		t.Errorf("expected default release name in output, got:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "namespace: default") {
+		t.Errorf("expected default release namespace in output, got:\n%s", yaml)
+	}
+}
+
 func TestAssembleManifests_SkipsPartials(t *testing.T) {
 	rendered := map[string]string{
 		"mychart/templates/deployment.yaml": "kind: Deployment",


### PR DESCRIPTION
## Context

crane's `internal/transform/components/helmchart.go` needs to thread `ReleaseName`/`TargetNamespace`
into its Helm template-delivery rendering path (`autops/wharf/crane#378`). `RenderChart` hardcoded
`Name: "release"` / `Namespace: "default"` in `renderChart`'s `common.ReleaseOptions`, with no
caller override.

## Change

Adds a variadic `RenderOption` — `WithReleaseName`, `WithNamespace` — rather than a fourth
positional parameter. A positional parameter would break the existing
`crane/internal/bootstrap/render_cilium.go:33` call site plus all 8 existing kure test call sites.
`RenderChart` → `renderOCI`/`renderHTTP` → `renderChart` all forward `opts ...RenderOption`
through; zero-opts behavior is unchanged (release `"release"` in namespace `"default"`).

`README.md` and `doc.go` updated in the same commit — they carried the old literal signature.

## Tests

`TestRenderChart_ReleaseOptions` and `TestRenderChart_ReleaseOptions_Defaults` added, asserting
the override reaches `{{ .Release.Name }}`/`{{ .Release.Namespace }}` in rendered output, and that
the zero-opts path is unchanged. Full `go build ./...`, `go vet ./...`, `go test ./...` clean.

## Next step

Once merged, tag `v0.2.0-beta.10` so the crane-side MR (bumping `go.mod`, wiring
`c.ReleaseName`/`c.TargetNamespace` into `helmchart.go`'s template-delivery path) can proceed.