### PR TITLE
docs: add AI agent gates (A1-A7) section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,6 +411,22 @@ When implementing a GitHub issue, follow this checklist in order:
 7. **Verify the diff** — before committing, review the full working-tree diff. If there are more changes than expected, ask the user what should be committed.
 8. **Commit, push, PR** — commit with a conventional-commit message, push, and open a PR with `gh pr create`.
 
+## Agent gates (A1–A7)
+
+Process rules for AI agents (Claude Code, Codex, and any other). They constrain *how* work is
+done and are independent of any particular tool, harness or machine — everything below is
+checkable from a clone of this repository.
+
+| Gate | Rule | Relation to the workflow above |
+|---|---|---|
+| **A1** | Every factual claim in a plan or review carries a `file:line` actually read this session; anything uncitable goes in an explicit `ASSUMPTIONS` list. Recompute every number from source. Never cite your own uncommitted change as evidence of existing convention — check the base branch. | Sharpens step 2 — validate the issue against real code, not against its own description |
+| **A2** | Destructive operations require a *proven* dry-run, not an asserted one: print the exact command, then show the dry-run ran and what it output. A tool *accepting* `--dry-run` is not proof it honoured it. If it cannot be proven, say so and stop. | Rarely applies here (no live cluster in this repo's own scope), but binds any tooling change that touches one |
+| **A3** | "Stop" / "wait" means make no further edits and no further tool calls. One-line acknowledgement only. | Step 5 already stops for review — honour it literally |
+| **A4** | No merge-ready claim without per-item evidence. For kure: `mise run verify` (tidy, lint, test) or `make precommit`, plus code-and-docs in the same PR per `docs/standards.md`. | Step 5, with output quoted rather than asserted |
+| **A5** | Re-read your own diff for the recurring defect classes: `t.Cleanup` LIFO ordering, `$?` misuse around `if ! cmd`, partial `sed` block removals, cross-test contamination from undisposed resources, and a generated doc table (`site:gen`) left stale against `docs-map.yaml` after a package changes. | Step 7, with a named checklist instead of a general look |
+| **A6** | Any time you touch a changeset with an open PR, check for new comments or reviews since you last looked, before calling a round done. Enumerate every review thread, not just the top-level review list — a forge can carry several independent reviews over time, and an inline thread carries separate resolved/unresolved state from the review it belongs to. Per comment: push a fix commit, or state why not — silence is not a response. Mark the thread resolved once addressed. | Sharpens step 6 — "iterate on review feedback" means every thread, checked again immediately before declaring the round done, not just what was open the first time you looked |
+| **A7** | No bare internal identifier (gate ID, plan step, finding, round, run ID) in a plan, review, or comment without a short subject on first use. Every issue/PR reference is the full project path plus its sigil (`owner/repo#123`), never a bare number — except inside a comment posted on that same forge project, where the surrounding page already supplies the repo. **In this repo**, per the No Downstream References standard (`docs/standards.md`), a reference to any of the forbidden downstream repo names is never qualified even to resolve ambiguity — the qualified form is still a forbidden term. Reword to a generic functional reason and drop the number instead. | Applies wherever the workflow above cites an issue or PR — step 2's issue review through step 6's feedback thread |
+
 ## Organization Resources
 
 The go-kure org governance, design documents, and community files are maintained in


### PR DESCRIPTION
## Summary
Adopts the Agent gates (A1-A7) standard — not previously present in this repo. Mirrors crane's
Agent gates table (autops/wharf/crane!516) and includes an A7 carve-out for this repo's No
Downstream References standard (`docs/standards.md`): a downstream/closed-source repo reference is
never qualified, even to resolve ambiguity — reword to a generic functional reason instead.

## Test plan
- [x] `bash site/scripts/check-forbidden-terms.sh --full-tree` — OK, no forbidden terms
- Docs-only change (new `## Agent gates` table in AGENTS.md)
