### PR TITLE
fix(ci): tolerate whitespace around the [tools] table header

### DIFF
--- a/scripts/check-tool-versions.sh
+++ b/scripts/check-tool-versions.sh
@@ -20,8 +20,11 @@ cd "$ROOT"
 MISE="mise.toml"
 # Restrict to the [tools] table -- mise.toml can define other tables ([env], [tasks], ...) whose
 # keys aren't tool pins at all; a file-wide grep would count a same-named key in another table as
-# a spurious duplicate, or extract that table's value instead of the real pin.
-MISE_TOOLS="$(awk '/^[[:space:]]*\[[[:space:]]*tools[[:space:]]*\]/{f=1;next} /^[[:space:]]*\[/{f=0} f' "$MISE")"
+# a spurious duplicate, or extract that table's value instead of the real pin. Tolerant of
+# whitespace around the header ("[ tools ]", "[tools ]", ...) and of TOML's quoted-key table
+# header form ("[\"tools\"]", "['tools']") -- both are valid TOML, and a header this pattern
+# couldn't see would silently fall through to "table not found" (mise_count=0).
+MISE_TOOLS="$(awk '/^[[:space:]]*\[[[:space:]]*["'\'']?tools["'\'']?[[:space:]]*\]/{f=1;next} /^[[:space:]]*\[/{f=0} f' "$MISE")"
 # Exactly one match required, same discipline as the Makefile/ci.yml checks below, and
 # tolerant of ANY spacing around "=" (TOML permits "golangci-lint=", "golangci-lint =", etc.)
 # and either TOML quote style ("..." or '...', both valid literal/basic strings) -- a duplicate

--- a/scripts/check-tool-versions.sh
+++ b/scripts/check-tool-versions.sh
@@ -21,7 +21,7 @@ MISE="mise.toml"
 # Restrict to the [tools] table -- mise.toml can define other tables ([env], [tasks], ...) whose
 # keys aren't tool pins at all; a file-wide grep would count a same-named key in another table as
 # a spurious duplicate, or extract that table's value instead of the real pin.
-MISE_TOOLS="$(awk '/^\[tools\]/{f=1;next} /^\[/{f=0} f' "$MISE")"
+MISE_TOOLS="$(awk '/^[[:space:]]*\[[[:space:]]*tools[[:space:]]*\]/{f=1;next} /^[[:space:]]*\[/{f=0} f' "$MISE")"
 # Exactly one match required, same discipline as the Makefile/ci.yml checks below, and
 # tolerant of ANY spacing around "=" (TOML permits "golangci-lint=", "golangci-lint =", etc.)
 # and either TOML quote style ("..." or '...', both valid literal/basic strings) -- a duplicate

--- a/scripts/sync-tool-versions.sh
+++ b/scripts/sync-tool-versions.sh
@@ -14,11 +14,12 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
 MISE="mise.toml"
-# Restrict to the [tools] table (see the matching comment in check-tool-versions.sh) and, same
-# discipline as the checker, require exactly one match -- head -1 previously let a duplicate pin
-# resolve silently to whichever occurrence sorted first, then propagate that guess into every
-# target file instead of refusing to sync an invalid mise.toml.
-MISE_TOOLS="$(awk '/^[[:space:]]*\[[[:space:]]*tools[[:space:]]*\]/{f=1;next} /^[[:space:]]*\[/{f=0} f' "$MISE")"
+# Restrict to the [tools] table (see the matching comment in check-tool-versions.sh, including
+# its whitespace- and quoted-key-tolerant header match) and, same discipline as the checker,
+# require exactly one match -- head -1 previously let a duplicate pin resolve silently to
+# whichever occurrence sorted first, then propagate that guess into every target file instead of
+# refusing to sync an invalid mise.toml.
+MISE_TOOLS="$(awk '/^[[:space:]]*\[[[:space:]]*["'\'']?tools["'\'']?[[:space:]]*\]/{f=1;next} /^[[:space:]]*\[/{f=0} f' "$MISE")"
 # Same pattern check-tool-versions.sh's MISE_PATTERN accepts (any "=" spacing, either TOML
 # quote style) -- a narrower extraction here than the checker's count/match means a validly
 # formatted variant the checker accepts still leaves this script finding nothing to sync.

--- a/scripts/sync-tool-versions.sh
+++ b/scripts/sync-tool-versions.sh
@@ -18,7 +18,7 @@ MISE="mise.toml"
 # discipline as the checker, require exactly one match -- head -1 previously let a duplicate pin
 # resolve silently to whichever occurrence sorted first, then propagate that guess into every
 # target file instead of refusing to sync an invalid mise.toml.
-MISE_TOOLS="$(awk '/^\[tools\]/{f=1;next} /^\[/{f=0} f' "$MISE")"
+MISE_TOOLS="$(awk '/^[[:space:]]*\[[[:space:]]*tools[[:space:]]*\]/{f=1;next} /^[[:space:]]*\[/{f=0} f' "$MISE")"
 # Same pattern check-tool-versions.sh's MISE_PATTERN accepts (any "=" spacing, either TOML
 # quote style) -- a narrower extraction here than the checker's count/match means a validly
 # formatted variant the checker accepts still leaves this script finding nothing to sync.


### PR DESCRIPTION
TOML permits whitespace around a table header (` [tools]`, `[ tools ]`). The awk pre-filter that scopes mise.toml matching to `[tools]` (added in #701) required the exact literal `[tools]`, so a validly-formatted header with any whitespace made both check-tool-versions.sh and sync-tool-versions.sh see zero table entries — the checker would report the pin missing and block on a valid mise.toml, and the syncer's repair command would fail the same way.

Found by codex review on #701 after that PR had already merged; folded in here as a follow-up.