### PR TITLE
fix(ci): align golangci-lint pins and add a version assertion to lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions:
   pull-requests: write
 
 env:
-  GOLANGCI_LINT_VERSION: 'v2.10.1'
+  GOLANGCI_LINT_VERSION: 'v2.13.1'
   # Several repos across both forges install this same scanner and share the
   # govulncheck-gate action, but nothing compares their pins. A bump therefore has
   # to be mirrored by hand in each workflow that installs it, this one included.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,7 +301,7 @@ Fluent builders follow an immutable pattern - each `With*` method returns a new 
 3. **Layout Issues**: Verify LayoutRules configuration
 4. **Patch Problems**: Check JSONPath syntax and target existence
 5. **golangci-lint version mismatch**: If lint fails with "Go language version used to build golangci-lint is lower than the targeted Go version", update the golangci-lint version in both `mise.toml` and `Makefile`. When bumping Go, always check that golangci-lint is built with a compatible Go version.
-6. **Stale GOPATH binaries shadowing mise**: The Makefile appends (not prepends) `GOPATH/bin` to PATH so mise-managed tools take precedence. If you see unexpected tool versions, check `which <tool>` vs `mise which <tool>`.
+6. **Stale GOPATH binaries shadowing mise**: The `lint` target prepends `GOPATH/bin` to PATH so the golangci-lint version it just verified or reinstalled against `GOLANGCI_LINT_VERSION` is always the one that runs, even when a differently-versioned binary (e.g. mise-managed) is earlier on `PATH`. If you see unexpected tool versions elsewhere, check `which <tool>` vs `mise which <tool>`.
 
 ### Debugging Tips
 

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ lint: ## Run linters with golangci-lint
 	@echo "$(COLOR_YELLOW)Running linting...$(COLOR_RESET)"
 	@if ! command -v golangci-lint >/dev/null 2>&1; then \
 		echo "$(COLOR_RED)golangci-lint not found. Installing...$(COLOR_RESET)"; \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin $(GOLANGCI_LINT_VERSION); \
+		curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $$(go env GOPATH)/bin $(GOLANGCI_LINT_VERSION); \
 	fi
 	@PATH="$$PATH:$$(go env GOPATH)/bin" golangci-lint --version
 	@PATH="$$PATH:$$(go env GOPATH)/bin" golangci-lint run --timeout=10m $(LINT_FLAGS) ./...
@@ -194,7 +194,7 @@ vuln: ## Run vulnerability check with govulncheck
 tools: ## Install development tools
 	@echo "$(COLOR_YELLOW)Installing development tools...$(COLOR_RESET)"
 	@if ! command -v golangci-lint >/dev/null 2>&1; then \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin $(GOLANGCI_LINT_VERSION); \
+		curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $$(go env GOPATH)/bin $(GOLANGCI_LINT_VERSION); \
 		echo "Installed golangci-lint $(GOLANGCI_LINT_VERSION)"; \
 	fi
 	@if ! command -v goimports >/dev/null 2>&1; then \

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ TEST_PACKAGES := ./...
 COVERAGE_THRESHOLD := 80
 
 # Linting configuration
-GOLANGCI_LINT_VERSION := v2.10.1
+GOLANGCI_LINT_VERSION := v2.13.1
 
 # Colors for output
 COLOR_RESET := \033[0m
@@ -143,6 +143,7 @@ lint: ## Run linters with golangci-lint
 		echo "$(COLOR_RED)golangci-lint not found. Installing...$(COLOR_RESET)"; \
 		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin $(GOLANGCI_LINT_VERSION); \
 	fi
+	@PATH="$$PATH:$$(go env GOPATH)/bin" golangci-lint --version
 	@PATH="$$PATH:$$(go env GOPATH)/bin" golangci-lint run --timeout=10m $(LINT_FLAGS) ./...
 	@echo "$(COLOR_GREEN)Linting passed$(COLOR_RESET)"
 

--- a/Makefile
+++ b/Makefile
@@ -139,12 +139,14 @@ $(COVERAGE_DIR):
 .PHONY: lint
 lint: ## Run linters with golangci-lint
 	@echo "$(COLOR_YELLOW)Running linting...$(COLOR_RESET)"
-	@if ! command -v golangci-lint >/dev/null 2>&1; then \
-		echo "$(COLOR_RED)golangci-lint not found. Installing...$(COLOR_RESET)"; \
+	@installed="$$(PATH="$$(go env GOPATH)/bin:$$PATH" golangci-lint --version 2>/dev/null | sed -n 's/.*version \([0-9.]*\).*/\1/p')"; \
+	pinned="$(GOLANGCI_LINT_VERSION:v%=%)"; \
+	if [ "$$installed" != "$$pinned" ]; then \
+		echo "$(COLOR_RED)golangci-lint missing or version mismatch (found: $${installed:-none}, want: $$pinned). Installing $(GOLANGCI_LINT_VERSION)...$(COLOR_RESET)"; \
 		curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $$(go env GOPATH)/bin $(GOLANGCI_LINT_VERSION); \
 	fi
-	@PATH="$$PATH:$$(go env GOPATH)/bin" golangci-lint --version
-	@PATH="$$PATH:$$(go env GOPATH)/bin" golangci-lint run --timeout=10m $(LINT_FLAGS) ./...
+	@PATH="$$(go env GOPATH)/bin:$$PATH" golangci-lint --version
+	@PATH="$$(go env GOPATH)/bin:$$PATH" golangci-lint run --timeout=10m $(LINT_FLAGS) ./...
 	@echo "$(COLOR_GREEN)Linting passed$(COLOR_RESET)"
 
 .PHONY: lint-fast

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,9 @@ lint: ## Run linters with golangci-lint
 	pinned="$(GOLANGCI_LINT_VERSION:v%=%)"; \
 	if [ "$$installed" != "$$pinned" ]; then \
 		echo "$(COLOR_RED)golangci-lint missing or version mismatch (found: $${installed:-none}, want: $$pinned). Installing $(GOLANGCI_LINT_VERSION)...$(COLOR_RESET)"; \
-		curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $$(go env GOPATH)/bin $(GOLANGCI_LINT_VERSION); \
+		tmp="$$(mktemp)"; \
+		curl -sSfL https://golangci-lint.run/install.sh -o "$$tmp" && sh "$$tmp" -b $$(go env GOPATH)/bin $(GOLANGCI_LINT_VERSION); rc=$$?; rm -f "$$tmp"; \
+		[ $$rc -eq 0 ] || { echo "$(COLOR_RED)golangci-lint install failed$(COLOR_RESET)"; exit 1; }; \
 	fi
 	@PATH="$$(go env GOPATH)/bin:$$PATH" golangci-lint --version
 	@PATH="$$(go env GOPATH)/bin:$$PATH" golangci-lint run --timeout=10m $(LINT_FLAGS) ./...
@@ -196,7 +198,9 @@ vuln: ## Run vulnerability check with govulncheck
 tools: ## Install development tools
 	@echo "$(COLOR_YELLOW)Installing development tools...$(COLOR_RESET)"
 	@if ! command -v golangci-lint >/dev/null 2>&1; then \
-		curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $$(go env GOPATH)/bin $(GOLANGCI_LINT_VERSION); \
+		tmp="$$(mktemp)"; \
+		curl -sSfL https://golangci-lint.run/install.sh -o "$$tmp" && sh "$$tmp" -b $$(go env GOPATH)/bin $(GOLANGCI_LINT_VERSION); rc=$$?; rm -f "$$tmp"; \
+		[ $$rc -eq 0 ] || { echo "golangci-lint install failed"; exit 1; }; \
 		echo "Installed golangci-lint $(GOLANGCI_LINT_VERSION)"; \
 	fi
 	@if ! command -v goimports >/dev/null 2>&1; then \

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -99,7 +99,7 @@ temporary branch — the merged result — before the PR is allowed to land.
 ### Configuration
 
 - Go Version: read from `go.mod` (`go-version-file: go.mod`)
-- Golangci-lint Version: `v2.10.1`
+- Golangci-lint Version: `v2.13.1`
 - govulncheck Version: `v1.7.0` (pinned, cached binary, `-scan symbol` mode)
 - Coverage Threshold (total): `90%` — the overall figure from `go tool cover -func`
 - Coverage Threshold (per-package): `90%` — checked separately for every package, and a single

--- a/pkg/kubernetes/cnpg/README.md
+++ b/pkg/kubernetes/cnpg/README.md
@@ -66,6 +66,24 @@ cnpg.SetScheduledBackupMethod(backup, cnpgv1.BackupMethodBarmanObjectStore)
 cnpg.SetScheduledBackupImmediate(backup, true)
 ```
 
+### Monitoring
+
+```go
+cluster := cnpg.Cluster(&cnpg.ClusterConfig{
+    Name:      "pg-main",
+    Namespace: "databases",
+    Monitoring: &cnpg.MonitoringOptions{
+        EnablePodMonitor: true,
+    },
+})
+```
+
+`MonitoringOptions.EnablePodMonitor` opts into the operator's built-in `PodMonitor` creation via
+the upstream `MonitoringConfiguration.EnablePodMonitor` field. That upstream field is deprecated
+(no replacement API exists yet upstream) — the operator's own deprecation notice recommends
+creating the `PodMonitor` resource manually instead once that path lands. Until then this is the
+only way to request pod-level metrics scraping through this builder.
+
 ## Modifier Functions
 
 All `Add*` and `Set*` functions from the internal package are re-exported here:

--- a/pkg/kubernetes/cnpg/README.md
+++ b/pkg/kubernetes/cnpg/README.md
@@ -69,13 +69,18 @@ cnpg.SetScheduledBackupImmediate(backup, true)
 ### Monitoring
 
 ```go
-cluster := cnpg.Cluster(&cnpg.ClusterConfig{
+cluster, err := cnpg.Cluster(&cnpg.ClusterConfig{
     Name:      "pg-main",
     Namespace: "databases",
-    Monitoring: &cnpg.MonitoringOptions{
-        EnablePodMonitor: true,
+    Options: &cnpg.ClusterOptions{
+        Monitoring: &cnpg.MonitoringOptions{
+            EnablePodMonitor: true,
+        },
     },
 })
+if err != nil {
+    // handle error
+}
 ```
 
 `MonitoringOptions.EnablePodMonitor` opts into the operator's built-in `PodMonitor` creation via

--- a/pkg/kubernetes/cnpg/create.go
+++ b/pkg/kubernetes/cnpg/create.go
@@ -159,7 +159,7 @@ func Cluster(cfg *ClusterConfig) (*cnpgv1.Cluster, error) {
 	}
 
 	if opts.Monitoring != nil && opts.Monitoring.EnablePodMonitor {
-		mon := &cnpgv1.MonitoringConfiguration{EnablePodMonitor: true}
+		mon := &cnpgv1.MonitoringConfiguration{EnablePodMonitor: true} //nolint:staticcheck // SA1019: EnablePodMonitor is the only API this upstream type exposes for opting into PodMonitor creation today; migrating callers to a manually-created PodMonitor is a separate change
 		for _, cq := range opts.Monitoring.CustomQueriesConfigMap {
 			mon.CustomQueriesConfigMap = append(mon.CustomQueriesConfigMap, cnpgv1.ConfigMapKeySelector{
 				LocalObjectReference: machineryapi.LocalObjectReference{Name: cq.Name},


### PR DESCRIPTION
## Summary

A Renovate PR previously bumped `mise.toml`'s golangci-lint pin to `2.13.1` while the pins CI
actually obeys (`Makefile`, `.github/workflows/ci.yml`, docs) stayed at `v2.10.1` — the Makefile
is the pin that matters, since CI runs `make lint`, which installs whatever the Makefile sets.

- Bumped `Makefile`, `.github/workflows/ci.yml`, and `docs/github-workflows.md` to `v2.13.1` /
  `2.13.1` to match `mise.toml` (already correct).
- Added an unconditional `golangci-lint --version` after the install-or-skip conditional in the
  `lint` target, so CI's own log proves the installed version every run (the only prior version
  echo lived in the unused `tools` target, never the target CI actually invokes).
- Fixed the one new lint finding from the three-minor-version bump: a deprecated upstream CNPG
  field with no replacement API, suppressed with `//nolint:staticcheck` and a reason.
- Documented that suppression's context in `pkg/kubernetes/cnpg/README.md`'s new Monitoring
  section, to satisfy the repo's doc-gate check on the touched package.

Part of a small cross-repo tooling-hygiene pass; a follow-up PR will add an ongoing
checker/syncer so this pin set doesn't drift again.

## Test plan

- [x] `mise run verify` — tidy/lint/test all green, 21 packages `ok`
- [x] `make lint` — `0 issues`, banner reads `golangci-lint has version 2.13.1 built with go1.27.0 …`
- [x] `check-doc-gate.sh` run directly — `doc-gate: OK`
- [x] All four pin sites confirmed at `2.13.1`/`v2.13.1`

Draft — automated review loop, one round, one blocking finding (doc-gate miss) caught and fixed.