### PR TITLE
chore(ci): drop stale ready_for_review from pr-review workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,13 +2,7 @@ name: PR Review
 
 on:
   pull_request:
-    # ready_for_review kept (2026-08-19): the callee (pr-review.yml) is pinned @main, so its
-    # no-longer-draft-gated behavior only lands here once that reusable workflow's own PR
-    # merges to main — an async rollout window this caller cannot see. A PR whose own branch
-    # already dropped this type, marked ready with no further push, gets no re-trigger at all
-    # until that merge completes. Cost is one redundant run at ready-time once the rollout is
-    # done; ci.yml has no such gap (self-contained per-branch, not pinned) and correctly omits it.
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
   # Required so this check reports (as `skipped`/success, via the callee's existing fork `if:`)
   # on the merge queue's temporary ref. A required context that never triggers stays pending
   # forever and stalls every queue entry for check_response_timeout_minutes (60), then ejects

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -329,21 +329,17 @@ managed centrally in `go-kure/.github` (`governance/repository-settings-policy.y
 
 ### Triggers
 
-- Pull requests: `opened`, `synchronize`, `reopened`, `ready_for_review`
+- Pull requests: `opened`, `synchronize`, `reopened`, on GitHub's default types
 - `merge_group` (no filters): required so this check reports on the merge queue's temporary
   ref once it becomes a required status check — the queue payload has no `pull_request` field,
   so the existing fork skip below evaluates false and the job reports `skipped`/success as a
   no-op
-- Runs on draft PRs (2026-08-19, GitLab `mr-review` parity — see [Draft PRs](#draft-prs)) —
-  **effective once go-kure/.github#75 merges**; until then the callee (`pr-review.yml@main`)
-  still gates on `draft == false`, so a draft PR here still gets a skipped reviewer job, and
-  `ready_for_review` below is what actually triggers the review; skips fork PRs (self-hosted
-  runner security)
-- `ready_for_review` is kept here (unlike `ci.yml`, which omits it) because the reviewer itself
-  lives in `go-kure/.github` and is called `@main`: its no-longer-draft-gated behavior only takes
-  effect once that repo's own parity change merges, an async window this caller can't see. Without
-  the type, a PR whose branch already dropped it and gets marked ready with no further push gets no
-  re-trigger until that merge lands. Costs one redundant run at ready-time once the rollout is done.
+- Runs on draft PRs the same as ready ones (2026-08-19, GitLab `mr-review` parity — see
+  [Draft PRs](#draft-prs)); skips fork PRs (self-hosted runner security)
+- `ready_for_review` is not declared, same reasoning as `ci.yml`: it was kept as a rollout-window
+  safety net while the callee (`pr-review.yml@main`, in `go-kure/.github`) still gated on
+  `draft == false` (its own parity fix landed 2026-08-19, `46dfc88`) and dropped once that window
+  closed.
 
 ### How It Works
 


### PR DESCRIPTION
Rollout-window safety net for go-kure/.github#75 (the callee's own draft-gate removal, 46dfc88) — closed 2026-08-19. \`ci.yml\` already omits this type for the same reason.

Claude-Session: https://claude.ai/code/session_014V3DiHzq3GW7gfZF4F7k9j