### PR TITLE
ci: only save Go build cache from the default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,12 @@ jobs:
         fi
 
     - name: Save Go build cache
-      if: success() && steps.gocache.outputs.cache-hit != 'true'
+      # Default-branch only: a PR's own gocache entry is dead the moment it merges (GitHub
+      # scopes a cache to the branch that wrote it and its descendants), so saving from
+      # feature branches only inflates the shared actions-cache bucket for no restore benefit.
+      # Restores still fall back to the main-branch entry via restore-keys above.
+      # See ginsys/opsmaster docs/arc-runners.md "Purge / retention" (2026-08-25 growth incident).
+      if: success() && steps.gocache.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main'
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: ~/.cache/go-build
@@ -318,7 +323,12 @@ jobs:
         go test -v -race -coverprofile=coverage/coverage.out -covermode=atomic -timeout 15m ./... 2>&1 | tee /tmp/gotest.log
 
     - name: Save Go build cache
-      if: success() && steps.gocache.outputs.cache-hit != 'true'
+      # Default-branch only: a PR's own gocache entry is dead the moment it merges (GitHub
+      # scopes a cache to the branch that wrote it and its descendants), so saving from
+      # feature branches only inflates the shared actions-cache bucket for no restore benefit.
+      # Restores still fall back to the main-branch entry via restore-keys above.
+      # See ginsys/opsmaster docs/arc-runners.md "Purge / retention" (2026-08-25 growth incident).
+      if: success() && steps.gocache.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main'
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: ~/.cache/go-build
@@ -468,7 +478,12 @@ jobs:
         allowlist: 'GO-2026-5377'
 
     - name: Save Go build cache
-      if: success() && steps.gocache.outputs.cache-hit != 'true'
+      # Default-branch only: a PR's own gocache entry is dead the moment it merges (GitHub
+      # scopes a cache to the branch that wrote it and its descendants), so saving from
+      # feature branches only inflates the shared actions-cache bucket for no restore benefit.
+      # Restores still fall back to the main-branch entry via restore-keys above.
+      # See ginsys/opsmaster docs/arc-runners.md "Purge / retention" (2026-08-25 growth incident).
+      if: success() && steps.gocache.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main'
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: ~/.cache/go-build


### PR DESCRIPTION
## What
Gates the three `actions/cache/save` steps in `ci.yml` (validate/build, test-race-cover, security)
to `github.ref == 'refs/heads/main'`.

## Why
Every commit on every branch was saving a new, uniquely-keyed Go build cache (source-hash key,
3 jobs, no ref gating). GitHub scopes a cache to the branch that wrote it and its descendants, so
a feature-branch/PR save is dead the instant it merges — pure waste that never gets restored.
Restores are unaffected: they fall back to the main-branch entry via the existing `restore-keys:`.

This was the primary driver of a shared-infrastructure incident: the self-hosted ARC runner
actions-cache bucket (`ginsys/opsmaster`, Garage S3) grew 134.9 GB → 250.3 GB in 8 days and
tripped disk-space alerts on all 3 storage nodes. Storage-side purge tuning (size ceiling, shorter
age retention) landed separately in that repo; this PR addresses the input side.

Draft while CI runs.