### PR TITLE
feat: add LayoutIntentAugmenter companion interface for layout placement intent

### DIFF
--- a/pkg/stack/layout/README.md
+++ b/pkg/stack/layout/README.md
@@ -124,7 +124,28 @@ type LayoutAugmenter interface {
 }
 ```
 
-When `app.Config` implements it, the walker invokes `AugmentLayout` on the per-app `ManifestLayout` after resource generation, giving the config a chance to attach `ExtraFiles`, `ConfigMapGenerators`, and sub-`ManifestLayout` children. Only invoked on per-app layouts produced by the non-flat (`GroupByName`) walker paths; `GroupFlat` and umbrella layouts merge resources into shared parent layouts and are not currently augmented.
+When `app.Config` implements it, the walker invokes `AugmentLayout` on the per-app `ManifestLayout` after resource generation, giving the config a chance to attach `ExtraFiles`, `ConfigMapGenerators`, and sub-`ManifestLayout` children. It runs on per-app layouts on every walker path that creates one, including the flat-bundle (`GroupFlat`) path and umbrella children — an augmenter app there gets its own per-app sub-layout instead of merging flat into the parent.
+
+`LayoutIntentAugmenter` is an optional companion to `LayoutAugmenter`, for a config whose desire for its own layout varies per instance rather than being fixed for the whole type:
+
+```go
+type LayoutIntentAugmenter interface {
+    LayoutAugmenter
+    WantsOwnLayout() bool
+}
+```
+
+`WantsOwnLayout()` gates placement only, and only on the flat-bundle walker path:
+
+| Walker path | `WantsOwnLayout()` absent, `true`, or `false` |
+|---|---|
+| `GroupByName` and by-package | own layout + `AugmentLayout`, unconditionally — identical to today's behaviour in every case |
+
+| Flat bundle (`GroupFlat`, incl. umbrella children) | `WantsOwnLayout()` absent or `true` | `WantsOwnLayout() == false` |
+|---|---|---|
+| | own child layout + `AugmentLayout` | resources merged flat into parent, `AugmentLayout` **not** called (no layout exists to pass it) |
+
+A config that implements only `LayoutAugmenter` keeps today's presence-only behaviour unchanged.
 
 #### Sub-Layout Children and Flux Integration
 

--- a/pkg/stack/layout/augmenter.go
+++ b/pkg/stack/layout/augmenter.go
@@ -24,6 +24,34 @@ type LayoutAugmenter interface {
 	AugmentLayout(layout *ManifestLayout) error
 }
 
+// LayoutIntentAugmenter is an optional companion to LayoutAugmenter for a
+// config whose desire for its own per-app layout varies per instance rather
+// than being fixed for the whole type. Implementing LayoutAugmenter alone is
+// a per-type, presence-only signal: the method either exists or it doesn't,
+// so a config that only wants its own layout for some instance
+// configurations has no way to express that without a separate wrapper type
+// per case. LayoutIntentAugmenter lets such a config implement AugmentLayout
+// unconditionally and answer "do I want the walker to carve me a directory"
+// per instance instead.
+//
+// WantsOwnLayout() gates placement only, on the flat-bundle walker path
+// (processFlatBundleApps): false is treated as-if-absent for that decision —
+// the app's resources merge flat into the parent layout instead of getting a
+// per-app child, and AugmentLayout is not invoked because no per-app layout
+// exists to pass it. It has no effect on the GroupByName or by-package
+// walker paths, where an app already gets its own layout and AugmentLayout
+// already runs unconditionally, regardless of augmenter status.
+//
+// A config that does not implement this interface keeps LayoutAugmenter's
+// existing presence-only behaviour unchanged.
+//
+// The interface lives in the layout package for the same import-cycle
+// reason as LayoutAugmenter above.
+type LayoutIntentAugmenter interface {
+	LayoutAugmenter
+	WantsOwnLayout() bool
+}
+
 // renderConfigMapGeneratorBlock renders the kustomization.yaml
 // configMapGenerator: section for the given specs. Returns the empty string
 // when no specs are present, so callers can append unconditionally.

--- a/pkg/stack/layout/augmenter_test.go
+++ b/pkg/stack/layout/augmenter_test.go
@@ -26,6 +26,50 @@ func TestIsAugmenter_NilConfig(t *testing.T) {
 	}
 }
 
+// intentAugmentingConfig implements stack.ApplicationConfig, LayoutAugmenter
+// and LayoutIntentAugmenter, with a settable WantsOwnLayout() result.
+type intentAugmentingConfig struct {
+	objs      []*client.Object
+	wantsOwn  bool
+	augmented bool
+}
+
+func (f *intentAugmentingConfig) Generate(*stack.Application) ([]*client.Object, error) {
+	return f.objs, nil
+}
+
+func (f *intentAugmentingConfig) AugmentLayout(ml *ManifestLayout) error {
+	f.augmented = true
+	return nil
+}
+
+func (f *intentAugmentingConfig) WantsOwnLayout() bool {
+	return f.wantsOwn
+}
+
+func TestIsAugmenter_IntentFalse(t *testing.T) {
+	app := stack.NewApplication("app", "ns", &intentAugmentingConfig{wantsOwn: false})
+	if isAugmenter(app) {
+		t.Error("isAugmenter should return false when WantsOwnLayout() is false")
+	}
+}
+
+func TestIsAugmenter_IntentTrue(t *testing.T) {
+	app := stack.NewApplication("app", "ns", &intentAugmentingConfig{wantsOwn: true})
+	if !isAugmenter(app) {
+		t.Error("isAugmenter should return true when WantsOwnLayout() is true")
+	}
+}
+
+func TestWantsOwnLayout_AbsentCompanion(t *testing.T) {
+	// flattenFakeConfig implements only stack.ApplicationConfig, not
+	// LayoutIntentAugmenter — absent companion must default to true.
+	cfg := &flattenFakeConfig{}
+	if !wantsOwnLayout(cfg) {
+		t.Error("wantsOwnLayout should default to true for a config without LayoutIntentAugmenter")
+	}
+}
+
 func TestProcessFlatBundleApps_NilObjectPointer(t *testing.T) {
 	// App returns a slice containing a nil *client.Object pointer — should be skipped.
 	nilObjPtr := (*client.Object)(nil)

--- a/pkg/stack/layout/walker.go
+++ b/pkg/stack/layout/walker.go
@@ -451,18 +451,29 @@ func augmentAppLayout(app *stack.Application, ml *ManifestLayout) error {
 	return nil
 }
 
-// isAugmenter reports whether app.Config implements LayoutAugmenter.
+// wantsOwnLayout reports whether an augmenting config wants its own layout.
+// Absent companion interface ⇒ true (today's presence-only behaviour).
+func wantsOwnLayout(cfg stack.ApplicationConfig) bool {
+	if intent, ok := cfg.(LayoutIntentAugmenter); ok {
+		return intent.WantsOwnLayout()
+	}
+	return true
+}
+
+// isAugmenter reports whether app.Config implements LayoutAugmenter and
+// wants its own layout.
 func isAugmenter(app *stack.Application) bool {
 	if app == nil || app.Config == nil {
 		return false
 	}
 	_, ok := app.Config.(LayoutAugmenter)
-	return ok
+	return ok && wantsOwnLayout(app.Config)
 }
 
 // processFlatBundleApps places each application from a flat bundle into either
-// a per-app sub-layout (when its Config implements LayoutAugmenter) or into
-// the parent layout's flat Resources (otherwise). The per-app sub-layout path
+// a per-app sub-layout (when its Config implements LayoutAugmenter and wants
+// its own layout) or into the parent layout's flat Resources (otherwise). The
+// per-app sub-layout path
 // lets augmenters (e.g. values.yaml + configMapGenerator emitters) mutate
 // their own ManifestLayout without colliding with sibling apps that share the
 // same bundle.

--- a/pkg/stack/layout/walker_test.go
+++ b/pkg/stack/layout/walker_test.go
@@ -65,6 +65,29 @@ func (f *fakeAugmentingConfig) AugmentLayout(ml *layout.ManifestLayout) error {
 	return nil
 }
 
+// fakeIntentAugmentingConfig implements stack.ApplicationConfig,
+// layout.LayoutAugmenter and layout.LayoutIntentAugmenter, with a settable
+// WantsOwnLayout() result. It records the layout it was called with, same as
+// fakeAugmentingConfig.
+type fakeIntentAugmentingConfig struct {
+	objs     []*client.Object
+	wantsOwn bool
+	called   *layout.ManifestLayout
+}
+
+func (f *fakeIntentAugmentingConfig) Generate(*stack.Application) ([]*client.Object, error) {
+	return f.objs, nil
+}
+
+func (f *fakeIntentAugmentingConfig) AugmentLayout(ml *layout.ManifestLayout) error {
+	f.called = ml
+	return nil
+}
+
+func (f *fakeIntentAugmentingConfig) WantsOwnLayout() bool {
+	return f.wantsOwn
+}
+
 // TestWalkCluster_DefaultFill verifies that WalkCluster fills in default values
 // for GroupUnset/FilePerUnset/FluxUnset when an empty LayoutRules is passed,
 // exercising the default-fill branches in WalkCluster.
@@ -1068,6 +1091,103 @@ func TestWalkCluster_NodeOnly_MixedBundle(t *testing.T) {
 	}
 	if nodeML.Resources[0].GetName() != "b" {
 		t.Errorf("flat resource = %q, want %q", nodeML.Resources[0].GetName(), "b")
+	}
+}
+
+// TestWalkCluster_NodeOnly_IntentFalse verifies that a flat-bundle app whose
+// config implements LayoutIntentAugmenter with WantsOwnLayout() == false is
+// treated as-if-absent for placement: its resources land flat in the parent
+// layout's Resources, no per-app sub-layout is created, and AugmentLayout is
+// never called (no layout exists to pass it).
+func TestWalkCluster_NodeOnly_IntentFalse(t *testing.T) {
+	cfg := &fakeIntentAugmentingConfig{objs: []*client.Object{makeCM("a")}, wantsOwn: false}
+	app := stack.NewApplication("a", "ns", cfg)
+	bundle := &stack.Bundle{Name: "bundle", Applications: []*stack.Application{app}}
+	node := &stack.Node{Name: "apps", Bundle: bundle}
+	root := &stack.Node{Name: "root", Children: []*stack.Node{node}}
+	node.SetParent(root)
+	cluster := &stack.Cluster{Name: "demo", Node: root}
+
+	ml, err := layout.WalkCluster(cluster, layout.DefaultLayoutRules())
+	if err != nil {
+		t.Fatalf("walk cluster: %v", err)
+	}
+	nodeML := ml.Children[0]
+	if len(nodeML.Children) != 0 {
+		t.Fatalf("expected no per-app sub-layout when WantsOwnLayout() is false, got %d", len(nodeML.Children))
+	}
+	if len(nodeML.Resources) != 1 || nodeML.Resources[0].GetName() != "a" {
+		t.Fatalf("expected app's resource flat in nodeML.Resources, got %+v", nodeML.Resources)
+	}
+	if cfg.called != nil {
+		t.Errorf("AugmentLayout should not be called when WantsOwnLayout() is false, got called with %+v", cfg.called)
+	}
+}
+
+// TestWalkCluster_NodeOnly_IntentTrue verifies that a flat-bundle app whose
+// config implements LayoutIntentAugmenter with WantsOwnLayout() == true
+// behaves exactly like a plain LayoutAugmenter: own per-app sub-layout,
+// AugmentLayout called with it. Parity with
+// TestWalkCluster_NodeOnly_SingleAugmenter.
+func TestWalkCluster_NodeOnly_IntentTrue(t *testing.T) {
+	cfg := &fakeIntentAugmentingConfig{objs: []*client.Object{makeCM("a")}, wantsOwn: true}
+	app := stack.NewApplication("a", "ns", cfg)
+	bundle := &stack.Bundle{Name: "bundle", Applications: []*stack.Application{app}}
+	node := &stack.Node{Name: "apps", Bundle: bundle}
+	root := &stack.Node{Name: "root", Children: []*stack.Node{node}}
+	node.SetParent(root)
+	cluster := &stack.Cluster{Name: "demo", Node: root}
+
+	ml, err := layout.WalkCluster(cluster, layout.DefaultLayoutRules())
+	if err != nil {
+		t.Fatalf("walk cluster: %v", err)
+	}
+	nodeML := ml.Children[0]
+	if len(nodeML.Children) != 1 {
+		t.Fatalf("expected one per-app sub-layout, got %d", len(nodeML.Children))
+	}
+	appLayout := nodeML.Children[0]
+	if appLayout.Name != "a" {
+		t.Errorf("appLayout.Name = %q, want %q", appLayout.Name, "a")
+	}
+	if cfg.called != appLayout {
+		t.Errorf("AugmentLayout was not called with the per-app layout")
+	}
+}
+
+// TestWalkCluster_GroupByName_Augmenter_IntentFalse verifies that WantsOwnLayout() ==
+// false has NO effect on the GroupByName walker path: the app already gets
+// its own layout there regardless of augmenter status, and AugmentLayout
+// still runs against it — cfg.called must be non-nil. This is the regression
+// guard for the footgun the design section rejects: gating augmentAppLayout
+// itself by intent would silently drop ExtraFiles/ConfigMapGenerators on
+// this path even though a layout exists and is willing to receive them.
+// Modeled on TestWalkCluster_LayoutAugmenter.
+func TestWalkCluster_GroupByName_Augmenter_IntentFalse(t *testing.T) {
+	cfg := &fakeIntentAugmentingConfig{objs: []*client.Object{makeCM("a")}, wantsOwn: false}
+	app := stack.NewApplication("app", "ns", cfg)
+	bundle := &stack.Bundle{Name: "bundle", Applications: []*stack.Application{app}}
+	root := &stack.Node{Name: "root", Bundle: bundle}
+	cluster := &stack.Cluster{Name: "demo", Node: root}
+
+	ml, err := layout.WalkCluster(cluster, layout.LayoutRules{
+		BundleGrouping:      layout.GroupByName,
+		ApplicationGrouping: layout.GroupByName,
+	})
+	if err != nil {
+		t.Fatalf("walk cluster: %v", err)
+	}
+
+	bundleLayout := ml.Children[0]
+	if len(bundleLayout.Children) != 1 {
+		t.Fatalf("expected one app layout, got %d", len(bundleLayout.Children))
+	}
+	appLayout := bundleLayout.Children[0]
+	if cfg.called == nil {
+		t.Errorf("AugmentLayout must still be called on the GroupByName path when WantsOwnLayout() is false")
+	}
+	if cfg.called != appLayout {
+		t.Errorf("AugmentLayout was not called with the per-app layout")
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #696.

Adds `LayoutIntentAugmenter`, an optional companion interface to `layout.LayoutAugmenter`, so an
`ApplicationConfig` can implement `AugmentLayout` unconditionally while declaring per-instance
placement intent (`WantsOwnLayout() bool`) instead of relying on `LayoutAugmenter`'s presence
alone to decide sub-layout placement.

```go
type LayoutIntentAugmenter interface {
    LayoutAugmenter
    WantsOwnLayout() bool
}
```

**Semantics — placement only, "as-if-absent" when false:**

- `WantsOwnLayout()` absent or `true`: identical to today's behaviour on every walker path.
- `WantsOwnLayout() == false`: on the flat-bundle path (`processFlatBundleApps`), the config's
  resources merge flat into the parent layout instead of getting a dedicated child layout, and
  `AugmentLayout` is not called (no layout exists to pass it).
- `GroupByName`/by-package paths are **unaffected in every case** — an app already gets its own
  layout there regardless of augmenter status, so `augmentAppLayout` itself is left unmodified.
  Gating it too would silently drop `ExtraFiles`/`ConfigMapGenerators` for a config that wants
  flat-bundle placement on every other grouping mode — a data-loss footgun this design rejects
  (caught during plan review, see the plan doc linked below).

Backward compatible: a config that doesn't implement the companion interface keeps today's
presence-only behaviour exactly.

## Changes

- `pkg/stack/layout/augmenter.go` — new `LayoutIntentAugmenter` interface.
- `pkg/stack/layout/walker.go` — new `wantsOwnLayout` helper; `isAugmenter` now
  `ok && wantsOwnLayout(app.Config)`; doc comments on `isAugmenter`/`processFlatBundleApps`
  reworded to match. `augmentAppLayout` is untouched.
- `pkg/stack/layout/augmenter_test.go`, `pkg/stack/layout/walker_test.go` — new tests covering
  intent-false/intent-true on the flat-bundle path, and a `GroupByName` regression guard proving
  `WantsOwnLayout() == false` has no effect there (the footgun guard above).
- `pkg/stack/layout/README.md` — documents the new interface and its two-path contract table;
  also fixes a stale sentence claiming augmentation only runs on the `GroupByName` path (it also
  runs on `GroupFlat`/umbrella-child paths via `processFlatBundleApps`).

## Process note

This plan was hardened through 2 rounds of `plan-loop` review + a final citation pass before
implementation (design rationale, full call-graph analysis, and citation verification recorded at
<!-- plan doc kept locally, not published --> hash `44721c678de433ee`). Implementation round 1
ran a full-scope codex review at the pushed commit with zero findings; `mise run verify` passed
(tidy/lint/test/tool-version/govulncheck-docs all green); `pkg/stack/layout` coverage 90.4%,
at/above the repo's 90% package gate.

Per `/gmr`'s standing deviation from `AGENTS.md`'s pre-commit review pause: this branch was pushed
without a human pausing to review the full diff before commit — human review happens here, on this
ready, evidenced draft PR, instead of on an unreviewed draft nobody was told about.

This PR stays draft until review converges (zero blocking findings at the pushed OID, CI reported
as-is, comment triage complete) per this org's standard review-loop process.
