### PR TITLE
fix(ci): syntax-check the two new sync scripts; reject duplicate mise pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,10 +196,17 @@ jobs:
     # `sync-versions.sh check`/`make check-tool-versions`/`make check-govulncheck-docs` ever
     # invokes or parses — a syntax error here would only surface the next time Renovate runs
     # it. Cheap floor: catch a broken script before it merges, not full shellcheck (a
-    # repo-wide tooling decision, out of scope for these scripts).
+    # repo-wide tooling decision, out of scope for these scripts). Dispatched per each
+    # script's own shebang/renovate.json invocation, not uniformly via bash -n: renovate.json
+    # runs sync-tool-versions.sh and sync-govulncheck-docs.sh with `sh` (not bash), and bash
+    # accepts bashisms POSIX sh would reject, so a bash -n pass on a #!/bin/sh script doesn't
+    # prove sh can actually parse it.
     - name: Syntax-check version-sync scripts
       run: |
-        for f in scripts/sync-eso-pin.sh scripts/sync-versions.sh scripts/sync-tool-versions.sh scripts/sync-govulncheck-docs.sh; do
+        for f in scripts/sync-tool-versions.sh scripts/sync-govulncheck-docs.sh; do
+          sh -n "$f"
+        done
+        for f in scripts/sync-eso-pin.sh scripts/sync-versions.sh; do
           bash -n "$f"
         done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,14 +191,15 @@ jobs:
     - name: Validate version consistency
       run: ./scripts/sync-versions.sh check
 
-    # sync-eso-pin.sh has no other CI coverage: it's a Renovate postUpgradeTasks command,
-    # not something `sync-versions.sh check`/`make lint` (Go-only) ever invokes or parses —
-    # a syntax error here would only surface the next time Renovate runs it. Cheap floor:
-    # catch a broken script before it merges, not full shellcheck (a repo-wide tooling
-    # decision, out of scope for this one script).
+    # sync-eso-pin.sh, sync-tool-versions.sh and sync-govulncheck-docs.sh have no other CI
+    # coverage: they're Renovate postUpgradeTasks commands, not something
+    # `sync-versions.sh check`/`make check-tool-versions`/`make check-govulncheck-docs` ever
+    # invokes or parses — a syntax error here would only surface the next time Renovate runs
+    # it. Cheap floor: catch a broken script before it merges, not full shellcheck (a
+    # repo-wide tooling decision, out of scope for these scripts).
     - name: Syntax-check version-sync scripts
       run: |
-        for f in scripts/sync-eso-pin.sh scripts/sync-versions.sh; do
+        for f in scripts/sync-eso-pin.sh scripts/sync-versions.sh scripts/sync-tool-versions.sh scripts/sync-govulncheck-docs.sh; do
           bash -n "$f"
         done
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -85,7 +85,7 @@ temporary branch — the merged result — before the PR is allowed to land.
 
 | Job | Check Name | Timeout | Dependencies | Purpose |
 |-----|------------|---------|--------------|---------|
-| `validate` | `lint` | 15 min | changes | Go fmt, tidy, vet, lint, tool-version parity (golangci-lint pin across Makefile/ci.yml/docs), govulncheck doc parity; `sync-versions.sh check`; `bash -n` syntax-check on the version-sync scripts; caches goimports + yq binaries |
+| `validate` | `lint` | 15 min | changes | Go fmt, tidy, vet, lint, tool-version parity (golangci-lint pin across Makefile/ci.yml/docs), govulncheck doc parity; `sync-versions.sh check`; syntax-check on the version-sync scripts, `sh -n` or `bash -n` per each script's own shebang; caches goimports + yq binaries |
 | `action-pins` | `action-pins` | 2 min | — | Fails if any third-party `uses:` ref is not pinned to a 40-char commit SHA (`go-kure/.github` canonical checker) |
 | `forbidden-terms` | `forbidden-terms` | 2 min | — | Runs the canonical full-tree downstream-reference guard on every workflow event and verifies the vendored release guard |
 | `test` | `test` | 20 min | changes | Unit tests with race detection and coverage; `-race` compilation takes ~5 min on the in-cluster runner, so 20 min allows compilation + 15 min for test execution |

--- a/scripts/check-tool-versions.sh
+++ b/scripts/check-tool-versions.sh
@@ -20,15 +20,18 @@ cd "$ROOT"
 MISE="mise.toml"
 # Exactly one match required, same discipline as the Makefile/ci.yml checks below, and
 # tolerant of ANY spacing around "=" (TOML permits "golangci-lint=", "golangci-lint =", etc.)
-# for the same reason those checks are: a duplicate key in a spacing this pattern couldn't see
-# would be invisible to the count while still being invalid TOML mise can't parse at all.
-MISE_PATTERN='^golangci-lint[[:space:]]*=[[:space:]]*"'
+# and either TOML quote style ("..." or '...', both valid literal/basic strings) -- a duplicate
+# key in a spacing or quoting this pattern couldn't see would be invisible to the count while
+# still being invalid TOML mise can't parse at all.
+MISE_PATTERN='^golangci-lint[[:space:]]*=[[:space:]]*["'\'']'
 mise_count="$(grep -cE "$MISE_PATTERN" "$MISE" || true)"
 if [ "$mise_count" -ne 1 ]; then
 	echo "✗ $MISE: expected exactly 1 golangci-lint [tools] entry, found $mise_count"
 	exit 1
 fi
-MISE_VAL="$(grep -E "$MISE_PATTERN" "$MISE" | cut -d'"' -f2)"
+# Strip the leading key/quote, then everything from the closing quote (whichever style opened
+# it) onward -- cut -d'"' can't do this once the quote character itself varies.
+MISE_VAL="$(grep -E "$MISE_PATTERN" "$MISE" | sed -E "s/^golangci-lint[[:space:]]*=[[:space:]]*[\"']//; s/[\"'].*//")"
 # mise tolerates a "v"-prefixed pin (golangci-lint's own release tags carry one); strip it so a
 # future Renovate bump that writes "vX.Y.Z" here can't double-prefix every target's "v$MISE_VAL".
 MISE_VAL="${MISE_VAL#v}"

--- a/scripts/check-tool-versions.sh
+++ b/scripts/check-tool-versions.sh
@@ -18,20 +18,24 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
 MISE="mise.toml"
+# Restrict to the [tools] table -- mise.toml can define other tables ([env], [tasks], ...) whose
+# keys aren't tool pins at all; a file-wide grep would count a same-named key in another table as
+# a spurious duplicate, or extract that table's value instead of the real pin.
+MISE_TOOLS="$(awk '/^\[tools\]/{f=1;next} /^\[/{f=0} f' "$MISE")"
 # Exactly one match required, same discipline as the Makefile/ci.yml checks below, and
 # tolerant of ANY spacing around "=" (TOML permits "golangci-lint=", "golangci-lint =", etc.)
 # and either TOML quote style ("..." or '...', both valid literal/basic strings) -- a duplicate
 # key in a spacing or quoting this pattern couldn't see would be invisible to the count while
 # still being invalid TOML mise can't parse at all.
 MISE_PATTERN='^golangci-lint[[:space:]]*=[[:space:]]*["'\'']'
-mise_count="$(grep -cE "$MISE_PATTERN" "$MISE" || true)"
+mise_count="$(printf '%s\n' "$MISE_TOOLS" | grep -cE "$MISE_PATTERN" || true)"
 if [ "$mise_count" -ne 1 ]; then
 	echo "✗ $MISE: expected exactly 1 golangci-lint [tools] entry, found $mise_count"
 	exit 1
 fi
 # Strip the leading key/quote, then everything from the closing quote (whichever style opened
 # it) onward -- cut -d'"' can't do this once the quote character itself varies.
-MISE_VAL="$(grep -E "$MISE_PATTERN" "$MISE" | sed -E "s/^golangci-lint[[:space:]]*=[[:space:]]*[\"']//; s/[\"'].*//")"
+MISE_VAL="$(printf '%s\n' "$MISE_TOOLS" | grep -E "$MISE_PATTERN" | sed -E "s/^golangci-lint[[:space:]]*=[[:space:]]*[\"']//; s/[\"'].*//")"
 # mise tolerates a "v"-prefixed pin (golangci-lint's own release tags carry one); strip it so a
 # future Renovate bump that writes "vX.Y.Z" here can't double-prefix every target's "v$MISE_VAL".
 MISE_VAL="${MISE_VAL#v}"

--- a/scripts/check-tool-versions.sh
+++ b/scripts/check-tool-versions.sh
@@ -18,7 +18,15 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
 MISE="mise.toml"
-MISE_VAL="$(grep -E '^golangci-lint = "' "$MISE" | head -1 | cut -d'"' -f2)"
+# Exactly one match required, same discipline as the Makefile/ci.yml checks below — a
+# duplicate `golangci-lint = "..."` key is invalid TOML (mise cannot parse it at all), but
+# `head -1` would silently accept the first one and report parity anyway.
+mise_count="$(grep -cE '^golangci-lint = "' "$MISE" || true)"
+if [ "$mise_count" -ne 1 ]; then
+	echo "✗ $MISE: expected exactly 1 golangci-lint [tools] entry, found $mise_count"
+	exit 1
+fi
+MISE_VAL="$(grep -E '^golangci-lint = "' "$MISE" | cut -d'"' -f2)"
 # mise tolerates a "v"-prefixed pin (golangci-lint's own release tags carry one); strip it so a
 # future Renovate bump that writes "vX.Y.Z" here can't double-prefix every target's "v$MISE_VAL".
 MISE_VAL="${MISE_VAL#v}"

--- a/scripts/check-tool-versions.sh
+++ b/scripts/check-tool-versions.sh
@@ -18,15 +18,17 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
 MISE="mise.toml"
-# Exactly one match required, same discipline as the Makefile/ci.yml checks below — a
-# duplicate `golangci-lint = "..."` key is invalid TOML (mise cannot parse it at all), but
-# `head -1` would silently accept the first one and report parity anyway.
-mise_count="$(grep -cE '^golangci-lint = "' "$MISE" || true)"
+# Exactly one match required, same discipline as the Makefile/ci.yml checks below, and
+# tolerant of ANY spacing around "=" (TOML permits "golangci-lint=", "golangci-lint =", etc.)
+# for the same reason those checks are: a duplicate key in a spacing this pattern couldn't see
+# would be invisible to the count while still being invalid TOML mise can't parse at all.
+MISE_PATTERN='^golangci-lint[[:space:]]*=[[:space:]]*"'
+mise_count="$(grep -cE "$MISE_PATTERN" "$MISE" || true)"
 if [ "$mise_count" -ne 1 ]; then
 	echo "✗ $MISE: expected exactly 1 golangci-lint [tools] entry, found $mise_count"
 	exit 1
 fi
-MISE_VAL="$(grep -E '^golangci-lint = "' "$MISE" | cut -d'"' -f2)"
+MISE_VAL="$(grep -E "$MISE_PATTERN" "$MISE" | cut -d'"' -f2)"
 # mise tolerates a "v"-prefixed pin (golangci-lint's own release tags carry one); strip it so a
 # future Renovate bump that writes "vX.Y.Z" here can't double-prefix every target's "v$MISE_VAL".
 MISE_VAL="${MISE_VAL#v}"

--- a/scripts/sync-tool-versions.sh
+++ b/scripts/sync-tool-versions.sh
@@ -14,7 +14,11 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
 MISE="mise.toml"
-MISE_VAL="$(grep -E '^golangci-lint = "' "$MISE" | head -1 | cut -d'"' -f2)"
+# Same pattern check-tool-versions.sh's MISE_PATTERN accepts (any "=" spacing, either TOML
+# quote style) -- a narrower extraction here than the checker's count/match means a validly
+# formatted variant the checker accepts still leaves this script finding nothing to sync.
+MISE_PATTERN='^golangci-lint[[:space:]]*=[[:space:]]*["'\'']'
+MISE_VAL="$(grep -E "$MISE_PATTERN" "$MISE" | head -1 | sed -E "s/^golangci-lint[[:space:]]*=[[:space:]]*[\"']//; s/[\"'].*//")"
 # See the matching comment in check-tool-versions.sh: strip a possible "v" prefix so this
 # doesn't write "v$MISE_VAL" as "vv2.13.1" into every target.
 MISE_VAL="${MISE_VAL#v}"

--- a/scripts/sync-tool-versions.sh
+++ b/scripts/sync-tool-versions.sh
@@ -14,11 +14,21 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
 MISE="mise.toml"
+# Restrict to the [tools] table (see the matching comment in check-tool-versions.sh) and, same
+# discipline as the checker, require exactly one match -- head -1 previously let a duplicate pin
+# resolve silently to whichever occurrence sorted first, then propagate that guess into every
+# target file instead of refusing to sync an invalid mise.toml.
+MISE_TOOLS="$(awk '/^\[tools\]/{f=1;next} /^\[/{f=0} f' "$MISE")"
 # Same pattern check-tool-versions.sh's MISE_PATTERN accepts (any "=" spacing, either TOML
 # quote style) -- a narrower extraction here than the checker's count/match means a validly
 # formatted variant the checker accepts still leaves this script finding nothing to sync.
 MISE_PATTERN='^golangci-lint[[:space:]]*=[[:space:]]*["'\'']'
-MISE_VAL="$(grep -E "$MISE_PATTERN" "$MISE" | head -1 | sed -E "s/^golangci-lint[[:space:]]*=[[:space:]]*[\"']//; s/[\"'].*//")"
+mise_count="$(printf '%s\n' "$MISE_TOOLS" | grep -cE "$MISE_PATTERN" || true)"
+if [ "$mise_count" -ne 1 ]; then
+	echo "Error: expected exactly 1 golangci-lint [tools] entry in $MISE, found $mise_count"
+	exit 1
+fi
+MISE_VAL="$(printf '%s\n' "$MISE_TOOLS" | grep -E "$MISE_PATTERN" | sed -E "s/^golangci-lint[[:space:]]*=[[:space:]]*[\"']//; s/[\"'].*//")"
 # See the matching comment in check-tool-versions.sh: strip a possible "v" prefix so this
 # doesn't write "v$MISE_VAL" as "vv2.13.1" into every target.
 MISE_VAL="${MISE_VAL#v}"


### PR DESCRIPTION
Follow-up to #695, which merged before these two codex-review findings on the new OID could land.

- Syntax-check loop only covered `sync-eso-pin.sh`/`sync-versions.sh`; add `sync-tool-versions.sh` and `sync-govulncheck-docs.sh`, which have the same "no other CI coverage, Renovate postUpgradeTasks only" property.
- `check-tool-versions.sh`'s `MISE_VAL` extraction used `head -1`, silently accepting the first of a duplicate `golangci-lint` key (invalid TOML mise can't parse at all) and reporting parity anyway. Require exactly one match, same discipline the Makefile/ci.yml checks already apply.