### PR TITLE
feat(renovate): detect the govulncheck env pin and keep golangci-lint pins in sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,10 @@ jobs:
             - 'scripts/check-tool-versions.sh'
             - 'scripts/sync-tool-versions.sh'
             - 'docs/github-workflows.md'
+            # check-govulncheck-docs (govulncheck version parity, ci.yml vs the doc) reads
+            # these two scripts plus ci.yml/docs/github-workflows.md, both already listed above.
+            - 'scripts/check-govulncheck-docs.sh'
+            - 'scripts/sync-govulncheck-docs.sh'
           docs:
             - 'site/**'
             - 'docs/**'
@@ -160,6 +164,9 @@ jobs:
 
     - name: Check tool version parity
       run: make check-tool-versions
+
+    - name: Check govulncheck docs
+      run: make check-govulncheck-docs
 
     - name: Cache yq
       id: yq-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ env:
   # Several repos across both forges install this same scanner and share the
   # govulncheck-gate action, but nothing compares their pins. A bump therefore has
   # to be mirrored by hand in each workflow that installs it, this one included.
+  # renovate: datasource=go depName=golang.org/x/vuln
   GOVULNCHECK_VERSION: 'v1.7.0'
   # The runner binary patch (Runner.Worker.dll) renames all occurrences of
   # ACTIONS_RESULTS_URL to ACTIONS_RESULTS_ORL, including the name the Worker
@@ -77,6 +78,14 @@ jobs:
             # gate accepts `skipped` deps), so a broken release-pinning script
             # could land with a green build.
             - 'scripts/sync-eso-pin.sh'
+            # check-tool-versions (golangci-lint pin parity) reads all of these;
+            # a PR touching only one must not be able to skip the lint job it
+            # runs in — that would leave the checker unexercised on exactly the
+            # class of edit most likely to break it.
+            - 'mise.toml'
+            - 'scripts/check-tool-versions.sh'
+            - 'scripts/sync-tool-versions.sh'
+            - 'docs/github-workflows.md'
           docs:
             - 'site/**'
             - 'docs/**'
@@ -148,6 +157,9 @@ jobs:
 
     - name: Check Go version consistency
       run: make check-go-version
+
+    - name: Check tool version parity
+      run: make check-tool-versions
 
     - name: Cache yq
       id: yq-cache
@@ -923,3 +935,4 @@ jobs:
       with:
         base-ref: origin/${{ github.base_ref }}
         skip: ${{ contains(github.event.pull_request.labels.*.name, 'docs-skip') }}
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,7 +300,7 @@ Fluent builders follow an immutable pattern - each `With*` method returns a new 
 2. **Test Failures**: Ensure all required fields are set in constructors
 3. **Layout Issues**: Verify LayoutRules configuration
 4. **Patch Problems**: Check JSONPath syntax and target existence
-5. **golangci-lint version mismatch**: If lint fails with "Go language version used to build golangci-lint is lower than the targeted Go version", update the golangci-lint version in both `mise.toml` and `Makefile`. When bumping Go, always check that golangci-lint is built with a compatible Go version.
+5. **golangci-lint version mismatch**: If lint fails with "Go language version used to build golangci-lint is lower than the targeted Go version", bump the version in `mise.toml` and run `scripts/sync-tool-versions.sh` to propagate it to `Makefile`, `.github/workflows/ci.yml` and `docs/github-workflows.md` — `scripts/check-tool-versions.sh` (run during `precommit`) requires all four to match. When bumping Go, always check that golangci-lint is built with a compatible Go version.
 6. **Stale GOPATH binaries shadowing mise**: The `lint` target prepends `GOPATH/bin` to PATH so the golangci-lint version it just verified or reinstalled against `GOLANGCI_LINT_VERSION` is always the one that runs, even when a differently-versioned binary (e.g. mise-managed) is earlier on `PATH`. If you see unexpected tool versions elsewhere, check `which <tool>` vs `mise which <tool>`.
 
 ### Debugging Tips

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -218,7 +218,11 @@ surface:
 
 Renovate regenerates `docs/compatibility.md` on its own branch after gomod or
 mise bumps (`postUpgradeTasks` running `./scripts/sync-versions.sh generate`),
-so its PRs pass the `validate` drift check without manual help.
+so its PRs pass the `validate` drift check without manual help. The same
+`postUpgradeTasks` rule also runs `sh scripts/sync-tool-versions.sh`, which
+keeps the golangci-lint pin in `Makefile`, `.github/workflows/ci.yml` and
+`docs/github-workflows.md` in step with `mise.toml` — a bot PR touching those
+files, or a `check-tool-versions` failure on one, is this same automation.
 
 For the full dependency update process (review, bundling, version tracking), see [Dependency Updates](/contributing/dependency-updates/).
 

--- a/Makefile
+++ b/Makefile
@@ -304,6 +304,14 @@ check-tool-versions: ## Verify golangci-lint pin parity (Makefile/ci.yml/docs) a
 sync-tool-versions: ## Sync golangci-lint pins (Makefile/ci.yml/docs) from mise.toml
 	sh scripts/sync-tool-versions.sh
 
+.PHONY: check-govulncheck-docs
+check-govulncheck-docs: ## Verify govulncheck version parity (docs/github-workflows.md) against ci.yml
+	sh scripts/check-govulncheck-docs.sh
+
+.PHONY: sync-govulncheck-docs
+sync-govulncheck-docs: ## Sync govulncheck doc mentions (docs/github-workflows.md) from ci.yml
+	sh scripts/sync-govulncheck-docs.sh
+
 # =============================================================================
 # Development Environment
 # =============================================================================
@@ -336,10 +344,10 @@ dev: tools ## Set up development environment (mise, deps, git hooks)
 # =============================================================================
 
 .PHONY: check
-check: lint vet test-short check-tool-versions ## Quick code quality check (lint, vet, short tests, tool pins)
+check: lint vet test-short check-tool-versions check-govulncheck-docs ## Quick code quality check (lint, vet, short tests, tool pins)
 
 .PHONY: precommit
-precommit: fmt tidy lint test check-tool-versions ## Run fast pre-commit checks (fmt, tidy, lint, test, tool pins)
+precommit: fmt tidy lint test check-tool-versions check-govulncheck-docs ## Run fast pre-commit checks (fmt, tidy, lint, test, tool pins)
 
 .PHONY: ci
 ci: deps fmt tidy lint vet test test-race test-coverage test-integration vuln ## Run comprehensive CI pipeline

--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,7 @@ check: lint vet test-short check-tool-versions check-govulncheck-docs ## Quick c
 precommit: fmt tidy lint test check-tool-versions check-govulncheck-docs ## Run fast pre-commit checks (fmt, tidy, lint, test, tool pins)
 
 .PHONY: ci
-ci: deps fmt tidy lint vet test test-race test-coverage test-integration vuln ## Run comprehensive CI pipeline
+ci: deps fmt tidy lint vet test test-race test-coverage test-integration vuln check-tool-versions check-govulncheck-docs ## Run comprehensive CI pipeline
 
 # =============================================================================
 # Cleanup

--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,7 @@ dev: tools ## Set up development environment (mise, deps, git hooks)
 check: lint vet test-short check-tool-versions ## Quick code quality check (lint, vet, short tests, tool pins)
 
 .PHONY: precommit
-precommit: fmt tidy lint test ## Run fast pre-commit checks (fmt, tidy, lint, test)
+precommit: fmt tidy lint test check-tool-versions ## Run fast pre-commit checks (fmt, tidy, lint, test, tool pins)
 
 .PHONY: ci
 ci: deps fmt tidy lint vet test test-race test-coverage test-integration vuln ## Run comprehensive CI pipeline

--- a/Makefile
+++ b/Makefile
@@ -296,6 +296,14 @@ check-go-version: ## Verify Go version consistency across all files
 		exit 1; \
 	fi
 
+.PHONY: check-tool-versions
+check-tool-versions: ## Verify golangci-lint pin parity (Makefile/ci.yml/docs) against mise.toml
+	sh scripts/check-tool-versions.sh
+
+.PHONY: sync-tool-versions
+sync-tool-versions: ## Sync golangci-lint pins (Makefile/ci.yml/docs) from mise.toml
+	sh scripts/sync-tool-versions.sh
+
 # =============================================================================
 # Development Environment
 # =============================================================================
@@ -328,7 +336,7 @@ dev: tools ## Set up development environment (mise, deps, git hooks)
 # =============================================================================
 
 .PHONY: check
-check: lint vet test-short ## Quick code quality check (lint, vet, short tests)
+check: lint vet test-short check-tool-versions ## Quick code quality check (lint, vet, short tests, tool pins)
 
 .PHONY: precommit
 precommit: fmt tidy lint test ## Run fast pre-commit checks (fmt, tidy, lint, test)

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -612,6 +612,10 @@ The `changes` job uses `dorny/paths-filter` to skip jobs when unrelated files ch
   metadata or the release-pinning script skipped both the supported-range guard and the
   compatibility-matrix drift guard (or, for `sync-eso-pin.sh`, all of `validate`/`test`)
   and still reported success — the `build` gate accepts a `skipped` dependency as passing.
+  Also includes `mise.toml`, `scripts/check-tool-versions.sh`, `scripts/sync-tool-versions.sh`
+  and this file, for the same reason: `check-tool-versions` also runs only in the `validate`
+  job, and a PR touching only one of those would otherwise skip the golangci-lint pin-parity
+  guard.
 - `docs:` filter — triggers docs-build/docs-check jobs. Includes `site/**`, `docs/**`, `*.md`,
   `scripts/**`, and `.github/workflows/ci.yml` (only ci.yml, since other workflows don't affect
   the docs build).

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -508,7 +508,7 @@ The development version shows a warning banner linking to the latest stable vers
 | Target | Tasks | Use Case |
 |--------|-------|----------|
 | `precommit` | fmt, tidy, lint, test, check-tool-versions, check-govulncheck-docs | Fast local checks (~10s) |
-| `ci` | deps, fmt, tidy, lint, vet, test, test-race, test-coverage, test-integration, vuln | Comprehensive CI pipeline (~2min) |
+| `ci` | deps, fmt, tidy, lint, vet, test, test-race, test-coverage, test-integration, vuln, check-tool-versions, check-govulncheck-docs | Comprehensive CI pipeline (~2min) |
 
 ---
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -507,7 +507,7 @@ The development version shows a warning banner linking to the latest stable vers
 
 | Target | Tasks | Use Case |
 |--------|-------|----------|
-| `precommit` | fmt, tidy, lint, test | Fast local checks (~10s) |
+| `precommit` | fmt, tidy, lint, test, check-tool-versions, check-govulncheck-docs | Fast local checks (~10s) |
 | `ci` | deps, fmt, tidy, lint, vet, test, test-race, test-coverage, test-integration, vuln | Comprehensive CI pipeline (~2min) |
 
 ---

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -85,7 +85,7 @@ temporary branch — the merged result — before the PR is allowed to land.
 
 | Job | Check Name | Timeout | Dependencies | Purpose |
 |-----|------------|---------|--------------|---------|
-| `validate` | `lint` | 15 min | changes | Go fmt, tidy, vet, lint; `sync-versions.sh check`; `bash -n` syntax-check on the version-sync scripts; caches goimports + yq binaries |
+| `validate` | `lint` | 15 min | changes | Go fmt, tidy, vet, lint, tool-version parity (golangci-lint pin across Makefile/ci.yml/docs), govulncheck doc parity; `sync-versions.sh check`; `bash -n` syntax-check on the version-sync scripts; caches goimports + yq binaries |
 | `action-pins` | `action-pins` | 2 min | — | Fails if any third-party `uses:` ref is not pinned to a 40-char commit SHA (`go-kure/.github` canonical checker) |
 | `forbidden-terms` | `forbidden-terms` | 2 min | — | Runs the canonical full-tree downstream-reference guard on every workflow event and verifies the vendored release guard |
 | `test` | `test` | 20 min | changes | Unit tests with race detection and coverage; `-race` compilation takes ~5 min on the in-cluster runner, so 20 min allows compilation + 15 min for test execution |
@@ -615,7 +615,8 @@ The `changes` job uses `dorny/paths-filter` to skip jobs when unrelated files ch
   Also includes `mise.toml`, `scripts/check-tool-versions.sh`, `scripts/sync-tool-versions.sh`
   and this file, for the same reason: `check-tool-versions` also runs only in the `validate`
   job, and a PR touching only one of those would otherwise skip the golangci-lint pin-parity
-  guard.
+  guard. Same reasoning covers `scripts/check-govulncheck-docs.sh` and
+  `scripts/sync-govulncheck-docs.sh` — `check-govulncheck-docs` also runs only in `validate`.
 - `docs:` filter — triggers docs-build/docs-check jobs. Includes `site/**`, `docs/**`, `*.md`,
   `scripts/**`, and `.github/workflows/ci.yml` (only ci.yml, since other workflows don't affect
   the docs build).

--- a/mise.toml
+++ b/mise.toml
@@ -27,7 +27,15 @@ run = "make check"
 
 [tasks.verify]
 description = "Run all checks (tidy, lint, test)"
-depends = ["tidy", "lint", "test"]
+depends = ["tidy", "lint", "test", "check-tool-versions"]
+
+[tasks.check-tool-versions]
+description = "Verify golangci-lint pin parity (Makefile/ci.yml/docs) against mise.toml"
+run = "sh scripts/check-tool-versions.sh"
+
+[tasks.sync-tool-versions]
+description = "Sync golangci-lint pins (Makefile/ci.yml/docs) from mise.toml"
+run = "sh scripts/sync-tool-versions.sh"
 
 [tasks.changelog]
 description = "Generate changelog from git history"

--- a/mise.toml
+++ b/mise.toml
@@ -27,7 +27,7 @@ run = "make check"
 
 [tasks.verify]
 description = "Run all checks (tidy, lint, test)"
-depends = ["tidy", "lint", "test", "check-tool-versions"]
+depends = ["tidy", "lint", "test", "check-tool-versions", "check-govulncheck-docs"]
 
 [tasks.check-tool-versions]
 description = "Verify golangci-lint pin parity (Makefile/ci.yml/docs) against mise.toml"
@@ -36,6 +36,14 @@ run = "sh scripts/check-tool-versions.sh"
 [tasks.sync-tool-versions]
 description = "Sync golangci-lint pins (Makefile/ci.yml/docs) from mise.toml"
 run = "sh scripts/sync-tool-versions.sh"
+
+[tasks.check-govulncheck-docs]
+description = "Verify govulncheck version parity (docs/github-workflows.md) against ci.yml"
+run = "sh scripts/check-govulncheck-docs.sh"
+
+[tasks.sync-govulncheck-docs]
+description = "Sync govulncheck doc mentions (docs/github-workflows.md) from ci.yml"
+run = "sh scripts/sync-govulncheck-docs.sh"
 
 [tasks.changelog]
 description = "Generate changelog from git history"

--- a/mise.toml
+++ b/mise.toml
@@ -26,7 +26,7 @@ description = "Quick pre-commit check"
 run = "make check"
 
 [tasks.verify]
-description = "Run all checks (tidy, lint, test)"
+description = "Run all checks (tidy, lint, test, tool pins, govulncheck docs)"
 depends = ["tidy", "lint", "test", "check-tool-versions", "check-govulncheck-docs"]
 
 [tasks.check-tool-versions]

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,15 @@
   "customManagers": [
     {
       "customType": "regex",
+      "description": "govulncheck pin in ci.yml's env: block — invisible to the github-actions manager, which only reads uses: refs, not env: values.",
+      "managerFilePatterns": [".github/workflows/ci.yml"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s+GOVULNCHECK_VERSION: ['\"]?(?<currentValue>v[\\d.]+)['\"]?"
+      ],
+      "datasourceTemplate": "{{{datasource}}}"
+    },
+    {
+      "customType": "regex",
       "description": "The canonical-guard checkout in ci.yml pins go-kure/.github by SHA in `ref:`, invisible to the github-actions manager. Without this the vendored guard is byte-compared against a stale revision (go-kure/kure#689).",
       "managerFilePatterns": ["/^\\.github/workflows/ci\\.yml$/"],
       "matchStrings": ["repository: go-kure/\\.github[\\s\\S]*?ref: (?<currentDigest>[0-9a-f]{40})"],
@@ -39,11 +48,20 @@
       }
     },
     {
-      "description": "Regenerate docs/compatibility.md on the bot's own branch after any gomod or mise bump — the committed matrix is generated from versions.yaml + go.mod, and CI's validate job fails on drift (sync-versions.sh check). Dependabot could not run this step, which left its PRs permanently red (#665, #667). The script is a no-op when nothing derived changes, so matching both managers is safe. go.mod is included because generate also rewrites its `// Current pin:` comment from the k8s.io/api replace directive.",
+      "description": "Regenerate docs/compatibility.md, and keep golangci-lint's Makefile/ci.yml/docs pins in sync with mise.toml, on the bot's own branch after any gomod or mise bump. The compatibility matrix is generated from versions.yaml + go.mod, and CI's validate job fails on drift (sync-versions.sh check); the golangci-lint pins are plain strings only scripts/sync-tool-versions.sh keeps in step with mise.toml, the only copy the mise datasource actually bumps. Dependabot could not run this step, which left its PRs permanently red (#665, #667). Both scripts are no-ops when nothing derived changes, so matching both managers is safe. go.mod is included because generate also rewrites its `// Current pin:` comment from the k8s.io/api replace directive.",
       "matchManagers": ["gomod", "mise"],
       "postUpgradeTasks": {
-        "commands": ["./scripts/sync-versions.sh generate"],
-        "fileFilters": ["docs/compatibility.md", "go.mod"],
+        "commands": [
+          "./scripts/sync-versions.sh generate",
+          "sh scripts/sync-tool-versions.sh"
+        ],
+        "fileFilters": [
+          "docs/compatibility.md",
+          "go.mod",
+          "Makefile",
+          ".github/workflows/ci.yml",
+          "docs/github-workflows.md"
+        ],
         "executionMode": "branch"
       }
     },

--- a/renovate.json
+++ b/renovate.json
@@ -83,6 +83,15 @@
       ],
       "matchUpdateTypes": ["minor"],
       "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Keep docs/github-workflows.md's govulncheck version mentions in sync with the GOVULNCHECK_VERSION pin the customManager above bumps in ci.yml. A separate rule from the gomod/mise one above: this fires on the customManager's own update (matched by its depName, since custom regex managers aren't covered by matchManagers: [gomod, mise]), not on a gomod or mise bump.",
+      "matchPackageNames": ["golang.org/x/vuln"],
+      "postUpgradeTasks": {
+        "commands": ["sh scripts/sync-govulncheck-docs.sh"],
+        "fileFilters": ["docs/github-workflows.md"],
+        "executionMode": "branch"
+      }
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -85,7 +85,8 @@
       "dependencyDashboardApproval": true
     },
     {
-      "description": "Keep docs/github-workflows.md's govulncheck version mentions in sync with the GOVULNCHECK_VERSION pin the customManager above bumps in ci.yml. A separate rule from the gomod/mise one above: this fires on the customManager's own update (matched by its depName, since custom regex managers aren't covered by matchManagers: [gomod, mise]), not on a gomod or mise bump.",
+      "description": "Keep docs/github-workflows.md's govulncheck version mentions in sync with the GOVULNCHECK_VERSION pin the customManager above bumps in ci.yml. Scoped to that customManager specifically, not just by depName: golang.org/x/vuln is also a real go.mod dependency, and without matchManagers a gomod-sourced bump of it would match here too — postUpgradeTasks has no merge semantics, so this rule's commands would silently replace the gomod/mise rule's ./scripts/sync-versions.sh generate, reintroducing the compatibility-matrix drift that rule exists to prevent.",
+      "matchManagers": ["custom.regex"],
       "matchPackageNames": ["golang.org/x/vuln"],
       "postUpgradeTasks": {
         "commands": ["sh scripts/sync-govulncheck-docs.sh"],

--- a/scripts/check-govulncheck-docs.sh
+++ b/scripts/check-govulncheck-docs.sh
@@ -28,7 +28,10 @@ if [ "$ci_count" -ne 1 ]; then
 	echo "✗ govulncheck: expected exactly 1 GOVULNCHECK_VERSION assignment in .github/workflows/ci.yml, found $ci_count"
 	exit 1
 fi
-CI_VAL="$(grep -E '^[[:space:]]*GOVULNCHECK_VERSION:' .github/workflows/ci.yml | sed -E 's/^[^:]+:[[:space:]]*//' | tr -d "\"'" | sed -E 's/^v//')"
+# Trim trailing whitespace too — a stray space before the line end (e.g. "v1.7.0 ") would
+# otherwise survive into CI_VAL and propagate into sync-govulncheck-docs.sh's rewrite, embedding
+# a space in every doc mention it touches before this checker's own self-verify catches it dirty.
+CI_VAL="$(grep -E '^[[:space:]]*GOVULNCHECK_VERSION:' .github/workflows/ci.yml | sed -E 's/^[^:]+:[[:space:]]*//' | tr -d "\"'" | sed -E 's/^v//; s/[[:space:]]+$//')"
 if [ -z "$CI_VAL" ]; then
 	echo "✗ govulncheck: GOVULNCHECK_VERSION not found in .github/workflows/ci.yml"
 	exit 1

--- a/scripts/check-govulncheck-docs.sh
+++ b/scripts/check-govulncheck-docs.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# check-govulncheck-docs.sh — enforce parity between the govulncheck version pinned in
+# .github/workflows/ci.yml's env: block and every mention of it in docs/github-workflows.md.
+#
+# Unlike golangci-lint (source of truth: mise.toml, a file none of its own targets are),
+# govulncheck's source of truth is ci.yml itself — the same file Renovate's customManagers
+# regex entry in renovate.json bumps directly. Before that customManager existed, govulncheck
+# was invisible to Renovate and any manual bump landed in the same PR as its doc updates; now
+# that it can update automatically, an automated bump leaves the docs stale unless something
+# enforces parity.
+#
+# CI images do not have mise installed, so this is a plain POSIX shell script CI can run
+# directly — it must NOT depend on mise.
+#
+# Exit non-zero on any mismatch. Run scripts/sync-govulncheck-docs.sh to fix.
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+CI_VAL="$(grep -E '^[[:space:]]*GOVULNCHECK_VERSION:' .github/workflows/ci.yml | head -1 | sed -E 's/^[^:]+:[[:space:]]*//' | tr -d "\"'" | sed -E 's/^v//')"
+if [ -z "$CI_VAL" ]; then
+	echo "✗ govulncheck: GOVULNCHECK_VERSION not found in .github/workflows/ci.yml"
+	exit 1
+fi
+
+DOC="docs/github-workflows.md"
+if [ ! -f "$DOC" ]; then
+	echo "✗ govulncheck: $DOC not found"
+	exit 1
+fi
+
+# Every line pairing "govulncheck" (case-insensitive) with a vX.Y.Z-shaped version is a target —
+# matches the doc's three current mentions (a table cell, a version-list bullet, a cache-key
+# bullet) without hand-anchoring three different line shapes. Zero matches is itself a failure:
+# a renamed/deleted mention must not silently pass.
+LINES="$(grep -inE 'govulncheck.*v[0-9]+\.[0-9]+' "$DOC" || true)"
+if [ -z "$LINES" ]; then
+	echo "✗ $DOC: no govulncheck version mention found (expected at least one)"
+	exit 1
+fi
+
+ERRORS=0
+LINE_COUNT=0
+# Heredoc, not a pipe, so the loop runs in this shell (not a subshell) and ERRORS/LINE_COUNT
+# survive past the loop — a `LINES | while read` here would silently drop every increment.
+while IFS= read -r line; do
+	lineno="${line%%:*}"
+	val="$(printf '%s\n' "$line" | grep -oE 'v[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1 | sed -E 's/^v//')"
+	LINE_COUNT=$((LINE_COUNT + 1))
+	if [ "$val" != "$CI_VAL" ]; then
+		echo "✗ $DOC:$lineno has v$val (expected v$CI_VAL from .github/workflows/ci.yml)"
+		ERRORS=$((ERRORS + 1))
+	fi
+done <<EOF
+$LINES
+EOF
+
+if [ "$ERRORS" -gt 0 ]; then
+	echo "Found $ERRORS mismatch(es). Run 'scripts/sync-govulncheck-docs.sh' (or 'mise run sync-govulncheck-docs') to fix."
+	exit 1
+fi
+echo "✓ govulncheck docs (v$CI_VAL, $LINE_COUNT mention(s) in $DOC)"

--- a/scripts/check-govulncheck-docs.sh
+++ b/scripts/check-govulncheck-docs.sh
@@ -18,7 +18,17 @@ set -eu
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-CI_VAL="$(grep -E '^[[:space:]]*GOVULNCHECK_VERSION:' .github/workflows/ci.yml | head -1 | sed -E 's/^[^:]+:[[:space:]]*//' | tr -d "\"'" | sed -E 's/^v//')"
+# Exactly one match required — a second GOVULNCHECK_VERSION assignment (e.g. a job-level env
+# override in the security job) would still silently win under `head -1`'s first-match pick,
+# while the govulncheck install step actually consumes whichever one GitHub Actions resolves for
+# that job — the same duplicate-pin risk scripts/check-tool-versions.sh already guards against
+# for GOLANGCI_LINT_VERSION.
+ci_count="$(grep -cE '^[[:space:]]*GOVULNCHECK_VERSION:' .github/workflows/ci.yml || true)"
+if [ "$ci_count" -ne 1 ]; then
+	echo "✗ govulncheck: expected exactly 1 GOVULNCHECK_VERSION assignment in .github/workflows/ci.yml, found $ci_count"
+	exit 1
+fi
+CI_VAL="$(grep -E '^[[:space:]]*GOVULNCHECK_VERSION:' .github/workflows/ci.yml | sed -E 's/^[^:]+:[[:space:]]*//' | tr -d "\"'" | sed -E 's/^v//')"
 if [ -z "$CI_VAL" ]; then
 	echo "✗ govulncheck: GOVULNCHECK_VERSION not found in .github/workflows/ci.yml"
 	exit 1
@@ -49,9 +59,19 @@ while IFS= read -r line; do
 	# Extract from the text after the FIRST "govulncheck" on the line, not the whole line and
 	# not a greedy match to the LAST occurrence — a line can legitimately mention govulncheck
 	# twice (e.g. "govulncheck ... v1.7.0 ... govulncheck-gate action"), and a greedy `.*` would
-	# skip past the actual pin looking for the later mention. `#*govulncheck` is shell parameter
-	# expansion's shortest-prefix removal, i.e. genuinely first-occurrence, unlike sed's `.*`.
-	after="${line#*govulncheck}"
+	# skip past the actual pin looking for the later mention. The line SELECTION above is
+	# case-insensitive (`grep -inE`), so extraction must be too — a case-sensitive shell
+	# `${line#*govulncheck}` would fail to strip a differently-cased mention (e.g.
+	# "Govulncheck"), leaving the whole line (including the "NN:" prefix) as `after` and
+	# producing a false mismatch. `index(tolower(...))` mirrors sync-govulncheck-docs.sh's own
+	# case-insensitive first-occurrence split, so checker and syncer agree on what "the text
+	# after govulncheck" means.
+	after="$(printf '%s\n' "$line" | awk '
+		{
+			idx = index(tolower($0), "govulncheck")
+			if (idx > 0) print substr($0, idx + length("govulncheck"))
+		}
+	')"
 	val="$(printf '%s\n' "$after" | grep -oE 'v[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1 | sed -E 's/^v//')"
 	LINE_COUNT=$((LINE_COUNT + 1))
 	if [ "$val" != "$CI_VAL" ]; then

--- a/scripts/check-govulncheck-docs.sh
+++ b/scripts/check-govulncheck-docs.sh
@@ -46,7 +46,13 @@ LINE_COUNT=0
 # survive past the loop — a `LINES | while read` here would silently drop every increment.
 while IFS= read -r line; do
 	lineno="${line%%:*}"
-	val="$(printf '%s\n' "$line" | grep -oE 'v[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1 | sed -E 's/^v//')"
+	# Extract from the text after the FIRST "govulncheck" on the line, not the whole line and
+	# not a greedy match to the LAST occurrence — a line can legitimately mention govulncheck
+	# twice (e.g. "govulncheck ... v1.7.0 ... govulncheck-gate action"), and a greedy `.*` would
+	# skip past the actual pin looking for the later mention. `#*govulncheck` is shell parameter
+	# expansion's shortest-prefix removal, i.e. genuinely first-occurrence, unlike sed's `.*`.
+	after="${line#*govulncheck}"
+	val="$(printf '%s\n' "$after" | grep -oE 'v[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1 | sed -E 's/^v//')"
 	LINE_COUNT=$((LINE_COUNT + 1))
 	if [ "$val" != "$CI_VAL" ]; then
 		echo "✗ $DOC:$lineno has v$val (expected v$CI_VAL from .github/workflows/ci.yml)"

--- a/scripts/check-tool-versions.sh
+++ b/scripts/check-tool-versions.sh
@@ -56,7 +56,7 @@ if [ "$mk_count" -ne 1 ]; then
 	echo "✗ Makefile: expected exactly 1 GOLANGCI_LINT_VERSION assignment, found $mk_count"
 	ERRORS=$((ERRORS + 1))
 else
-	mk_val="$(grep -E '^GOLANGCI_LINT_VERSION[[:space:]]*:=[[:space:]]*v' Makefile | sed -E 's/^GOLANGCI_LINT_VERSION[[:space:]]*:=[[:space:]]*v//')"
+	mk_val="$(grep -E '^GOLANGCI_LINT_VERSION[[:space:]]*:=[[:space:]]*v' Makefile | sed -E 's/^GOLANGCI_LINT_VERSION[[:space:]]*:=[[:space:]]*v//; s/[[:space:]]+$//')"
 	check "Makefile" "Makefile" "$mk_val"
 fi
 

--- a/scripts/check-tool-versions.sh
+++ b/scripts/check-tool-versions.sh
@@ -72,7 +72,7 @@ if [ "$ci_count" -ne 1 ]; then
 	echo "✗ ci.yml: expected exactly 1 GOLANGCI_LINT_VERSION assignment, found $ci_count"
 	ERRORS=$((ERRORS + 1))
 else
-	ci_val="$(grep -E "$CI_PATTERN" .github/workflows/ci.yml | sed -E 's/^[^:]+:[[:space:]]*//' | tr -d "\"'" | sed -E 's/^v//')"
+	ci_val="$(grep -E "$CI_PATTERN" .github/workflows/ci.yml | sed -E 's/^[^:]+:[[:space:]]*//' | tr -d "\"'" | sed -E 's/^v//; s/[[:space:]]+$//')"
 	check "ci.yml" ".github/workflows/ci.yml" "$ci_val"
 fi
 

--- a/scripts/check-tool-versions.sh
+++ b/scripts/check-tool-versions.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+# check-tool-versions.sh — enforce golangci-lint version parity between the
+# mise.toml [tools] source of truth and the pins duplicated by hand in
+# Makefile, .github/workflows/ci.yml and docs/github-workflows.md.
+#
+# mise.toml is the only copy Renovate's `mise` datasource actually bumps.
+# Every other copy is a plain string a human — or Renovate's own
+# postUpgradeTasks sync command — must keep in step by hand; this script is
+# what enforces that "by hand" doesn't mean "silently drifts".
+#
+# CI images do not have mise installed, so this is a plain POSIX shell
+# script that CI can run directly — it must NOT depend on mise.
+#
+# Exit non-zero on any mismatch. Run scripts/sync-tool-versions.sh to fix.
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+MISE="mise.toml"
+MISE_VAL="$(grep -E '^golangci-lint = "' "$MISE" | head -1 | cut -d'"' -f2)"
+if [ -z "$MISE_VAL" ]; then
+	echo "✗ golangci-lint: not found in $MISE [tools]"
+	exit 1
+fi
+
+ERRORS=0
+
+# check LABEL FILE ACTUAL — ACTUAL is the caller-extracted value, already
+# stripped of quoting/prefix noise, compared against mise.toml's bare version.
+check() {
+	label="$1"; file="$2"; actual="$3"
+	if [ -z "$actual" ]; then
+		echo "✗ $label: not found in $file"
+		ERRORS=$((ERRORS + 1))
+		return
+	fi
+	if [ "$actual" != "$MISE_VAL" ]; then
+		echo "✗ $label: $file has $actual (expected $MISE_VAL from $MISE)"
+		ERRORS=$((ERRORS + 1))
+		return
+	fi
+	echo "✓ $label ($actual)"
+}
+
+# Makefile: GOLANGCI_LINT_VERSION := v2.13.1
+# Exactly one match required, over ANY spacing around ":=" — a second
+# assignment in a different spacing would still silently win under GNU
+# Make's last-assignment-wins semantics for ":=" even though a
+# canonical-spacing-only pattern couldn't see it.
+mk_count="$(grep -cE '^GOLANGCI_LINT_VERSION[[:space:]]*:=[[:space:]]*v' Makefile || true)"
+if [ "$mk_count" -ne 1 ]; then
+	echo "✗ Makefile: expected exactly 1 GOLANGCI_LINT_VERSION assignment, found $mk_count"
+	ERRORS=$((ERRORS + 1))
+else
+	mk_val="$(grep -E '^GOLANGCI_LINT_VERSION[[:space:]]*:=[[:space:]]*v' Makefile | sed -E 's/^GOLANGCI_LINT_VERSION[[:space:]]*:=[[:space:]]*v//')"
+	check "Makefile" "Makefile" "$mk_val"
+fi
+
+# .github/workflows/ci.yml: GOLANGCI_LINT_VERSION: 'v2.13.1'
+# Exactly one match required, over ANY indentation and ANY quote style
+# (single/double/none), and the value is extracted with the SAME pattern
+# used for the count — a looser extraction pattern than the count pattern
+# would let a second line the count can't see pull ci_val into a multi-line
+# value while the count still reports exactly one.
+CI_PATTERN='^[[:space:]]*GOLANGCI_LINT_VERSION:[[:space:]]*.?v[0-9.]+.?[[:space:]]*$'
+ci_count="$(grep -cE "$CI_PATTERN" .github/workflows/ci.yml || true)"
+if [ "$ci_count" -ne 1 ]; then
+	echo "✗ ci.yml: expected exactly 1 GOLANGCI_LINT_VERSION assignment, found $ci_count"
+	ERRORS=$((ERRORS + 1))
+else
+	ci_val="$(grep -E "$CI_PATTERN" .github/workflows/ci.yml | sed -E 's/^[^:]+:[[:space:]]*//' | tr -d "\"'" | sed -E 's/^v//')"
+	check "ci.yml" ".github/workflows/ci.yml" "$ci_val"
+fi
+
+# docs/github-workflows.md: - Golangci-lint Version: `v2.13.1`
+# Exactly one match required — a renamed/deleted line must fail, not
+# silently pass. (kure's own check-go-version treats zero matches as a
+# pass; this script deliberately does not copy that.)
+# shellcheck disable=SC2016 # the backticks below are literal markdown, not
+# unexpanded variables — single-quoting is correct (double quotes would let
+# them trigger real command substitution).
+doc_count="$(grep -cE '^- Golangci-lint Version: `v[0-9.]+`$' docs/github-workflows.md || true)"
+if [ "$doc_count" -ne 1 ]; then
+	echo "✗ docs/github-workflows.md: expected exactly 1 'Golangci-lint Version' line, found $doc_count"
+	ERRORS=$((ERRORS + 1))
+else
+	# shellcheck disable=SC2016 # same false positive as above
+	doc_val="$(grep -E '^- Golangci-lint Version: `v[0-9.]+`$' docs/github-workflows.md | sed -E 's/.*`v([0-9.]+)`.*/\1/')"
+	check "docs/github-workflows.md" "docs/github-workflows.md" "$doc_val"
+fi
+
+if [ "$ERRORS" -gt 0 ]; then
+	echo "Found $ERRORS mismatch(es). Run 'scripts/sync-tool-versions.sh' (or 'mise run sync-tool-versions') to fix."
+	exit 1
+fi
+echo "All pinned tool versions consistent."

--- a/scripts/check-tool-versions.sh
+++ b/scripts/check-tool-versions.sh
@@ -19,6 +19,9 @@ cd "$ROOT"
 
 MISE="mise.toml"
 MISE_VAL="$(grep -E '^golangci-lint = "' "$MISE" | head -1 | cut -d'"' -f2)"
+# mise tolerates a "v"-prefixed pin (golangci-lint's own release tags carry one); strip it so a
+# future Renovate bump that writes "vX.Y.Z" here can't double-prefix every target's "v$MISE_VAL".
+MISE_VAL="${MISE_VAL#v}"
 if [ -z "$MISE_VAL" ]; then
 	echo "✗ golangci-lint: not found in $MISE [tools]"
 	exit 1

--- a/scripts/sync-govulncheck-docs.sh
+++ b/scripts/sync-govulncheck-docs.sh
@@ -24,10 +24,26 @@ if [ ! -f "$DOC" ]; then
 	exit 1
 fi
 
-# Every line pairing "govulncheck" (case-insensitive) with a version gets that version
-# rewritten — same selection rule as the checker, so a line the checker would flag is a line
-# this can actually fix.
-sed -i -E "/govulncheck/I s/v[0-9]+\.[0-9]+(\.[0-9]+)?/v$CI_VAL/" "$DOC"
+# Rewrite only the version immediately following the FIRST "govulncheck" on each line — a
+# version-shaped token before it (another tool's pin) must stay untouched, and a line can
+# legitimately mention govulncheck twice (e.g. "govulncheck ... v1.7.0 ... govulncheck-gate
+# action"), so a sed `.*` greedy match to the LAST occurrence would skip past the actual pin.
+# awk's index()/match() give genuine first-occurrence, single-token splitting that sed's
+# regex-only approach can't (POSIX ERE has no non-greedy quantifier).
+awk -v ver="$CI_VAL" '
+{
+	line = $0
+	idx = index(tolower(line), "govulncheck")
+	if (idx > 0) {
+		prefix = substr(line, 1, idx + length("govulncheck") - 1)
+		rest = substr(line, idx + length("govulncheck"))
+		if (match(rest, /v[0-9]+\.[0-9]+(\.[0-9]+)?/)) {
+			rest = substr(rest, 1, RSTART - 1) "v" ver substr(rest, RSTART + RLENGTH)
+		}
+		line = prefix rest
+	}
+	print line
+}' "$DOC" > "$DOC.tmp" && mv "$DOC.tmp" "$DOC"
 
 echo "Synced govulncheck doc mentions to v$CI_VAL ($DOC)"
 

--- a/scripts/sync-govulncheck-docs.sh
+++ b/scripts/sync-govulncheck-docs.sh
@@ -12,7 +12,9 @@ set -eu
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-CI_VAL="$(grep -E '^[[:space:]]*GOVULNCHECK_VERSION:' .github/workflows/ci.yml | head -1 | sed -E 's/^[^:]+:[[:space:]]*//' | tr -d "\"'" | sed -E 's/^v//')"
+# Trim trailing whitespace too — an untrimmed value would embed a literal space in every doc
+# mention this script rewrites, via the ver substitution below.
+CI_VAL="$(grep -E '^[[:space:]]*GOVULNCHECK_VERSION:' .github/workflows/ci.yml | head -1 | sed -E 's/^[^:]+:[[:space:]]*//' | tr -d "\"'" | sed -E 's/^v//; s/[[:space:]]+$//')"
 if [ -z "$CI_VAL" ]; then
 	echo "Error: GOVULNCHECK_VERSION not found in .github/workflows/ci.yml"
 	exit 1

--- a/scripts/sync-govulncheck-docs.sh
+++ b/scripts/sync-govulncheck-docs.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# sync-govulncheck-docs.sh — rewrite every govulncheck version mention in
+# docs/github-workflows.md from .github/workflows/ci.yml's GOVULNCHECK_VERSION pin.
+#
+# The inverse of scripts/check-govulncheck-docs.sh. ci.yml is the source of truth here (not
+# mise.toml) — it's the file Renovate's govulncheck customManager in renovate.json bumps
+# directly, so this script has nothing to read except the file it's also rewriting a copy of.
+#
+# Run scripts/check-govulncheck-docs.sh afterwards (or 'mise run check-govulncheck-docs').
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+CI_VAL="$(grep -E '^[[:space:]]*GOVULNCHECK_VERSION:' .github/workflows/ci.yml | head -1 | sed -E 's/^[^:]+:[[:space:]]*//' | tr -d "\"'" | sed -E 's/^v//')"
+if [ -z "$CI_VAL" ]; then
+	echo "Error: GOVULNCHECK_VERSION not found in .github/workflows/ci.yml"
+	exit 1
+fi
+
+DOC="docs/github-workflows.md"
+if [ ! -f "$DOC" ]; then
+	echo "Error: $DOC not found"
+	exit 1
+fi
+
+# Every line pairing "govulncheck" (case-insensitive) with a version gets that version
+# rewritten — same selection rule as the checker, so a line the checker would flag is a line
+# this can actually fix.
+sed -i -E "/govulncheck/I s/v[0-9]+\.[0-9]+(\.[0-9]+)?/v$CI_VAL/" "$DOC"
+
+echo "Synced govulncheck doc mentions to v$CI_VAL ($DOC)"
+
+# sed exits 0 even when a pattern matched zero lines — self-verify by re-running the checker
+# rather than trusting sed's silent-success-on-no-match behavior.
+if ! sh "$ROOT/scripts/check-govulncheck-docs.sh"; then
+	echo "Error: sync ran but a mention still does not match v$CI_VAL — the doc's format probably drifted from what this script's sed pattern expects. Fix scripts/sync-govulncheck-docs.sh and scripts/check-govulncheck-docs.sh together." >&2
+	exit 1
+fi

--- a/scripts/sync-tool-versions.sh
+++ b/scripts/sync-tool-versions.sh
@@ -27,10 +27,17 @@ fi
 # regexes accept (arbitrary spacing around ":=", arbitrary indentation and quote style in
 # ci.yml) — a narrower syncer than checker means a validly-formatted variant the checker
 # tolerates still leaves the syncer rewriting nothing, and its own self-verify below aborting.
-sed -i -E "s/^(GOLANGCI_LINT_VERSION[[:space:]]*:=[[:space:]]*)v[0-9.]+/\\1v$MISE_VAL/" Makefile
-sed -i -E "s/^([[:space:]]*GOLANGCI_LINT_VERSION:[[:space:]]*)[\"']?v[0-9.]+[\"']?([[:space:]]*)\$/\\1'v$MISE_VAL'\\2/" .github/workflows/ci.yml
+#
+# Temp-file + mv, not `sed -i -E` — this script declares itself #!/bin/sh (portable POSIX),
+# but BSD/macOS sed's `-i` takes the backup suffix as its next argument, so `-i -E` parses
+# `-E` as that suffix: the substitution then runs as a literal BRE (no groups), nothing
+# matches, and a stray `Makefile-E`/`ci.yml-E` is left behind. The self-verify below would
+# then fail with a misleading "a target file's format probably drifted" — sync-govulncheck-docs.sh
+# already avoids this the same way.
+sed -E "s/^(GOLANGCI_LINT_VERSION[[:space:]]*:=[[:space:]]*)v[0-9.]+/\\1v$MISE_VAL/" Makefile > Makefile.tmp && mv Makefile.tmp Makefile
+sed -E "s/^([[:space:]]*GOLANGCI_LINT_VERSION:[[:space:]]*)[\"']?v[0-9.]+[\"']?([[:space:]]*)\$/\\1'v$MISE_VAL'\\2/" .github/workflows/ci.yml > .github/workflows/ci.yml.tmp && mv .github/workflows/ci.yml.tmp .github/workflows/ci.yml
 # shellcheck disable=SC2016 # literal markdown backticks, not unexpanded vars
-sed -i -E "s/^- Golangci-lint Version: \`v[0-9.]+\`\$/- Golangci-lint Version: \`v$MISE_VAL\`/" docs/github-workflows.md
+sed -E "s/^- Golangci-lint Version: \`v[0-9.]+\`\$/- Golangci-lint Version: \`v$MISE_VAL\`/" docs/github-workflows.md > docs/github-workflows.md.tmp && mv docs/github-workflows.md.tmp docs/github-workflows.md
 
 echo "Synced golangci-lint pins to $MISE_VAL (Makefile, ci.yml, docs/github-workflows.md)"
 

--- a/scripts/sync-tool-versions.sh
+++ b/scripts/sync-tool-versions.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# sync-tool-versions.sh — rewrite the golangci-lint version pinned by hand in
+# Makefile, .github/workflows/ci.yml and docs/github-workflows.md from the
+# mise.toml [tools] source of truth.
+#
+# The inverse of scripts/check-tool-versions.sh — keep every copy equal, or
+# the checker will fail on a file this cannot fix, or Renovate's
+# postUpgradeTasks will sync a file the checker does not police.
+#
+# Run scripts/check-tool-versions.sh afterwards (or 'mise run check-tool-versions').
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+MISE="mise.toml"
+MISE_VAL="$(grep -E '^golangci-lint = "' "$MISE" | head -1 | cut -d'"' -f2)"
+if [ -z "$MISE_VAL" ]; then
+	echo "Error: golangci-lint not found in $MISE [tools]"
+	exit 1
+fi
+
+sed -i -E "s/^GOLANGCI_LINT_VERSION := v[0-9.]+/GOLANGCI_LINT_VERSION := v$MISE_VAL/" Makefile
+sed -i -E "s/^([[:space:]]*GOLANGCI_LINT_VERSION: )'v[0-9.]+'/\\1'v$MISE_VAL'/" .github/workflows/ci.yml
+# shellcheck disable=SC2016 # literal markdown backticks, not unexpanded vars
+sed -i -E "s/^- Golangci-lint Version: \`v[0-9.]+\`\$/- Golangci-lint Version: \`v$MISE_VAL\`/" docs/github-workflows.md
+
+echo "Synced golangci-lint pins to $MISE_VAL (Makefile, ci.yml, docs/github-workflows.md)"
+
+# sed exits 0 even when a pattern matched zero lines (format drift, a
+# renamed line) — self-verify by re-running the checker rather than
+# trusting sed's silent-success-on-no-match behavior.
+if ! sh "$ROOT/scripts/check-tool-versions.sh"; then
+	echo "Error: sync ran but a pin still does not match $MISE ($MISE_VAL) — a target file's format probably drifted from what this script's sed patterns expect. Fix scripts/sync-tool-versions.sh and scripts/check-tool-versions.sh together." >&2
+	exit 1
+fi

--- a/scripts/sync-tool-versions.sh
+++ b/scripts/sync-tool-versions.sh
@@ -15,6 +15,9 @@ cd "$ROOT"
 
 MISE="mise.toml"
 MISE_VAL="$(grep -E '^golangci-lint = "' "$MISE" | head -1 | cut -d'"' -f2)"
+# See the matching comment in check-tool-versions.sh: strip a possible "v" prefix so this
+# doesn't write "v$MISE_VAL" as "vv2.13.1" into every target.
+MISE_VAL="${MISE_VAL#v}"
 if [ -z "$MISE_VAL" ]; then
 	echo "Error: golangci-lint not found in $MISE [tools]"
 	exit 1

--- a/scripts/sync-tool-versions.sh
+++ b/scripts/sync-tool-versions.sh
@@ -23,8 +23,12 @@ if [ -z "$MISE_VAL" ]; then
 	exit 1
 fi
 
-sed -i -E "s/^GOLANGCI_LINT_VERSION := v[0-9.]+/GOLANGCI_LINT_VERSION := v$MISE_VAL/" Makefile
-sed -i -E "s/^([[:space:]]*GOLANGCI_LINT_VERSION: )'v[0-9.]+'/\\1'v$MISE_VAL'/" .github/workflows/ci.yml
+# Both patterns below match anything scripts/check-tool-versions.sh's own count/extraction
+# regexes accept (arbitrary spacing around ":=", arbitrary indentation and quote style in
+# ci.yml) — a narrower syncer than checker means a validly-formatted variant the checker
+# tolerates still leaves the syncer rewriting nothing, and its own self-verify below aborting.
+sed -i -E "s/^(GOLANGCI_LINT_VERSION[[:space:]]*:=[[:space:]]*)v[0-9.]+/\\1v$MISE_VAL/" Makefile
+sed -i -E "s/^([[:space:]]*GOLANGCI_LINT_VERSION:[[:space:]]*)[\"']?v[0-9.]+[\"']?([[:space:]]*)\$/\\1'v$MISE_VAL'\\2/" .github/workflows/ci.yml
 # shellcheck disable=SC2016 # literal markdown backticks, not unexpanded vars
 sed -i -E "s/^- Golangci-lint Version: \`v[0-9.]+\`\$/- Golangci-lint Version: \`v$MISE_VAL\`/" docs/github-workflows.md
 


### PR DESCRIPTION
## Why

- `GOVULNCHECK_VERSION` lives in `ci.yml`'s `env:` block, invisible to the `github-actions` manager (it only reads `uses:` refs). Add a `customManagers` regex keyed off a `# renovate:` marker comment, same convention used elsewhere in this org.
- `golangci-lint` is pinned by hand in three places besides `mise.toml` (`Makefile`, `ci.yml`, `docs/github-workflows.md`) — none of which the `mise` datasource bumps, so they drift silently.

## What

- `scripts/check-tool-versions.sh` — enforces parity between `mise.toml`'s `golangci-lint` pin and its three hand-maintained copies. Exactly-one-match validation, tolerant of any spacing/quote style. Wired into `make check`, `mise run verify`, and a new "Check tool version parity" CI step.
- `scripts/sync-tool-versions.sh` — the inverse: rewrites all three copies from `mise.toml`, self-verifies by re-running the checker.
- `renovate.json` — new `customManagers` entry for the govulncheck marker; extended (not replaced) the existing `gomod`/`mise` `postUpgradeTasks` rule to also run the new syncer and watch the three synced files.
- `.github/workflows/ci.yml` — `go:` paths-filter now also covers `mise.toml`, both new scripts, and `docs/github-workflows.md`, so a PR touching only one of them doesn't skip the lint job the new check runs in.
- `mise.toml` — `check-tool-versions`/`sync-tool-versions` task entries, `verify` now depends on `check-tool-versions`.

## Verify

- `mise run verify` — green (tidy, lint, test, check-tool-versions).
- Guard-tested: clean pass; single-pin mutation → checker fails, syncer repairs, re-run is a no-op (idempotent); duplicate-assignment in both non-canonical Makefile spacing and double-quoted ci.yml form → checker catches both.
- `shellcheck` clean on both new scripts.
