### PR TITLE
test: add hermetic failure-path harness for sync-versions.sh guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,11 @@ jobs:
     - name: Check govulncheck docs
       run: make check-govulncheck-docs
 
+    # Version pinned here (4.44.6) is a separate copy from mise.toml's own `yq` pin --
+    # scripts/check-tool-versions.sh does not cover yq (golangci-lint only). Bumping
+    # one without the other silently desyncs mise's toolchain from CI. If you bump
+    # this, also update mise.toml's `yq` pin and the other 3 occurrences of this exact
+    # cache-key/download-URL pair (2 more in this file, 1 in deploy-docs.yml).
     - name: Cache yq
       id: yq-cache
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
@@ -800,6 +805,11 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-hugo-
 
+    # Version pinned here (4.44.6) is a separate copy from mise.toml's own `yq` pin --
+    # scripts/check-tool-versions.sh does not cover yq (golangci-lint only). Bumping
+    # one without the other silently desyncs mise's toolchain from CI. If you bump
+    # this, also update mise.toml's `yq` pin and the other 3 occurrences of this exact
+    # cache-key/download-URL pair (2 more in this file, 1 in deploy-docs.yml).
     - name: Cache yq
       id: yq-cache
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
@@ -945,6 +955,11 @@ jobs:
       with:
         fetch-depth: 0
 
+    # Version pinned here (4.44.6) is a separate copy from mise.toml's own `yq` pin --
+    # scripts/check-tool-versions.sh does not cover yq (golangci-lint only). Bumping
+    # one without the other silently desyncs mise's toolchain from CI. If you bump
+    # this, also update mise.toml's `yq` pin and the other 3 occurrences of this exact
+    # cache-key/download-URL pair (2 more in this file, 1 in deploy-docs.yml).
     - name: Cache yq
       id: yq-cache
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,12 @@ jobs:
             - 'versions.yaml'
             - 'docs/compatibility.md'
             - 'scripts/sync-versions.sh'
+            # scripts/test/** is sync-versions.sh's own guard-test harness (run as
+            # the "Run sync-versions.sh guard tests" step below). Without this
+            # entry, a PR touching only a case file or the harness itself -- the
+            # exact changes this harness exists to enforce CI coverage of -- would
+            # skip `validate` and report success unexercised.
+            - 'scripts/test/**'
             # Renovate's postUpgradeTasks command for the external-secrets pin —
             # same reasoning as the three entries above: a PR touching only this
             # script would otherwise skip `validate`/`test` entirely (the `build`
@@ -210,9 +216,19 @@ jobs:
         for f in scripts/sync-tool-versions.sh scripts/sync-govulncheck-docs.sh; do
           sh -n "$f"
         done
-        for f in scripts/sync-eso-pin.sh scripts/sync-versions.sh; do
+        for f in scripts/sync-eso-pin.sh scripts/sync-versions.sh scripts/test/run-tests.sh scripts/test/lib.sh scripts/test/cases/*.sh; do
           bash -n "$f"
         done
+
+    # Runs the mutation matrix (scripts/test/cases/*.sh) that proves
+    # sync-versions.sh's six guards actually fail when they should, not just
+    # pass on the real repo -- see scripts/test/lib.sh and the fixtures/
+    # under it. Hermetic and network-independent (stub go/curl/git), so
+    # unlike "Validate version consistency" above it needs no populated
+    # module cache from make deps -- a statement about this step's own
+    # dependencies, not about step order, which still runs it after deps.
+    - name: Run sync-versions.sh guard tests
+      run: bash scripts/test/run-tests.sh
 
     - name: Cache goimports
       id: goimports-cache

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -90,6 +90,11 @@ jobs:
         go-version: ${{ steps.go-version.outputs.version }}
         check-latest: true
 
+    # Version pinned here (4.44.6) is a separate copy from mise.toml's own `yq` pin --
+    # scripts/check-tool-versions.sh does not cover yq (golangci-lint only). Bumping
+    # one without the other silently desyncs mise's toolchain from CI. If you bump
+    # this, also update mise.toml's `yq` pin and the other 3 occurrences of this exact
+    # cache-key/download-URL pair (all 3 in ci.yml).
     - name: Cache yq
       id: yq-cache
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6

--- a/Makefile
+++ b/Makefile
@@ -312,6 +312,12 @@ check-govulncheck-docs: ## Verify govulncheck version parity (docs/github-workfl
 sync-govulncheck-docs: ## Sync govulncheck doc mentions (docs/github-workflows.md) from ci.yml
 	sh scripts/sync-govulncheck-docs.sh
 
+.PHONY: versions-test
+versions-test: ## Run sync-versions.sh guard tests (hermetic, no network)
+	@echo "$(COLOR_YELLOW)Running sync-versions.sh guard tests...$(COLOR_RESET)"
+	@bash scripts/test/run-tests.sh
+	@echo "$(COLOR_GREEN)Guard tests passed$(COLOR_RESET)"
+
 # =============================================================================
 # Development Environment
 # =============================================================================
@@ -347,7 +353,7 @@ dev: tools ## Set up development environment (mise, deps, git hooks)
 check: lint vet test-short check-tool-versions check-govulncheck-docs ## Quick code quality check (lint, vet, short tests, tool pins)
 
 .PHONY: precommit
-precommit: fmt tidy lint test check-tool-versions check-govulncheck-docs ## Run fast pre-commit checks (fmt, tidy, lint, test, tool pins)
+precommit: fmt tidy lint test check-tool-versions check-govulncheck-docs versions-test ## Run fast pre-commit checks (fmt, tidy, lint, test, tool pins, versions guard)
 
 .PHONY: ci
 ci: deps fmt tidy lint vet test test-race test-coverage test-integration vuln check-tool-versions check-govulncheck-docs ## Run comprehensive CI pipeline

--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,7 @@ check: lint vet test-short check-tool-versions check-govulncheck-docs ## Quick c
 precommit: fmt tidy lint test check-tool-versions check-govulncheck-docs versions-test ## Run fast pre-commit checks (fmt, tidy, lint, test, tool pins, versions guard)
 
 .PHONY: ci
-ci: deps fmt tidy lint vet test test-race test-coverage test-integration vuln check-tool-versions check-govulncheck-docs ## Run comprehensive CI pipeline
+ci: deps fmt tidy lint vet test test-race test-coverage test-integration vuln check-tool-versions check-govulncheck-docs versions-test ## Run comprehensive CI pipeline
 
 # =============================================================================
 # Cleanup

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -175,6 +175,46 @@ barman-cloud:
   is what let `barman-cloud` digest-bump unreviewed for months before this pattern existed
   (the shared preset's `go-patch` group automerges `gomod` patch/digest bumps).
 
+### Testing the guards
+
+`scripts/sync-versions.sh` has six guards (`validate_gomod`, `validate_gomod_pin_comment`,
+`validate_no_sha_in_notes`, `validate_mvs_floors`, `validate_docs_drift`,
+`validate_go_api_drift`), and CI only ever runs them against a repo state where they all
+pass. Nothing proves a guard actually **fails** when it should — a guard that stops
+guarding (a dropped flag, a loosened regex, a silently-skipped branch) looks identical to
+one still doing its job. `scripts/test/` closes that gap with a hermetic, network-free
+mutation-matrix harness: each `scripts/test/cases/*.sh` file builds a synthetic fixture
+tree, mutates one thing, runs `sync-versions.sh`, and asserts both the exit code and the
+specific error text.
+
+Run it locally with:
+
+```bash
+mise run versions:test
+```
+
+It's part of `mise run verify` and runs in CI as its own step, gated on
+`scripts/test/**`/`scripts/sync-versions.sh`/`versions.yaml`/`docs/compatibility.md`
+changes (same path filter as `sync-versions.sh check` itself).
+
+**Adding a case:** every case follows the same shape — see `scripts/test/lib.sh` for the
+full helper reference (`new_fixture`, `yq_set`, `gomod_sub`, `run_check`/`run_generate`,
+the `assert_*` family, `with_stub_go`/`with_stub_net`):
+
+```bash
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+yq_set '.infrastructure.<dep>.<field>' '<mutated value>'   # or gomod_sub for go.mod
+run_check
+assert_rc 1
+assert_err_contains '<the exact error substring the guard must emit>'
+```
+
+**A new guard lands with a case proving it fails.** A guard with no case exercising its
+failure path is, by this harness's own standard, unproven — the whole point is that CI
+should never again be able to report green while a guard silently stopped guarding.
+
 ## Update Risk Levels
 
 ### Patch Updates (Low Risk)

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -184,8 +184,10 @@ pass. Nothing proves a guard actually **fails** when it should — a guard that 
 guarding (a dropped flag, a loosened regex, a silently-skipped branch) looks identical to
 one still doing its job. `scripts/test/` closes that gap with a hermetic, network-free
 mutation-matrix harness: each `scripts/test/cases/*.sh` file builds a synthetic fixture
-tree, mutates one thing, runs `sync-versions.sh`, and asserts both the exit code and the
-specific error text.
+tree, sets up exactly one scenario — a fixture mutation, a stub `go`/`curl`/`git` mode, or
+the unmutated baseline — runs `sync-versions.sh`, and asserts both the exit code and the
+specific message the guard must emit (`assert_err_contains` for a failure case,
+`assert_out_contains` for one that must stay green).
 
 Run it locally with:
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -505,7 +505,7 @@ The development version shows a warning banner linking to the latest stable vers
 | Target | Tasks | Use Case |
 |--------|-------|----------|
 | `precommit` | fmt, tidy, lint, test, check-tool-versions, check-govulncheck-docs, versions-test | Fast local checks (~10s) |
-| `ci` | deps, fmt, tidy, lint, vet, test, test-race, test-coverage, test-integration, vuln, check-tool-versions, check-govulncheck-docs | Comprehensive CI pipeline (~2min) |
+| `ci` | deps, fmt, tidy, lint, vet, test, test-race, test-coverage, test-integration, vuln, check-tool-versions, check-govulncheck-docs, versions-test | Comprehensive CI pipeline (~2min) |
 
 ---
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -498,12 +498,13 @@ The development version shows a warning banner linking to the latest stable vers
 | `test-coverage` | `go test -coverprofile=... ./...` | ✅ | - |
 | `test-integration` | `go test -tags=integration -timeout 5m ./...` | - | - |
 | `vuln` | `govulncheck ./...` | ✅ | - |
+| `versions-test` | `bash scripts/test/run-tests.sh` | - (CI runs the script directly, not via `make`) | ✅ |
 
 ## CI vs Pre-commit
 
 | Target | Tasks | Use Case |
 |--------|-------|----------|
-| `precommit` | fmt, tidy, lint, test, check-tool-versions, check-govulncheck-docs | Fast local checks (~10s) |
+| `precommit` | fmt, tidy, lint, test, check-tool-versions, check-govulncheck-docs, versions-test | Fast local checks (~10s) |
 | `ci` | deps, fmt, tidy, lint, vet, test, test-race, test-coverage, test-integration, vuln, check-tool-versions, check-govulncheck-docs | Comprehensive CI pipeline (~2min) |
 
 ---

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -85,7 +85,7 @@ temporary branch — the merged result — before the PR is allowed to land.
 
 | Job | Check Name | Timeout | Dependencies | Purpose |
 |-----|------------|---------|--------------|---------|
-| `validate` | `lint` | 15 min | changes | Go fmt, tidy, vet, lint, tool-version parity (golangci-lint pin across Makefile/ci.yml/docs), govulncheck doc parity; `sync-versions.sh check`; syntax-check on the version-sync scripts, `sh -n` or `bash -n` per each script's own shebang; caches goimports + yq binaries |
+| `validate` | `lint` | 15 min | changes | Go fmt, tidy, vet, lint, tool-version parity (golangci-lint pin across Makefile/ci.yml/docs), govulncheck doc parity; `sync-versions.sh check`; syntax-check on the version-sync scripts, `sh -n` or `bash -n` per each script's own shebang; `scripts/test/run-tests.sh` (hermetic mutation-matrix guard tests for `sync-versions.sh`'s own six guards, no network); caches goimports + yq binaries |
 | `action-pins` | `action-pins` | 2 min | — | Fails if any third-party `uses:` ref is not pinned to a 40-char commit SHA (`go-kure/.github` canonical checker) |
 | `forbidden-terms` | `forbidden-terms` | 2 min | — | Runs the canonical full-tree downstream-reference guard on every workflow event and verifies the vendored release guard |
 | `test` | `test` | 20 min | changes | Unit tests with race detection and coverage; `-race` compilation takes ~5 min on the in-cluster runner, so 20 min allows compilation + 15 min for test execution |
@@ -602,12 +602,15 @@ The `changes` job uses `dorny/paths-filter` to skip jobs when unrelated files ch
 
 - `go:` filter — triggers lint/test/security/build jobs. Includes `**.go`, `go.mod`, `go.sum`,
   `Makefile`, and **`.github/workflows/**`** so that workflow-only PRs are also validated,
-  plus `versions.yaml`, `docs/compatibility.md`, `scripts/sync-versions.sh` and
-  `scripts/sync-eso-pin.sh`. Those last four are here because the only `sync-versions.sh
-  check` invocation lives in the `validate` job: without them a PR touching just version
-  metadata or the release-pinning script skipped both the supported-range guard and the
-  compatibility-matrix drift guard (or, for `sync-eso-pin.sh`, all of `validate`/`test`)
-  and still reported success — the `build` gate accepts a `skipped` dependency as passing.
+  plus `versions.yaml`, `docs/compatibility.md`, `scripts/sync-versions.sh`,
+  `scripts/test/**` and `scripts/sync-eso-pin.sh`. Those last five are here because the only
+  `sync-versions.sh check` invocation lives in the `validate` job: without them a PR touching
+  just version metadata, `sync-versions.sh`'s own guard-test harness (`scripts/test/**` — a
+  case file or the harness itself, the exact changes it exists to enforce CI coverage of), or
+  the release-pinning script skipped the supported-range guard, the compatibility-matrix drift
+  guard, and/or the "Run sync-versions.sh guard tests" step (or, for `sync-eso-pin.sh`, all of
+  `validate`/`test`) and still reported success — the `build` gate accepts a `skipped`
+  dependency as passing.
   Also includes `mise.toml`, `scripts/check-tool-versions.sh`, `scripts/sync-tool-versions.sh`
   and this file, for the same reason: `check-tool-versions` also runs only in the `validate`
   job, and a PR touching only one of those would otherwise skip the golangci-lint pin-parity

--- a/mise.toml
+++ b/mise.toml
@@ -10,6 +10,14 @@ hugo = "0.165.0"
 # and never relied on mise for it, which is what let this go unnoticed: a
 # clean mise-managed checkout with no system yq failed `mise run verify`
 # with no explanation.
+#
+# NOT covered by scripts/check-tool-versions.sh / sync-tool-versions.sh --
+# those two scripts only track golangci-lint. Bumping this pin does NOT
+# propagate anywhere automatically. If you bump it, also update the 4
+# hardcoded "4.44.6" occurrences by hand: .github/workflows/ci.yml (three
+# "Cache yq"/"Install yq" step pairs, ~:177-194, :803-820, :948-965) and
+# .github/workflows/deploy-docs.yml (one pair, ~:93-110). Each of those
+# carries a matching comment pointing back here.
 yq = "4.44.6"
 
 [env]

--- a/mise.toml
+++ b/mise.toml
@@ -27,7 +27,7 @@ run = "make check"
 
 [tasks.verify]
 description = "Run all checks (tidy, lint, test, tool pins, govulncheck docs)"
-depends = ["tidy", "lint", "test", "check-tool-versions", "check-govulncheck-docs"]
+depends = ["tidy", "lint", "test", "check-tool-versions", "check-govulncheck-docs", "versions:test"]
 
 [tasks.check-tool-versions]
 description = "Verify golangci-lint pin parity (Makefile/ci.yml/docs) against mise.toml"
@@ -65,6 +65,10 @@ run = "./scripts/sync-versions.sh check"
 [tasks."versions:generate"]
 description = "Generate docs and the pkg/versions Go API from versions.yaml"
 run = "./scripts/sync-versions.sh generate"
+
+[tasks."versions:test"]
+description = "Run scripts/sync-versions.sh guard tests (hermetic, no network)"
+run = "bash scripts/test/run-tests.sh"
 
 [tasks."site:dev"]
 description = "Start local docs dev server"

--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,13 @@ go = "1.26.6"
 golangci-lint = "2.13.1"
 git-cliff = "2.13.1"
 hugo = "0.165.0"
+# Pin matches .github/workflows/ci.yml's own yq install (v4.44.6) -- required
+# by scripts/sync-versions.sh and its versions:test guard harness, both now
+# on `mise run verify`'s dependency graph. CI installs yq as a separate step
+# and never relied on mise for it, which is what let this go unnoticed: a
+# clean mise-managed checkout with no system yq failed `mise run verify`
+# with no explanation.
+yq = "4.44.6"
 
 [env]
 GOBIN = "{{config_root}}/.bin"

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -16,11 +16,19 @@
 #    versions.yaml -- see generate_go_api / validate_go_api_drift
 # 6. a versions.yaml entry declaring floor_module has its go.mod pin exactly equal
 #    to what floor_module's own go.mod currently requires -- see validate_mvs_floors
+#
+# Test-only overrides (used by scripts/test/, never set in a real invocation):
+#   SYNC_VERSIONS_REPO_ROOT     - point REPO_ROOT at a synthetic fixture tree instead of the
+#                                 checkout this script lives in. Setting this in a real
+#                                 invocation makes the script validate a different tree than
+#                                 the one it lives in -- do not set it outside the test harness.
+#   SYNC_VERSIONS_PROBE_TIMEOUT - override the 10s timeout on the validate_mvs_floors `go list`
+#                                 probe, so the harness's timeout case runs in ~1s instead of 10s.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="${SYNC_VERSIONS_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 VERSIONS_FILE="$REPO_ROOT/versions.yaml"
 GO_MOD_FILE="$REPO_ROOT/go.mod"
 DOCS_FILE="$REPO_ROOT/docs/compatibility.md"
@@ -383,7 +391,7 @@ validate_mvs_floors() {
         # network) degrades to a warning -- this is the "can we even ask"
         # step, not the comparison itself.
         local gomod_path gomod_rc=0
-        gomod_path=$(timeout 10 env GOWORK=off go list -C "$REPO_ROOT" -mod=readonly -m -f '{{.GoMod}}' "$floor_module" 2>/dev/null) || gomod_rc=$?
+        gomod_path=$(timeout "${SYNC_VERSIONS_PROBE_TIMEOUT:-10}" env GOWORK=off go list -C "$REPO_ROOT" -mod=readonly -m -f '{{.GoMod}}' "$floor_module" 2>/dev/null) || gomod_rc=$?
         if [[ $gomod_rc -ne 0 || -z "$gomod_path" || ! -f "$gomod_path" ]]; then
             warning "$dep: could not resolve $floor_module's own go.mod (no Go, cold module cache, or no network) -- skipping MVS-floor equality check"
             continue

--- a/scripts/test/cases/01-mvs-floor-baseline.sh
+++ b/scripts/test/cases/01-mvs-floor-baseline.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Row 1: baseline (no mutation) -- validate_mvs_floors' success path.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+run_check
+assert_rc 0
+assert_out_contains "floor-dep: pin v0.5.1 matches the floor set by github.com/example/floor-owner"

--- a/scripts/test/cases/02-mvs-floor-pin-moved.sh
+++ b/scripts/test/cases/02-mvs-floor-pin-moved.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Row 2: floor-dep's pin moved to another same-major.minor pseudo-version --
+# no longer exact-string-equal to what floor-owner requires.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+gomod_sub 's|github.com/example/floor-dep v0.5.1|github.com/example/floor-dep v0.5.1-0.20260101000000-000000000001|'
+run_check
+assert_rc 1
+assert_err_contains "pin v0.5.1-0.20260101000000-000000000001 does not match github.com/example/floor-owner's requirement v0.5.1"

--- a/scripts/test/cases/02-mvs-floor-pin-moved.sh
+++ b/scripts/test/cases/02-mvs-floor-pin-moved.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 # Row 2: floor-dep's pin moved to another same-major.minor pseudo-version --
-# no longer exact-string-equal to what floor-owner requires.
+# no longer exact-string-equal to what floor-owner requires. Needs
+# run_generate before run_check (see 12a's header comment): without it,
+# validate_docs_drift independently fails too (docs/compatibility.md still
+# embeds the pre-mutation pin), so rc=1 alone would not prove
+# validate_mvs_floors's own return path fired -- proven by reproduction: with
+# validate_mvs_floors's error-counting deliberately suppressed, this case
+# still passed via docs-drift's unrelated rc=1 (verified locally, then
+# reverted). run_generate regenerates the docs against the moved pin, so
+# only validate_mvs_floors can supply this case's rc=1.
 set -uo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
 
 new_fixture
 gomod_sub 's|github.com/example/floor-dep v0.5.1|github.com/example/floor-dep v0.5.1-0.20260101000000-000000000001|'
+run_generate
+assert_rc 0
 run_check
 assert_rc 1
 assert_err_contains "pin v0.5.1-0.20260101000000-000000000001 does not match github.com/example/floor-owner's requirement v0.5.1"

--- a/scripts/test/cases/03-mvs-floor-floor-module-absent.sh
+++ b/scripts/test/cases/03-mvs-floor-floor-module-absent.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Row 3: floor_module points at a module that is not a go.mod dependency at all.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+yq_set '.infrastructure.floor-dep.floor_module' 'github.com/example/nowhere'
+run_check
+assert_rc 1
+assert_err_contains "floor_module github.com/example/nowhere (claimed to set the floor for github.com/example/floor-dep) was not found in go.mod"

--- a/scripts/test/cases/04-mvs-floor-go-module-removed.sh
+++ b/scripts/test/cases/04-mvs-floor-go-module-removed.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Row 4: go_module (floor-dep) removed from go.mod entirely.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+gomod_sub '/github.com\/example\/floor-dep v0.5.1/d'
+run_check
+assert_rc 1
+assert_err_contains "floor_module is set but github.com/example/floor-dep was not found in go.mod"

--- a/scripts/test/cases/04-mvs-floor-go-module-removed.sh
+++ b/scripts/test/cases/04-mvs-floor-go-module-removed.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
-# Row 4: go_module (floor-dep) removed from go.mod entirely.
+# Row 4: go_module (floor-dep) removed from go.mod entirely. Needs
+# run_generate before run_check (see 12a's header comment): removing
+# floor-dep's require line changes its build-version column in
+# docs/compatibility.md from "v0.5.1" to "(transitive)", so
+# validate_docs_drift independently fails too -- proven by reproduction
+# (suppressing validate_mvs_floors's error-counting here still left this
+# case passing via docs-drift's unrelated rc=1, verified locally then
+# reverted), same defect class as row 2. run_generate regenerates the docs
+# against the removal, so only validate_mvs_floors can supply this case's
+# rc=1.
 set -uo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
 
 new_fixture
 gomod_sub '/github.com\/example\/floor-dep v0.5.1/d'
+run_generate
+assert_rc 0
 run_check
 assert_rc 1
 assert_err_contains "floor_module is set but github.com/example/floor-dep was not found in go.mod"

--- a/scripts/test/cases/05-mvs-floor-norequire.sh
+++ b/scripts/test/cases/05-mvs-floor-norequire.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Row 5: floor-owner's go.mod does not require floor-dep at all.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+with_stub_go norequire
+run_check
+assert_rc 1
+assert_err_contains "github.com/example/floor-owner's go.mod does not require github.com/example/floor-dep at all"

--- a/scripts/test/cases/06-mvs-floor-editfail.sh
+++ b/scripts/test/cases/06-mvs-floor-editfail.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Row 6: `go mod edit` fails outright -- distinct from row 5's clean "not
-# required" result (guards #707's R2-02 fix: the two must not be conflated).
+# required" result. #707 fixed a bug where the two were conflated (a tool
+# failure misreported as a confirmed absence); this case guards that fix by
+# keeping the two failure modes asserting different text (see this row's
+# assertions vs. row 5's).
 set -uo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
 

--- a/scripts/test/cases/06-mvs-floor-editfail.sh
+++ b/scripts/test/cases/06-mvs-floor-editfail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Row 6: `go mod edit` fails outright -- distinct from row 5's clean "not
+# required" result (guards #707's R2-02 fix: the two must not be conflated).
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+with_stub_go editfail
+run_check
+assert_rc 1
+assert_err_contains "could not read github.com/example/floor-owner's go.mod requirements"
+assert_err_contains "rc=3"

--- a/scripts/test/cases/07-mvs-floor-go-absent.sh
+++ b/scripts/test/cases/07-mvs-floor-go-absent.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Row 7: `go` is entirely unresolvable on PATH -- the offline invariant.
+# Must degrade to a warning (rc 0), never a hard failure.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+with_stub_go absent
+run_check
+assert_rc 0
+assert_out_contains "could not resolve github.com/example/floor-owner's own go.mod (no Go, cold module cache, or no network) -- skipping MVS-floor equality check"

--- a/scripts/test/cases/08-mvs-floor-badpath.sh
+++ b/scripts/test/cases/08-mvs-floor-badpath.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Row 8: `go list` prints a path that does not exist on disk.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+with_stub_go badpath
+run_check
+assert_rc 0
+assert_out_contains "could not resolve github.com/example/floor-owner's own go.mod (no Go, cold module cache, or no network) -- skipping MVS-floor equality check"

--- a/scripts/test/cases/09-mvs-floor-hang-timeout.sh
+++ b/scripts/test/cases/09-mvs-floor-hang-timeout.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Row 9: `go list` hangs; SYNC_VERSIONS_PROBE_TIMEOUT bounds it to ~1s instead
+# of the production 10s default, and the result must still be a warning
+# (rc 0), not a hang.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+with_stub_go hang
+export SYNC_VERSIONS_PROBE_TIMEOUT=1
+
+start=$(date +%s)
+run_check
+elapsed=$(( $(date +%s) - start ))
+
+assert_rc 0
+assert_out_contains "could not resolve github.com/example/floor-owner's own go.mod (no Go, cold module cache, or no network) -- skipping MVS-floor equality check"
+
+if [[ $elapsed -ge 4 ]]; then
+    echo "FAIL: expected the 1s override to bound the hang, took ${elapsed}s" >&2
+    exit 1
+fi

--- a/scripts/test/cases/09-mvs-floor-hang-timeout.sh
+++ b/scripts/test/cases/09-mvs-floor-hang-timeout.sh
@@ -16,7 +16,13 @@ elapsed=$(( $(date +%s) - start ))
 assert_rc 0
 assert_out_contains "could not resolve github.com/example/floor-owner's own go.mod (no Go, cold module cache, or no network) -- skipping MVS-floor equality check"
 
-if [[ $elapsed -ge 4 ]]; then
+# Bound is 8s, not a tight margin over the 1s override: this times run_check's
+# WHOLE `sync-versions.sh check` invocation (every guard, not just the bounded
+# probe), so host scheduling contention -- not just a stuck probe -- can
+# inflate elapsed. 8s still fails loudly if the override is silently ignored
+# (production default is 10s, sync-versions.sh:394's `${SYNC_VERSIONS_PROBE_TIMEOUT:-10}`),
+# while leaving headroom a 4s bound didn't have under a loaded host.
+if [[ $elapsed -ge 8 ]]; then
     echo "FAIL: expected the 1s override to bound the hang, took ${elapsed}s" >&2
     exit 1
 fi

--- a/scripts/test/cases/10-mvs-floor-no-floor-module.sh
+++ b/scripts/test/cases/10-mvs-floor-no-floor-module.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Row 10: an entry with no floor_module gets no success or error line from
+# validate_mvs_floors at all -- it `continue`s before printing anything.
+# range-dep (a validate_gomod entry, not an mvs-floor one) stands in for
+# "any entry lacking floor_module"; its own validate_gomod output uses a
+# different message shape ("range-dep: vX within supported_range"), so it
+# cannot be confused with the mvs-floors "pin ... matches the floor" shape
+# this case is proving absent.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+run_check
+assert_rc 0
+assert_out_not_contains "range-dep: pin"

--- a/scripts/test/cases/11a-gomod-range-below.sh
+++ b/scripts/test/cases/11a-gomod-range-below.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Row 11 (below): range-dep's pin sits below supported_range.
+# Two case files, not one looped case: sync-versions.sh:576's range check is
+# one combined (( ver_key < lo_key || ver_key > hi_key )) -- a single
+# mutated-both-ways fixture entry can't tell you which comparison broke if
+# the other is later disabled by a regression.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+gomod_sub 's|github.com/example/range-dep v2.0.3|github.com/example/range-dep v1.9.0|'
+run_check
+assert_rc 1
+assert_err_contains 'range-dep 1.9 (go.mod github.com/example/range-dep v1.9.0) is outside supported_range "2.0"'

--- a/scripts/test/cases/11a-gomod-range-below.sh
+++ b/scripts/test/cases/11a-gomod-range-below.sh
@@ -4,11 +4,20 @@
 # one combined (( ver_key < lo_key || ver_key > hi_key )) -- a single
 # mutated-both-ways fixture entry can't tell you which comparison broke if
 # the other is later disabled by a regression.
+# Needs run_generate before run_check (see 12a's header comment): the pin
+# mutation changes range-dep's build-version column in docs/compatibility.md,
+# so validate_docs_drift independently fails too -- proven by reproduction
+# (suppressing the range guard's error-counting here still left this case
+# passing via docs-drift's unrelated rc=1, verified locally then reverted),
+# same defect class as row 2. run_generate regenerates the docs against the
+# mutation, so only the range guard can supply this case's rc=1.
 set -uo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
 
 new_fixture
 gomod_sub 's|github.com/example/range-dep v2.0.3|github.com/example/range-dep v1.9.0|'
+run_generate
+assert_rc 0
 run_check
 assert_rc 1
 assert_err_contains 'range-dep 1.9 (go.mod github.com/example/range-dep v1.9.0) is outside supported_range "2.0"'

--- a/scripts/test/cases/11b-gomod-range-above.sh
+++ b/scripts/test/cases/11b-gomod-range-above.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Row 11 (above): range-dep's pin sits above supported_range. Its own case
+# file, isolated from 11a -- see 11a's header comment for why.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+gomod_sub 's|github.com/example/range-dep v2.0.3|github.com/example/range-dep v2.1.0|'
+run_check
+assert_rc 1
+assert_err_contains 'range-dep 2.1 (go.mod github.com/example/range-dep v2.1.0) is outside supported_range "2.0"'

--- a/scripts/test/cases/11b-gomod-range-above.sh
+++ b/scripts/test/cases/11b-gomod-range-above.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 # Row 11 (above): range-dep's pin sits above supported_range. Its own case
-# file, isolated from 11a -- see 11a's header comment for why.
+# file, isolated from 11a -- see 11a's header comment for why. Also needs
+# run_generate before run_check for the same docs-drift-masking reason as
+# 11a -- see that file's header comment.
 set -uo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
 
 new_fixture
 gomod_sub 's|github.com/example/range-dep v2.0.3|github.com/example/range-dep v2.1.0|'
+run_generate
+assert_rc 0
 run_check
 assert_rc 1
 assert_err_contains 'range-dep 2.1 (go.mod github.com/example/range-dep v2.1.0) is outside supported_range "2.0"'

--- a/scripts/test/cases/12a-gomod-boundary-lower.sh
+++ b/scripts/test/cases/12a-gomod-boundary-lower.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Row 12 (lower bound): boundary-dep's pin sits exactly at supported_range's
+# low end -- proves the range check is inclusive. Needs run_generate before
+# run_check: generate_docs/generate_go_api embed the go.mod build version
+# verbatim, so mutating the pin without regenerating first leaves the
+# committed docs/go-api stale and validate_docs_drift/validate_go_api_drift
+# report rc 1 for a reason unrelated to the boundary check itself.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+gomod_sub 's|github.com/example/boundary-dep v1.6.0|github.com/example/boundary-dep v1.5.0|'
+run_generate
+assert_rc 0
+run_check
+assert_rc 0
+assert_out_contains 'boundary-dep: v1.5.0 within supported_range "1.5 - 1.7"'

--- a/scripts/test/cases/12b-gomod-boundary-upper.sh
+++ b/scripts/test/cases/12b-gomod-boundary-upper.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Row 12 (upper bound): boundary-dep's pin sits exactly at supported_range's
+# high end. See 12a's header comment for why run_generate runs first.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+gomod_sub 's|github.com/example/boundary-dep v1.6.0|github.com/example/boundary-dep v1.7.9|'
+run_generate
+assert_rc 0
+run_check
+assert_rc 0
+assert_out_contains 'boundary-dep: v1.7.9 within supported_range "1.5 - 1.7"'

--- a/scripts/test/cases/13-gomod-kubernetes-basis.sh
+++ b/scripts/test/cases/13-gomod-kubernetes-basis.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Row 13: version_basis: kubernetes normalizes k8s-basis-dep's v0.36.4 (major 0)
+# to mm "1.36" before comparing against supported_range "1.36" -- without the
+# normalization this would report outside "1.36" (its raw mm is "0.36").
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+run_check
+assert_rc 0
+assert_out_contains 'k8s-basis-dep: v0.36.4 within supported_range "1.36"'

--- a/scripts/test/cases/14-gomod-pseudo-skip.sh
+++ b/scripts/test/cases/14-gomod-pseudo-skip.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Row 14: pseudo-dep is a pseudo-version with no upstream_release declared --
+# the range check must be skipped entirely, not evaluated against its
+# deliberately-unsatisfiable supported_range "9.9".
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+run_check
+assert_rc 0
+assert_out_contains 'pseudo-dep: 0.0.0-20260101000000-000000000099 (pseudo-version, no upstream_release declared — range check skipped)'

--- a/scripts/test/cases/15-gomod-upstream-release-commit-missing.sh
+++ b/scripts/test/cases/15-gomod-upstream-release-commit-missing.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Row 15: upstream-dep declares upstream_release but upstream_release_commit
+# is deleted entirely -- validate_gomod must error rather than fall through
+# to a digest comparison against an empty string.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+yq eval -i 'del(.infrastructure.upstream-dep.upstream_release_commit)' "$FIXTURE/versions.yaml"
+run_check
+assert_rc 1
+assert_err_contains 'upstream_release is set but upstream_release_commit is missing in versions.yaml'

--- a/scripts/test/cases/16-gomod-upstream-release-digest-drift.sh
+++ b/scripts/test/cases/16-gomod-upstream-release-digest-drift.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Row 16: upstream-dep's go.mod pin digest no longer prefixes
+# upstream_release_commit -- the pin has drifted off the declared release
+# even though it's still syntactically a pseudo-version.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+gomod_sub 's|github.com/example/upstream-dep v0.0.0-20260101000000-eeeeeeeeeeee|github.com/example/upstream-dep v0.0.0-20260101000000-ffffffffffff|'
+run_check
+assert_rc 1
+assert_err_contains "go.mod pin digest 'ffffffffffff' does not match declared release v3.4.0"

--- a/scripts/test/cases/16-gomod-upstream-release-digest-drift.sh
+++ b/scripts/test/cases/16-gomod-upstream-release-digest-drift.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
 # Row 16: upstream-dep's go.mod pin digest no longer prefixes
 # upstream_release_commit -- the pin has drifted off the declared release
-# even though it's still syntactically a pseudo-version.
+# even though it's still syntactically a pseudo-version. Needs run_generate
+# before run_check (see 12a's header comment): the pin mutation changes
+# upstream-dep's build-version column in docs/compatibility.md, so
+# validate_docs_drift independently fails too -- proven by reproduction
+# (suppressing the digest guard's error-counting here still left this case
+# passing via docs-drift's unrelated rc=1, verified locally then reverted),
+# same defect class as row 2. run_generate regenerates the docs against the
+# mutation, so only the digest guard can supply this case's rc=1.
 set -uo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
 
 new_fixture
 gomod_sub 's|github.com/example/upstream-dep v0.0.0-20260101000000-eeeeeeeeeeee|github.com/example/upstream-dep v0.0.0-20260101000000-ffffffffffff|'
+run_generate
+assert_rc 0
 run_check
 assert_rc 1
 assert_err_contains "go.mod pin digest 'ffffffffffff' does not match declared release v3.4.0"

--- a/scripts/test/cases/17-gomod-go-version-mismatch.sh
+++ b/scripts/test/cases/17-gomod-go-version-mismatch.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Row 17: go.mod's go line no longer matches versions.yaml's go.current.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+gomod_sub 's|^go 1.26.6|go 1.26.7|'
+run_check
+assert_rc 1
+assert_err_contains "Go version mismatch: go.mod has '1.26.7', versions.yaml expects '1.26.6'"

--- a/scripts/test/cases/18-pin-comment-missing.sh
+++ b/scripts/test/cases/18-pin-comment-missing.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Row 18: delete the "// Current pin: ..." comment line entirely.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+gomod_sub '/^\/\/ Current pin: /d'
+run_check
+assert_rc 1
+assert_err_contains "go.mod is missing the '// Current pin: ' comment above the k8s.io replace block"

--- a/scripts/test/cases/19-pin-comment-stale.sh
+++ b/scripts/test/cases/19-pin-comment-stale.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Row 19: bump the k8s.io/api replace directive, leave the "// Current pin:"
+# comment untouched -- the two must now disagree.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+gomod_sub 's|k8s.io/api => k8s.io/api v0.36.4|k8s.io/api => k8s.io/api v0.37.0|'
+run_check
+assert_rc 1
+assert_err_contains "go.mod pin comment out of date: has '// Current pin: v0.36.4 (Kubernetes 1.36)', expected '// Current pin: v0.37.0 (Kubernetes 1.37)'"

--- a/scripts/test/cases/20-pin-comment-no-replace.sh
+++ b/scripts/test/cases/20-pin-comment-no-replace.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Row 20: delete the k8s.io/api replace directive entirely. The pin comment
+# check can't even compute an expected value without it.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+gomod_sub '/k8s.io\/api => k8s.io\/api v0.36.4/d'
+run_check
+assert_rc 1
+assert_err_contains "replace directive not found in go.mod"

--- a/scripts/test/cases/21-notes-sha-40hex.sh
+++ b/scripts/test/cases/21-notes-sha-40hex.sh
@@ -13,7 +13,7 @@ set -uo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
 
 new_fixture
-yq_set '.infrastructure.notes-dep.notes' "pinned at $(printf 'b%.0s' $(seq 40))"
+yq_set '.infrastructure.notes-dep.notes' "pinned at $(printf 'b%.0s' {1..40})"
 run_generate
 assert_rc 0
 run_check

--- a/scripts/test/cases/21-notes-sha-40hex.sh
+++ b/scripts/test/cases/21-notes-sha-40hex.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Row 21: a 40-hex commit SHA embedded in notes-dep's notes: field.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+yq_set '.infrastructure.notes-dep.notes' "pinned at $(printf 'b%.0s' $(seq 40))"
+run_check
+assert_rc 1
+assert_err_contains 'notes-dep: notes contains a raw commit SHA'

--- a/scripts/test/cases/21-notes-sha-40hex.sh
+++ b/scripts/test/cases/21-notes-sha-40hex.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
-# Row 21: a 40-hex commit SHA embedded in notes-dep's notes: field.
+# Row 21: a 40-hex commit SHA embedded in notes-dep's notes: field. Needs
+# run_generate before run_check (see 23's header comment, which already
+# documents this for notes-dep mutations): generate_docs embeds notes
+# verbatim into docs/compatibility.md's table, so a notes change without
+# regenerating leaves the committed docs stale and validate_docs_drift
+# independently fails too -- proven by reproduction (suppressing
+# validate_no_sha_in_notes' own error-counting here still left this case
+# passing via docs-drift's unrelated rc=1, verified locally then reverted),
+# same defect class as row 2. run_generate regenerates the docs against the
+# mutation, so only validate_no_sha_in_notes can supply this case's rc=1.
 set -uo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
 
 new_fixture
 yq_set '.infrastructure.notes-dep.notes' "pinned at $(printf 'b%.0s' $(seq 40))"
+run_generate
+assert_rc 0
 run_check
 assert_rc 1
 assert_err_contains 'notes-dep: notes contains a raw commit SHA'

--- a/scripts/test/cases/22-notes-sha-12hex.sh
+++ b/scripts/test/cases/22-notes-sha-12hex.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 # Row 22: a 12-hex (pseudo-version-length) commit SHA embedded in notes-dep's
-# notes: field -- the regex must catch both lengths, not just 40.
+# notes: field -- the regex must catch both lengths, not just 40. Also needs
+# run_generate before run_check for the same docs-drift-masking reason as
+# row 21 -- see that file's header comment (and 23's, which documents it
+# first for this same notes-dep field).
 set -uo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
 
 new_fixture
 yq_set '.infrastructure.notes-dep.notes' "pinned at $(printf 'b%.0s' $(seq 12))"
+run_generate
+assert_rc 0
 run_check
 assert_rc 1
 assert_err_contains 'notes-dep: notes contains a raw commit SHA'

--- a/scripts/test/cases/22-notes-sha-12hex.sh
+++ b/scripts/test/cases/22-notes-sha-12hex.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Row 22: a 12-hex (pseudo-version-length) commit SHA embedded in notes-dep's
+# notes: field -- the regex must catch both lengths, not just 40.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+yq_set '.infrastructure.notes-dep.notes' "pinned at $(printf 'b%.0s' $(seq 12))"
+run_check
+assert_rc 1
+assert_err_contains 'notes-dep: notes contains a raw commit SHA'

--- a/scripts/test/cases/22-notes-sha-12hex.sh
+++ b/scripts/test/cases/22-notes-sha-12hex.sh
@@ -8,7 +8,7 @@ set -uo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
 
 new_fixture
-yq_set '.infrastructure.notes-dep.notes' "pinned at $(printf 'b%.0s' $(seq 12))"
+yq_set '.infrastructure.notes-dep.notes' "pinned at $(printf 'b%.0s' {1..12})"
 run_generate
 assert_rc 0
 run_check

--- a/scripts/test/cases/23-notes-prose-carveout.sh
+++ b/scripts/test/cases/23-notes-prose-carveout.sh
@@ -4,11 +4,35 @@
 # into docs/compatibility.md's table, so a notes change without regenerating
 # leaves the committed docs stale and validate_docs_drift fails for a reason
 # unrelated to what this case is proving.
+#
+# Two things make this case able to FAIL, which an earlier version of it could
+# not do (measured: with the yq_set line below removed it still exited 0,
+# because the assertion is validate_no_sha_in_notes' validator-wide success
+# line, which the untouched -- also SHA-free -- baseline fixture emits too):
+#
+#   1. The mutation is read back. `yq eval -i '.a.b = "x"'` CREATES a missing
+#      path instead of erroring, so renaming the notes-dep fixture entry would
+#      otherwise silently turn this case vacuous rather than failing loudly.
+#   2. The prose is boundary-shaped, not merely SHA-free: an 11-hex and a
+#      13-hex word sit either side of the 12-hex pattern at
+#      sync-versions.sh:309. Loosening `{12}` to `{11,}` makes the 11-hex word
+#      match; dropping the `\b` anchors makes the 13-hex word match. Either
+#      regression flips this case to rc 1.
 set -uo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
 
 new_fixture
-yq_set '.infrastructure.notes-dep.notes' 'v0.16.0 is a minor release; no API changes.'
+
+CARVEOUT_NOTES='v0.16.0 is a minor release; refs abcdefabcde and abcdefabcdefa are not commit SHAs.'
+yq_set '.infrastructure.notes-dep.notes' "$CARVEOUT_NOTES"
+
+landed=$(yq '.infrastructure.notes-dep.notes' "$FIXTURE/versions.yaml")
+if [[ "$landed" != "$CARVEOUT_NOTES" ]]; then
+    echo "FAIL: the notes mutation did not land -- versions.yaml has: $landed" >&2
+    echo "      (expected: $CARVEOUT_NOTES)" >&2
+    exit 1
+fi
+
 run_generate
 assert_rc 0
 run_check

--- a/scripts/test/cases/23-notes-prose-carveout.sh
+++ b/scripts/test/cases/23-notes-prose-carveout.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Row 23: the deliberate carve-out -- ordinary semver prose in notes: (no bare
+# hex SHA) must pass. run_generate first: generate_docs embeds notes verbatim
+# into docs/compatibility.md's table, so a notes change without regenerating
+# leaves the committed docs stale and validate_docs_drift fails for a reason
+# unrelated to what this case is proving.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+yq_set '.infrastructure.notes-dep.notes' 'v0.16.0 is a minor release; no API changes.'
+run_generate
+assert_rc 0
+run_check
+assert_rc 0
+assert_out_contains 'No raw commit SHAs in versions.yaml notes'

--- a/scripts/test/cases/24-generate-idempotent.sh
+++ b/scripts/test/cases/24-generate-idempotent.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Row 24: running generate twice with no mutation between must be a no-op --
+# proves generate_docs/generate_go_api are idempotent, not just correct once.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+run_generate
+assert_rc 0
+run_check
+assert_rc 0
+assert_out_contains 'compatibility.md is up to date'
+assert_out_contains 'versions_gen.go is up to date'

--- a/scripts/test/cases/25-docs-drift.sh
+++ b/scripts/test/cases/25-docs-drift.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Row 25: hand-edit the committed docs/compatibility.md so it no longer
+# matches what generate_docs would produce right now.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+printf '\nhand-edited, not regenerated\n' >> "$FIXTURE/docs/compatibility.md"
+run_check
+assert_rc 1
+assert_err_contains 'compatibility.md is out of date'

--- a/scripts/test/cases/26-go-api-drift.sh
+++ b/scripts/test/cases/26-go-api-drift.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Row 26: hand-edit the committed pkg/versions/versions_gen.go so it no longer
+# matches what generate_go_api would produce right now.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+printf '\n// hand-edited, not regenerated\n' >> "$FIXTURE/pkg/versions/versions_gen.go"
+run_check
+assert_rc 1
+assert_err_contains 'versions_gen.go is out of date'

--- a/scripts/test/cases/27-generate-unsafe-supported-range.sh
+++ b/scripts/test/cases/27-generate-unsafe-supported-range.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Row 27: supported_range containing a double-quote can't be emitted as a Go
+# string literal by generate_go_api -- it must refuse rather than emit
+# uncompilable output. Uses yq eval -i directly (not yq_set): the value
+# itself contains the quote character yq_set's own wrapping can't carry.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+yq eval -i '.infrastructure.range-dep.supported_range = "2.0\"bad"' "$FIXTURE/versions.yaml"
+run_generate
+assert_rc 1
+assert_err_contains 'versions.yaml value cannot be emitted as a Go string literal: 2.0"bad'

--- a/scripts/test/cases/28-generate-unsafe-go-current.sh
+++ b/scripts/test/cases/28-generate-unsafe-go-current.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Row 28: go.current containing a double-quote can't be emitted as a Go
+# string literal by generate_go_api's separate go.current guard (distinct
+# from the per-entry loop's guard that row 27 exercises) -- without this
+# guard, generate could emit an uncompilable `const GoVersion` literal while
+# every per-entry field still passes.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+yq eval -i '.go.current = "1.26.6\"bad"' "$FIXTURE/versions.yaml"
+run_generate
+assert_rc 1
+assert_err_contains 'versions.yaml go.current cannot be emitted as a Go string literal: 1.26.6"bad'

--- a/scripts/test/cases/29-live-check-mismatch.sh
+++ b/scripts/test/cases/29-live-check-mismatch.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Row 29: net-dep's upstream_release tag resolves live to a commit different
+# from the declared upstream_release_commit -- versions.yaml was hand-edited
+# out of sync with reality, independent of go.mod.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+with_stub_net mismatch
+run_check
+assert_rc 1
+assert_err_contains 'does not match the commit example/net-dep@v2.9.0 resolves to today'

--- a/scripts/test/cases/30-live-check-notfound.sh
+++ b/scripts/test/cases/30-live-check-notfound.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Row 30: net-dep's upstream_release tag does not exist upstream (API 404) --
+# a typo'd upstream_release, distinct from a network failure.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+with_stub_net notfound
+run_check
+assert_rc 1
+assert_err_contains 'tag v2.9.0 does not exist in example/net-dep (confirmed reachable) — check upstream_release for a typo'

--- a/scripts/test/cases/31-live-check-unreachable.sh
+++ b/scripts/test/cases/31-live-check-unreachable.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Row 31: net-dep's live check is entirely unreachable (both curl and git
+# ls-remote fail) -- the offline invariant: this must warn, never hard-fail a
+# `check` run just because the network (or GitHub) is unavailable. This is
+# also the default STUB_NET_MODE for every other case, so with_stub_net is
+# called here only for explicitness.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+with_stub_net unreachable
+run_check
+assert_rc 0
+assert_out_contains 'could not verify upstream_release_commit against example/net-dep@v2.9.0 live (no network or rate-limited) — offline digest check above still holds'

--- a/scripts/test/cases/32-live-check-range-entry.sh
+++ b/scripts/test/cases/32-live-check-range-entry.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Row 32: its own net-dep-range entry, never net-dep's -- see
+# fixtures/base/versions.yaml's header comment on why this can't live in the
+# base fixture (an earlier draft put it there and broke 7 of the other 13
+# cases). Injected here instead, only for this one case: a go.mod require
+# line and a versions.yaml entry sharing net-dep's upstream_release_commit
+# (NETDEP_COMMIT -- safe to reuse, since the stub always returns the same
+# fixed value regardless of which entry is being validated) but pinned to
+# net-dep-range's OWN mm ("1.5") while declaring the release's mm ("2.9") --
+# so the live check succeeds (STUB_NET_MODE=match) and the range check then
+# runs against the SUBSTITUTED release version, not the pin's own version.
+# If sync-versions.sh:552's substitution were ever deleted, actual_version
+# would stay the pin's pseudo-version (mm "1.5"), which IS inside "1.5" --
+# rc 0 instead of this case's expected rc 1 -- proving the substitution is
+# load-bearing rather than a no-op.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+
+sed -i '/^)/i\
+	github.com/example/net-dep-range v1.5.0-20260101000000-aaaaaaaaaaaa' "$FIXTURE/go.mod"
+
+yq eval -i '.infrastructure.net-dep-range = {
+  "go_module": "github.com/example/net-dep-range",
+  "upstream_repo": "example/net-dep-range",
+  "upstream_release": "v2.9.0",
+  "upstream_release_commit": env(NETDEP_COMMIT),
+  "supported_range": "1.5",
+  "notes": "Synthetic live-check dependency for scripts/test/ row 32 exclusively."
+}' "$FIXTURE/versions.yaml"
+
+with_stub_net match
+run_generate
+assert_rc 0
+run_check
+assert_rc 1
+# sync-versions.sh:577 prints $actual_version AFTER the :552 substitution --
+# the error names the SUBSTITUTED release version (v2.9.0), not the go.mod
+# pin (v1.5.0-...) -- the same substitution being proven load-bearing above.
+assert_err_contains 'net-dep-range 2.9 (go.mod github.com/example/net-dep-range v2.9.0) is outside supported_range "1.5"'

--- a/scripts/test/cases/32-live-check-range-entry.sh
+++ b/scripts/test/cases/32-live-check-range-entry.sh
@@ -25,9 +25,14 @@ new_fixture
 # directive, and the module effectively declared twice. Confirmed by
 # reproduction: the unscoped form left a malformed second entry inside
 # replace ( ... ), verified locally then reverted.
-sed -i '/^require (/,/^)/{/^)/i\
+#
+# Temp-file + mv, not `sed -i` -- BSD/macOS sed's `-i` takes the backup
+# suffix as its next (mandatory) argument and would otherwise consume this
+# script's own sed expression as that suffix, leaving go.mod unedited. Same
+# pattern as scripts/sync-tool-versions.sh's own file edits.
+sed '/^require (/,/^)/{/^)/i\
 	github.com/example/net-dep-range v1.5.0-20260101000000-aaaaaaaaaaaa
-}' "$FIXTURE/go.mod"
+}' "$FIXTURE/go.mod" > "$FIXTURE/go.mod.tmp" && mv "$FIXTURE/go.mod.tmp" "$FIXTURE/go.mod"
 
 yq eval -i '.infrastructure.net-dep-range = {
   "go_module": "github.com/example/net-dep-range",

--- a/scripts/test/cases/32-live-check-range-entry.sh
+++ b/scripts/test/cases/32-live-check-range-entry.sh
@@ -18,8 +18,16 @@ source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
 
 new_fixture
 
-sed -i '/^)/i\
-	github.com/example/net-dep-range v1.5.0-20260101000000-aaaaaaaaaaaa' "$FIXTURE/go.mod"
+# Range-restricted to the require ( ... ) block's own closing paren: a bare
+# /^)/ also matches the replace ( ... ) block's closing paren above it (both
+# fixtures/base/go.mod blocks close with a bare ")"), inserting this require
+# line into the replace block too -- with no "=>" target, an invalid replace
+# directive, and the module effectively declared twice. Confirmed by
+# reproduction: the unscoped form left a malformed second entry inside
+# replace ( ... ), verified locally then reverted.
+sed -i '/^require (/,/^)/{/^)/i\
+	github.com/example/net-dep-range v1.5.0-20260101000000-aaaaaaaaaaaa
+}' "$FIXTURE/go.mod"
 
 yq eval -i '.infrastructure.net-dep-range = {
   "go_module": "github.com/example/net-dep-range",

--- a/scripts/test/cases/33-live-check-annotated-tag-peel.sh
+++ b/scripts/test/cases/33-live-check-annotated-tag-peel.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Row 33: net-dep's upstream_release tag is an annotated tag -- the first API
+# response is the tag *object*, which must be peeled to the commit it points
+# at (a second API call) before comparing against upstream_release_commit. A
+# broken peel would compare the tag object's own SHA instead and misreport a
+# mismatch even though the release is correctly pinned.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+with_stub_net tag-object
+run_check
+assert_rc 0
+assert_out_contains 'net-dep: upstream_release_commit confirmed against live example/net-dep@v2.9.0'

--- a/scripts/test/cases/34-live-check-ls-remote-fallback.sh
+++ b/scripts/test/cases/34-live-check-ls-remote-fallback.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Row 34: the GitHub API is inconclusive (rate-limit-style, not a definitive
+# 404), but `git ls-remote` reaches the server and resolves the tag -- the
+# successful ls-remote fallback path. A broken match here would treat a
+# reachable-but-empty ls-remote as definitive absence and misreport "does not
+# exist" instead of confirming the release.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+with_stub_net ls-remote-match
+run_check
+assert_rc 0
+assert_out_contains 'net-dep: upstream_release_commit confirmed against live example/net-dep@v2.9.0'

--- a/scripts/test/fixtures/base/floor/go.mod
+++ b/scripts/test/fixtures/base/floor/go.mod
@@ -1,0 +1,5 @@
+module github.com/example/floor-owner
+
+go 1.26.6
+
+require github.com/example/floor-dep v0.5.1

--- a/scripts/test/fixtures/base/go.mod
+++ b/scripts/test/fixtures/base/go.mod
@@ -1,0 +1,28 @@
+module github.com/example/fixture
+
+go 1.26.6
+
+// Current pin: v0.36.4 (Kubernetes 1.36)
+
+replace (
+	k8s.io/api => k8s.io/api v0.36.4
+)
+
+require (
+	k8s.io/api v0.36.4
+	github.com/example/floor-dep v0.5.1
+	github.com/example/floor-owner v1.0.0
+	github.com/example/range-dep v2.0.3
+	github.com/example/boundary-dep v1.6.0
+	github.com/example/k8s-basis-dep v0.36.4
+	github.com/example/pseudo-dep v0.0.0-20260101000000-000000000099
+	// Deliberately form-1 (vX.0.0-<ts>-<hash>), not vX.Y.Z-0.<ts>-<hash>:
+	// is_pseudo_version() (sync-versions.sh:104) only matches form 1 by
+	// design (barman-cloud's real-world need -- see its own comment). A
+	// form-3 pin here would skip the upstream_release live-check/
+	// substitution branch entirely and pass the ordinary range check by
+	// coincidence, which is exactly what an earlier draft of this fixture
+	// did and rows 15-17 never actually exercised what they claimed to.
+	github.com/example/upstream-dep v0.0.0-20260101000000-eeeeeeeeeeee
+	github.com/example/net-dep v0.0.0-20260101000000-aaaaaaaaaaaa
+)

--- a/scripts/test/fixtures/base/versions.yaml
+++ b/scripts/test/fixtures/base/versions.yaml
@@ -1,0 +1,88 @@
+# Synthetic fixture for scripts/test/. Mirrors the real versions.yaml's shape
+# (see the repo root's own versions.yaml) but every entry is a fake module
+# invented for one specific case or group of cases -- see scripts/test/lib.sh
+# and the plan this harness implements for which rows use which entry.
+
+go:
+  current: "1.26.6"
+
+infrastructure:
+  # Rows 1-10 (validate_mvs_floors). floor-owner's own go.mod is the static
+  # fixtures/base/floor/go.mod; fixtures/stub-go/go answers `go list`/`go mod
+  # edit` for it without ever invoking a real go toolchain.
+  floor-dep:
+    go_module: "github.com/example/floor-dep"
+    floor_module: "github.com/example/floor-owner"
+    notes: "Synthetic MVS-floor dependency for scripts/test/ rows 1-10."
+
+  # Row 11 (below/above supported_range) -- two case files, each mutating
+  # this one entry's own fixture copy independently.
+  range-dep:
+    go_module: "github.com/example/range-dep"
+    supported_range: "2.0"
+    notes: "Synthetic range-check dependency for scripts/test/ row 11."
+
+  # Row 12 (inclusive range boundary) -- two case files, each needing
+  # run_generate before run_check since the pin mutation changes the
+  # committed docs/go-api build-version column.
+  boundary-dep:
+    go_module: "github.com/example/boundary-dep"
+    supported_range: "1.5 - 1.7"
+    notes: "Synthetic boundary dependency for scripts/test/ row 12."
+
+  # Row 13 (version_basis: kubernetes). A dedicated go_module, not k8s.io/api
+  # itself -- rows 18-20 mutate the real k8s.io/api replace directive, and
+  # coupling this entry to the same module would make those mutations also
+  # flip this entry's own range check, muddying what each case proves.
+  k8s-basis-dep:
+    go_module: "github.com/example/k8s-basis-dep"
+    version_basis: "kubernetes"
+    supported_range: "1.36"
+    notes: "Synthetic version_basis:kubernetes dependency for scripts/test/ row 13."
+
+  # Row 14 (pseudo-version, no upstream_release -- range check skipped).
+  pseudo-dep:
+    go_module: "github.com/example/pseudo-dep"
+    supported_range: "9.9"
+    notes: "Synthetic pseudo-version dependency for scripts/test/ row 14; supported_range is deliberately unsatisfiable to prove the range check never runs for it."
+
+  # Rows 15-17 (upstream_release digest checks). Deliberately has NO
+  # upstream_repo -- the live-check network path (rows 29-34) is owned by
+  # net-dep/net-dep-range, kept separate on purpose.
+  upstream-dep:
+    go_module: "github.com/example/upstream-dep"
+    upstream_release: "v3.4.0"
+    upstream_release_commit: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    supported_range: "3.4"
+    notes: "Synthetic upstream_release digest dependency for scripts/test/ rows 15-17."
+
+  # Rows 21-23 (validate_no_sha_in_notes). No go_module/floor_module -- both
+  # validate_gomod and validate_mvs_floors skip an entry lacking them, so
+  # this entry exists purely to carry a notes: field.
+  notes-dep:
+    notes: "notes-dep tracks upstream directly; no special pin logic."
+
+  # Rows 29-31, 33, 34 (validate_gomod's upstream_release live-check path).
+  net-dep:
+    go_module: "github.com/example/net-dep"
+    upstream_repo: "example/net-dep"
+    upstream_release: "v2.9.0"
+    upstream_release_commit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    supported_range: "2.9"
+    notes: "Synthetic live-check dependency for scripts/test/ rows 29-31, 33, 34."
+
+  # Row 32's own net-dep-range entry is NOT here. sync-versions.sh:552
+  # substitutes actual_version with upstream_release unconditionally for any
+  # pseudo-version entry declaring upstream_release, on every resolve_rc
+  # (match, warning, or a plain unreachable default) -- not only when row 32's
+  # own case sets STUB_NET_MODE=match. A first draft put net-dep-range here,
+  # in the base fixture, with supported_range "1.5" bracketing the pin's own
+  # mm but excluding upstream_release's mm "2.9" -- and every other case
+  # (1, 7, 8, 9, 10, 12a, 12b, ...) inherited this entry through new_fixture,
+  # substituted the same way, and failed with "net-dep-range 2.9 ... is
+  # outside supported_range \"1.5\"" for a reason having nothing to do with
+  # what any of those cases were testing. Caught by actually running the
+  # harness (7 of 13 cases failed identically) rather than by more review of
+  # the plan text. Case 32 injects both this entry and its go.mod require
+  # line itself via direct yq/sed calls, so no other case's fixture ever sees
+  # it.

--- a/scripts/test/fixtures/stub-go-absent/go
+++ b/scripts/test/fixtures/stub-go-absent/go
@@ -1,0 +1,7 @@
+#!/bin/bash
+# One-file always-fail `go` shim. Prepended ahead of PATH (including ahead
+# of fixtures/stub-go) by lib.sh's `with_stub_go absent`, so `go` is
+# unresolvable to any real go binary while fixtures/stub-go's curl/git stubs
+# stay reachable. See lib.sh for why this exists instead of truncating PATH.
+echo "stub-go-absent: go is not available" >&2
+exit 127

--- a/scripts/test/fixtures/stub-go/curl
+++ b/scripts/test/fixtures/stub-go/curl
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Stub `curl` for scripts/test/'s resolve_tag_commit() (sync-versions.sh:114-168).
+# Reproduces the -w $'\n%{http_code}' trailer real curl produces for the
+# ref-lookup call, and the plain JSON body for the tag-object peel call.
+# Mode selected by $STUB_NET_MODE (default "unreachable"). See
+# scripts/test/lib.sh's header comment for the full mode table.
+set -euo pipefail
+
+mode="${STUB_NET_MODE:-unreachable}"
+url="${@: -1}"
+
+: "${NETDEP_COMMIT:?NETDEP_COMMIT must be set (see lib.sh)}"
+: "${MISMATCH_COMMIT:?MISMATCH_COMMIT must be set (see lib.sh)}"
+: "${TAGOBJ_SHA:?TAGOBJ_SHA must be set (see lib.sh)}"
+
+if [[ "$url" == */git/ref/tags/* ]]; then
+    # First call: GET .../git/ref/tags/<tag> -- sync-versions.sh:127.
+    case "$mode" in
+        unreachable|ls-remote-match)
+            exit 1
+            ;;
+        mismatch)
+            printf '{"object":{"type":"commit","sha":"%s"}}\n200' "$MISMATCH_COMMIT"
+            ;;
+        match)
+            printf '{"object":{"type":"commit","sha":"%s"}}\n200' "$NETDEP_COMMIT"
+            ;;
+        notfound)
+            printf '\n404'
+            ;;
+        tag-object)
+            printf '{"object":{"type":"tag","sha":"%s"}}\n200' "$TAGOBJ_SHA"
+            ;;
+        *)
+            exit 1
+            ;;
+    esac
+elif [[ "$url" == */git/tags/* ]]; then
+    # Second call: GET .../git/tags/<tag-object-sha> -- the annotated-tag
+    # peel, sync-versions.sh:143. Only ever reached when the first call
+    # returned obj_type=="tag", i.e. mode=tag-object.
+    case "$mode" in
+        tag-object)
+            printf '{"object":{"sha":"%s"}}\n' "$NETDEP_COMMIT"
+            ;;
+        *)
+            exit 1
+            ;;
+    esac
+else
+    echo "stub-curl: unrecognized URL: $url" >&2
+    exit 1
+fi

--- a/scripts/test/fixtures/stub-go/git
+++ b/scripts/test/fixtures/stub-go/git
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Stub `git` for scripts/test/'s resolve_tag_commit() ls-remote fallback
+# (sync-versions.sh:152). Only handles `ls-remote <url> <ref> <ref^{}>`;
+# anything else is unhandled. Mode selected by $STUB_NET_MODE (default
+# "unreachable").
+set -euo pipefail
+
+mode="${STUB_NET_MODE:-unreachable}"
+
+if [[ "${1:-}" != "ls-remote" ]]; then
+    echo "stub-git: unhandled invocation: $*" >&2
+    exit 1
+fi
+shift
+# Remaining args: <url> <ref1> [<ref2>] -- sync-versions.sh:152 passes both
+# "refs/tags/<tag>" and "refs/tags/<tag>^{}"; the peeled form is what a
+# successful match returns (the annotated-tag dereference), matched first by
+# the caller's own awk pass.
+ref2="${3:-${2:-}}"
+
+: "${NETDEP_COMMIT:?NETDEP_COMMIT must be set (see lib.sh)}"
+
+case "$mode" in
+    ls-remote-match)
+        printf '%s\t%s\n' "$NETDEP_COMMIT" "$ref2"
+        ;;
+    *)
+        exit 1
+        ;;
+esac

--- a/scripts/test/fixtures/stub-go/go
+++ b/scripts/test/fixtures/stub-go/go
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Stub `go` for scripts/test/. Intercepts the two calls validate_mvs_floors
+# makes (sync-versions.sh:394,417):
+#   env GOWORK=off go list -C "$REPO_ROOT" -mod=readonly -m -f '{{.GoMod}}' <module>
+#   GOWORK=off go mod edit -json <path>
+# Mode selected by $STUB_GO_MODE (default "ok"). See scripts/test/lib.sh's
+# header comment for the full mode table and rationale.
+set -euo pipefail
+
+mode="${STUB_GO_MODE:-ok}"
+
+# Canned answer for "what does floor-owner's go.mod require for floor-dep" --
+# fixed regardless of mode. Cases mutate the ACTUAL go.mod pin instead (see
+# fixtures/base/go.mod), never this constant, so a mismatch always means a
+# case mutated the real pin, not this stub. Must match lib.sh's
+# FLOOR_REQUIRE_PATH/FLOOR_REQUIRE_VERSION.
+FLOOR_REQUIRE_PATH="github.com/example/floor-dep"
+FLOOR_REQUIRE_VERSION="v0.5.1"
+
+if [[ "${1:-}" == "list" ]]; then
+    shift
+    root=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -C) root="$2"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+    # Invocation-shape check: sync-versions.sh:394 must pass -C "$REPO_ROOT"
+    # -- dropping it (an oracle mutation this harness must be able to catch)
+    # makes this branch never match, degrading to the same failure as
+    # STUB_GO_MODE=missing regardless of the configured mode.
+    if [[ -z "$root" || "$root" != "${SYNC_VERSIONS_REPO_ROOT:-}" ]]; then
+        exit 1
+    fi
+    case "$mode" in
+        ok|norequire|editfail)
+            echo "$root/floor/go.mod"
+            exit 0
+            ;;
+        missing)
+            exit 1
+            ;;
+        badpath)
+            echo "$root/floor/does-not-exist.mod"
+            exit 0
+            ;;
+        hang)
+            sleep 5
+            echo "$root/floor/go.mod"
+            exit 0
+            ;;
+        *)
+            exit 1
+            ;;
+    esac
+elif [[ "${1:-}" == "mod" && "${2:-}" == "edit" ]]; then
+    # Invocation-shape check: sync-versions.sh:417 must run this with
+    # GOWORK=off in its environment -- dropping it (the other oracle
+    # mutation) makes this branch behave as editfail regardless of mode.
+    if [[ "${GOWORK:-}" != "off" ]]; then
+        exit 3
+    fi
+    case "$mode" in
+        ok)
+            printf '{"Require":[{"Path":"%s","Version":"%s"}]}\n' \
+                "$FLOOR_REQUIRE_PATH" "$FLOOR_REQUIRE_VERSION"
+            exit 0
+            ;;
+        norequire)
+            printf '{"Require":[]}\n'
+            exit 0
+            ;;
+        editfail)
+            exit 3
+            ;;
+        *)
+            exit 3
+            ;;
+    esac
+else
+    echo "stub-go: unhandled invocation: $*" >&2
+    exit 1
+fi

--- a/scripts/test/lib.sh
+++ b/scripts/test/lib.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# scripts/test/lib.sh - helpers for scripts/sync-versions.sh's failure-path harness.
+# Sourced by every scripts/test/cases/*.sh file. Never executed directly.
+
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURES_DIR="$TEST_DIR/fixtures"
+SYNC_VERSIONS="$TEST_DIR/../sync-versions.sh"
+
+# Three 40-hex-character placeholder commit SHAs shared by every rows-29-34
+# case. resolve_tag_commit's own format gate (sync-versions.sh:163-164) is
+# `^[0-9a-f]{40}$` -- anything else, even one character short, fails silently
+# into the warning/rc=2 branch instead of exercising the intended one.
+# Generated, never hand-typed: a hand-typed 38-character placeholder in an
+# earlier draft of this harness is exactly the bug this generate-and-assert
+# pair exists to prevent.
+NETDEP_COMMIT=$(printf 'a%.0s' $(seq 40))
+MISMATCH_COMMIT=$(printf 'c%.0s' $(seq 40))
+TAGOBJ_SHA=$(printf 'd%.0s' $(seq 40))
+UPSTREAM_DIGEST_COMMIT=$(printf 'e%.0s' $(seq 40))
+for _v in NETDEP_COMMIT MISMATCH_COMMIT TAGOBJ_SHA UPSTREAM_DIGEST_COMMIT; do
+    _val="${!_v}"
+    _len=${#_val}
+    if [[ "$_len" -ne 40 ]]; then
+        echo "lib.sh: $_v is $_len characters, not 40 -- fix the generator, do not hand-edit the value" >&2
+        exit 1
+    fi
+done
+unset _v _val _len
+export NETDEP_COMMIT MISMATCH_COMMIT TAGOBJ_SHA UPSTREAM_DIGEST_COMMIT
+
+# Fixed constants describing fixtures/base/versions.yaml's floor-dep entry --
+# shared between lib.sh's own documentation and fixtures/stub-go/go, which
+# hardcodes the same two values as its canned `go mod edit -json` answer.
+FLOOR_REQUIRE_PATH="github.com/example/floor-dep"
+FLOOR_REQUIRE_VERSION="v0.5.1"
+export FLOOR_REQUIRE_PATH FLOOR_REQUIRE_VERSION
+
+# Set by new_fixture. Read by every helper below. Never assign via
+# `fx=$(new_fixture)` -- a command-substitution subshell fires new_fixture's
+# own EXIT trap the instant the subshell exits (right after copying),
+# deleting the fixture before the calling case body ever runs. Call it bare.
+FIXTURE=""
+
+# Copies fixtures/base/ into a fresh mktemp -d, creates docs/ and
+# pkg/versions/, runs `generate` once so the two drift guards start green,
+# and registers cleanup. Also arranges PATH so fixtures/stub-go/'s go, curl
+# and git stubs are found ahead of the real ones, defaulting
+# STUB_GO_MODE=ok and STUB_NET_MODE=unreachable -- both are the default for
+# every case, not an opt-in.
+new_fixture() {
+    FIXTURE=$(mktemp -d)
+    trap 'rm -rf "$FIXTURE"' EXIT
+
+    cp -r "$FIXTURES_DIR/base/." "$FIXTURE/"
+    mkdir -p "$FIXTURE/docs" "$FIXTURE/pkg/versions"
+
+    export SYNC_VERSIONS_REPO_ROOT="$FIXTURE"
+    export STUB_GO_MODE="${STUB_GO_MODE:-ok}"
+    export STUB_NET_MODE="${STUB_NET_MODE:-unreachable}"
+    export PATH="$FIXTURES_DIR/stub-go:$PATH"
+
+    local out rc=0
+    out=$("$SYNC_VERSIONS" generate 2>&1) || rc=$?
+    if [[ $rc -ne 0 ]]; then
+        echo "new_fixture: initial 'generate' failed (rc=$rc) -- fixture is broken, not the case under test:" >&2
+        echo "$out" >&2
+        exit 1
+    fi
+}
+
+# yq_set <yaml-path> <value> -- set a scalar in $FIXTURE/versions.yaml.
+# For anything beyond a scalar set (deleting a key, adding a whole new
+# entry), call `yq eval -i '...' "$FIXTURE/versions.yaml"` directly in the
+# case file -- this helper only covers the common case.
+yq_set() {
+    local path="$1" value="$2"
+    yq eval -i "${path} = \"${value}\"" "$FIXTURE/versions.yaml"
+}
+
+# gomod_sub <sed-expr> -- apply a sed substitution to $FIXTURE/go.mod.
+gomod_sub() {
+    sed -i "$1" "$FIXTURE/go.mod"
+}
+
+# run_check / run_generate -- invoke sync-versions.sh against $FIXTURE,
+# capturing stdout, stderr and exit code into $out / $err / $rc. Never lets
+# a non-zero exit abort the case (the harness itself does not run under
+# `set -e`; this is belt-and-braces since lib.sh does set -u/-o pipefail).
+run_check() { _run check; }
+run_generate() { _run generate; }
+
+_run() {
+    local errfile
+    errfile=$(mktemp)
+    rc=0
+    out=$("$SYNC_VERSIONS" "$1" 2>"$errfile") || rc=$?
+    err=$(cat "$errfile")
+    rm -f "$errfile"
+}
+
+assert_rc() {
+    local expected="$1"
+    if [[ "$rc" -ne "$expected" ]]; then
+        echo "FAIL: expected rc=$expected, got rc=$rc" >&2
+        echo "--- stdout ---" >&2; echo "$out" >&2
+        echo "--- stderr ---" >&2; echo "$err" >&2
+        exit 1
+    fi
+}
+
+assert_err_contains() {
+    local needle="$1"
+    if [[ "$err" != *"$needle"* ]]; then
+        echo "FAIL: stderr does not contain: $needle" >&2
+        echo "--- stdout ---" >&2; echo "$out" >&2
+        echo "--- stderr ---" >&2; echo "$err" >&2
+        exit 1
+    fi
+}
+
+assert_out_contains() {
+    local needle="$1"
+    if [[ "$out" != *"$needle"* ]]; then
+        echo "FAIL: stdout does not contain: $needle" >&2
+        echo "--- stdout ---" >&2; echo "$out" >&2
+        echo "--- stderr ---" >&2; echo "$err" >&2
+        exit 1
+    fi
+}
+
+assert_out_not_contains() {
+    local needle="$1"
+    if [[ "$out" == *"$needle"* ]]; then
+        echo "FAIL: stdout unexpectedly contains: $needle" >&2
+        echo "--- stdout ---" >&2; echo "$out" >&2
+        exit 1
+    fi
+}
+
+# with_stub_go <mode> -- override STUB_GO_MODE (default "ok", set by
+# new_fixture) for a case needing missing/badpath/norequire/editfail/hang
+# instead, or "absent" for the one-file always-fail shim (see below).
+# Must be called AFTER new_fixture.
+with_stub_go() {
+    local mode="$1"
+    if [[ "$mode" == "absent" ]]; then
+        # Don't exclude go's real bindir from PATH -- its location varies by
+        # install method, and a flat PATH truncation also drops yq, tripping
+        # check_dependencies before the guard under test even runs. Instead
+        # prepend a one-file always-fail `go` shim ahead of PATH, including
+        # ahead of fixtures/stub-go -- this makes `go` unresolvable to any
+        # real go binary while leaving fixtures/stub-go's own curl/git stubs
+        # reachable, so the net-dep live-check path stays hermetic even
+        # though go is gone.
+        export PATH="$FIXTURES_DIR/stub-go-absent:$PATH"
+    else
+        export STUB_GO_MODE="$mode"
+    fi
+}
+
+# with_stub_net <mode> -- override STUB_NET_MODE (default "unreachable", set
+# by new_fixture) for a case needing mismatch, match, notfound, tag-object
+# or ls-remote-match instead (rows 29-34).
+with_stub_net() {
+    export STUB_NET_MODE="$1"
+}

--- a/scripts/test/lib.sh
+++ b/scripts/test/lib.sh
@@ -80,8 +80,13 @@ yq_set() {
 }
 
 # gomod_sub <sed-expr> -- apply a sed substitution to $FIXTURE/go.mod.
+# Temp-file + mv, not `sed -i` -- BSD/macOS sed's `-i` takes the backup
+# suffix as its next (mandatory) argument, so `sed -i "$1"` would consume
+# $1 itself as that suffix and leave go.mod unedited on any non-GNU sed.
+# Same pattern as scripts/sync-tool-versions.sh's own Makefile/ci.yml/docs
+# edits, for the same reason.
 gomod_sub() {
-    sed -i "$1" "$FIXTURE/go.mod"
+    sed "$1" "$FIXTURE/go.mod" > "$FIXTURE/go.mod.tmp" && mv "$FIXTURE/go.mod.tmp" "$FIXTURE/go.mod"
 }
 
 # run_check / run_generate -- invoke sync-versions.sh against $FIXTURE,

--- a/scripts/test/lib.sh
+++ b/scripts/test/lib.sh
@@ -105,7 +105,14 @@ run_generate() { _run generate; }
 
 _run() {
     local errfile
-    errfile=$(mktemp)
+    errfile=$(mktemp) || {
+        echo "_run: mktemp failed -- refusing to run '$SYNC_VERSIONS $1' without a place to capture stderr" >&2
+        exit 1
+    }
+    if [[ -z "$errfile" || ! -f "$errfile" ]]; then
+        echo "_run: mktemp produced an unusable path ('$errfile') -- refusing to continue" >&2
+        exit 1
+    fi
     rc=0
     out=$("$SYNC_VERSIONS" "$1" 2>"$errfile") || rc=$?
     err=$(cat "$errfile")

--- a/scripts/test/lib.sh
+++ b/scripts/test/lib.sh
@@ -15,10 +15,10 @@ SYNC_VERSIONS="$TEST_DIR/../sync-versions.sh"
 # Generated, never hand-typed: a hand-typed 38-character placeholder in an
 # earlier draft of this harness is exactly the bug this generate-and-assert
 # pair exists to prevent.
-NETDEP_COMMIT=$(printf 'a%.0s' $(seq 40))
-MISMATCH_COMMIT=$(printf 'c%.0s' $(seq 40))
-TAGOBJ_SHA=$(printf 'd%.0s' $(seq 40))
-UPSTREAM_DIGEST_COMMIT=$(printf 'e%.0s' $(seq 40))
+NETDEP_COMMIT=$(printf 'a%.0s' {1..40})
+MISMATCH_COMMIT=$(printf 'c%.0s' {1..40})
+TAGOBJ_SHA=$(printf 'd%.0s' {1..40})
+UPSTREAM_DIGEST_COMMIT=$(printf 'e%.0s' {1..40})
 for _v in NETDEP_COMMIT MISMATCH_COMMIT TAGOBJ_SHA UPSTREAM_DIGEST_COMMIT; do
     _val="${!_v}"
     _len=${#_val}
@@ -50,7 +50,14 @@ FIXTURE=""
 # STUB_GO_MODE=ok and STUB_NET_MODE=unreachable -- both are the default for
 # every case, not an opt-in.
 new_fixture() {
-    FIXTURE=$(mktemp -d)
+    FIXTURE=$(mktemp -d) || {
+        echo "new_fixture: mktemp -d failed -- refusing to continue (would otherwise copy into an empty/unset path)" >&2
+        exit 1
+    }
+    if [[ -z "$FIXTURE" || ! -d "$FIXTURE" ]]; then
+        echo "new_fixture: mktemp -d produced an unusable path ('$FIXTURE') -- refusing to continue" >&2
+        exit 1
+    fi
     trap 'rm -rf "$FIXTURE"' EXIT
 
     cp -r "$FIXTURES_DIR/base/." "$FIXTURE/"

--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -12,12 +12,25 @@ failed_names=()
 
 for case_file in "$TEST_DIR"/cases/*.sh; do
     name="$(basename "$case_file" .sh)"
-    # Each case runs in its own subshell: lib.sh's FIXTURE/PATH/env state
-    # (set via `export` and a bare global, never a subshell-scoped
+    # Each case runs as its own `bash` process: lib.sh's FIXTURE/PATH/env
+    # state (set via `export` and a bare global, never a subshell-scoped
     # assignment) must not leak between cases, and a case that dies mid-run
     # (an unguarded assert calling `exit 1`) must not take the runner down
     # with it.
-    if out=$(bash "$case_file" 2>&1); then
+    #
+    # `env -u` clears the four harness control variables from the CALLER's
+    # environment before each case. lib.sh applies its documented defaults
+    # with `${VAR:-default}`, which preserves an inherited value -- so an
+    # ambient STUB_GO_MODE/STUB_NET_MODE (say, left exported by a debugging
+    # session) would silently run every case in a mode it never asked for,
+    # and an ambient SYNC_VERSIONS_REPO_ROOT/SYNC_VERSIONS_PROBE_TIMEOUT
+    # would reach sync-versions.sh directly. Clearing them here rather than
+    # hard-assigning in lib.sh keeps `with_stub_go`/`with_stub_net` and case
+    # 9's own SYNC_VERSIONS_PROBE_TIMEOUT override working unchanged, since
+    # those all run after new_fixture.
+    if out=$(env -u STUB_GO_MODE -u STUB_NET_MODE \
+                 -u SYNC_VERSIONS_REPO_ROOT -u SYNC_VERSIONS_PROBE_TIMEOUT \
+                 bash "$case_file" 2>&1); then
         pass=$((pass + 1))
         printf 'PASS %s\n' "$name"
     else

--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# scripts/test/run-tests.sh - runs every scripts/test/cases/*.sh in isolation
+# and reports pass/fail. Hermetic and network-independent: see
+# scripts/test/lib.sh and fixtures/stub-go/{go,curl,git} for how.
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pass=0
+fail=0
+failed_names=()
+
+for case_file in "$TEST_DIR"/cases/*.sh; do
+    name="$(basename "$case_file" .sh)"
+    # Each case runs in its own subshell: lib.sh's FIXTURE/PATH/env state
+    # (set via `export` and a bare global, never a subshell-scoped
+    # assignment) must not leak between cases, and a case that dies mid-run
+    # (an unguarded assert calling `exit 1`) must not take the runner down
+    # with it.
+    if out=$(bash "$case_file" 2>&1); then
+        pass=$((pass + 1))
+        printf 'PASS %s\n' "$name"
+    else
+        fail=$((fail + 1))
+        failed_names+=("$name")
+        printf 'FAIL %s\n' "$name"
+        printf '%s\n' "$out" | sed 's/^/    /'
+    fi
+done
+
+echo ""
+echo "$pass passed, $fail failed"
+
+if [[ $fail -gt 0 ]]; then
+    echo "Failed: ${failed_names[*]}"
+    exit 1
+fi
+exit 0

--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -18,18 +18,25 @@ for case_file in "$TEST_DIR"/cases/*.sh; do
     # (an unguarded assert calling `exit 1`) must not take the runner down
     # with it.
     #
-    # `env -u` clears the four harness control variables from the CALLER's
+    # `env -u` clears the harness control variables from the CALLER's
     # environment before each case. lib.sh applies its documented defaults
     # with `${VAR:-default}`, which preserves an inherited value -- so an
     # ambient STUB_GO_MODE/STUB_NET_MODE (say, left exported by a debugging
     # session) would silently run every case in a mode it never asked for,
     # and an ambient SYNC_VERSIONS_REPO_ROOT/SYNC_VERSIONS_PROBE_TIMEOUT
-    # would reach sync-versions.sh directly. Clearing them here rather than
-    # hard-assigning in lib.sh keeps `with_stub_go`/`with_stub_net` and case
-    # 9's own SYNC_VERSIONS_PROBE_TIMEOUT override working unchanged, since
-    # those all run after new_fixture.
+    # would reach sync-versions.sh directly. GOWORK is cleared for the same
+    # reason: fixtures/stub-go/go's invocation-shape check for
+    # sync-versions.sh:417's `GOWORK=off go mod edit` call works by testing
+    # whether GOWORK=off reaches the stub -- an ambient GOWORK=off exported
+    # by the caller (a documented AGENTS.md workflow) would already satisfy
+    # that test regardless of whether sync-versions.sh itself still sets it,
+    # silently disabling detection of that oracle mutation. Clearing them
+    # here rather than hard-assigning in lib.sh keeps `with_stub_go`/
+    # `with_stub_net` and case 9's own SYNC_VERSIONS_PROBE_TIMEOUT override
+    # working unchanged, since those all run after new_fixture.
     if out=$(env -u STUB_GO_MODE -u STUB_NET_MODE \
                  -u SYNC_VERSIONS_REPO_ROOT -u SYNC_VERSIONS_PROBE_TIMEOUT \
+                 -u GOWORK \
                  bash "$case_file" 2>&1); then
         pass=$((pass + 1))
         printf 'PASS %s\n' "$name"


### PR DESCRIPTION
Closes go-kure/kure#711.

## Problem

`scripts/sync-versions.sh` has six guards wired into `check` (`validate_gomod`,
`validate_gomod_pin_comment`, `validate_no_sha_in_notes`, `validate_mvs_floors`,
`validate_docs_drift`, `validate_go_api_drift`). CI only ever runs them against a repo
state where they all pass — nothing proved a guard actually **fails** when it should.
That coverage instead came from a mutation matrix run by hand, three times in two days
(#699, #702, #707). #707's own review flagged the gap as deferred, out-of-scope work
(never filed until now).

## Change

- `scripts/sync-versions.sh`: two lines (`SYNC_VERSIONS_REPO_ROOT`,
  `SYNC_VERSIONS_PROBE_TIMEOUT`), both test-only overrides — the real-invocation default
  is byte-identical.
- `scripts/test/`: a hermetic, network-independent mutation-matrix harness. 36 cases
  against a synthetic fixture tree, with stub `go`/`curl`/`git` binaries covering every
  external dependency the guards touch (the MVS-floor `go list`/`go mod edit` calls, and
  the `upstream_release` live tag-resolution path).
- `mise.toml`: new `versions:test` task, added to `verify`'s depends.
- `.github/workflows/ci.yml`: new step running the harness; `scripts/test/**` added to
  the path filter so a PR touching only the harness still runs it.
- `docs/dependency-updates.md`: new "Testing the guards" subsection.

## Verification

- All 36 cases pass (`mise run versions:test`).
- **Oracle**: 4 independent mutations to the production script (drop `-C "$REPO_ROOT"`,
  drop `GOWORK=off`, drop the `timeout` wrapper, change an error string) each broke
  exactly the case the plan predicted — proves the harness can go red, not just green.
- `mise run versions:check` unchanged, from the worktree root and from an absolute-path
  invocation with cwd outside it.
- Hermetic under `GOPROXY=off` and with real `curl`/`git` shimmed to always-fail ahead
  of `PATH`.
- Full `mise run verify` green.

https://claude.ai/code/session_01LSHxoXKa24DszxSCVRc9NX
