### PR TITLE
fix: harden sync-versions.sh/vendor-guard.sh against missing timeout/mktemp

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -63,6 +63,24 @@ Enforced via the `main-protection` [repository ruleset](https://github.com/go-ku
 
 ### 1. Initial Setup
 
+**Prerequisites:**
+
+- `go` and `mise` — required
+- `make`, `git` — required
+- `bash` 4+ — required
+- `yq` — required by `scripts/sync-versions.sh`; pinned in `mise.toml`
+- `mktemp` — required by `scripts/sync-versions.sh` and `scripts/vendor-guard.sh`. An external
+  coreutils utility, not a bash builtin, but present on virtually every host with coreutils
+  installed; both scripts name the failure clearly on the rare host without it.
+- `timeout` (or macOS Homebrew's `gtimeout`) from GNU coreutils — split by scope, not one blanket
+  status:
+  - **optional for `scripts/sync-versions.sh check`** (production runtime): the two bounded
+    probes it uses degrade gracefully to running unbounded, with a startup warning, when neither
+    binary is found.
+  - **required to run the full local gate** (`mise run verify` / `scripts/test/run-tests.sh`):
+    pre-existing harness case `09-mvs-floor-hang-timeout.sh` needs a real `timeout`/`gtimeout` to
+    bound its stubbed probe — see `docs/dependency-updates.md`'s harness section for the caveat.
+
 ```bash
 # Install dependencies
 make deps

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -69,17 +69,19 @@ Enforced via the `main-protection` [repository ruleset](https://github.com/go-ku
 - `make`, `git` — required
 - `bash` 4+ — required
 - `yq` — required by `scripts/sync-versions.sh`; pinned in `mise.toml`
-- `mktemp` — required by `scripts/sync-versions.sh` and `scripts/vendor-guard.sh`. An external
-  coreutils utility, not a bash builtin, but present on virtually every host with coreutils
-  installed; both scripts name the failure clearly on the rare host without it.
+- `mktemp` — required by `scripts/sync-versions.sh` and `scripts/vendor-guard.sh`, and also by the
+  `scripts/test/` harness itself (`lib.sh`'s `new_fixture`/`_run`). An external coreutils utility,
+  not a bash builtin, but present on virtually every host with coreutils installed; the two
+  scripts name the failure clearly on the rare host without it.
 - `timeout` (or macOS Homebrew's `gtimeout`) from GNU coreutils — split by scope, not one blanket
   status:
   - **optional for `scripts/sync-versions.sh check`** (production runtime): the two bounded
     probes it uses degrade gracefully to running unbounded, with a startup warning, when neither
     binary is found.
   - **required to run the full local gate** (`mise run verify` / `scripts/test/run-tests.sh`):
-    pre-existing harness case `09-mvs-floor-hang-timeout.sh` needs a real `timeout`/`gtimeout` to
-    bound its stubbed probe — see `docs/dependency-updates.md`'s harness section for the caveat.
+    harness cases `09-mvs-floor-hang-timeout.sh` (pre-existing) and
+    `36-timeout-present-no-warning.sh` (new) both need a real `timeout`/`gtimeout` to pass — see
+    `docs/dependency-updates.md`'s harness section for the caveat.
 
 ```bash
 # Install dependencies

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -217,6 +217,26 @@ assert_err_contains '<the exact error substring the guard must emit>'
 failure path is, by this harness's own standard, unproven — the whole point is that CI
 should never again be able to report green while a guard silently stopped guarding.
 
+**Portable-environment prerequisites (`timeout`, `mktemp`).** The harness itself needs no
+network. Without a `timeout`/`gtimeout` binary on `PATH`, `sync-versions.sh check` runs its
+two bounded probes (the MVS-floor `go list` lookup and the tag-resolution `git ls-remote`
+fallback) unbounded instead, and says so once at startup — `generate` never reaches either
+probe, so it is unaffected either way. This is production-runtime graceful degradation, not
+a hard requirement — see `DEVELOPMENT.md`'s Prerequisites block for the full split.
+
+That degradation does **not** extend to the test harness itself: pre-existing case
+`09-mvs-floor-hang-timeout.sh` needs a real `timeout`/`gtimeout` on the machine *running the
+test suite* — it hangs a stubbed `go` and asserts `SYNC_VERSIONS_PROBE_TIMEOUT` bounds it. On
+a host with neither binary, that case (and therefore `run-tests.sh` / `mise run verify`)
+hangs instead of failing loudly. This is a test-harness-only prerequisite, narrower than and
+separate from production's graceful degradation.
+
+`mise registry` maps `coreutils` to `aqua:uutils/coreutils`; checked directly against a local
+install, that backend provisions one multi-call `coreutils` binary (a `timeout` applet is
+reachable only via `coreutils timeout ...`), never a standalone binary literally named
+`timeout` — so it is **not** pinned in `mise.toml` for this. `yq` remains the only
+externally-required tool mise provisions for this script.
+
 ## Update Risk Levels
 
 ### Patch Updates (Low Risk)

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -226,10 +226,13 @@ a hard requirement — see `DEVELOPMENT.md`'s Prerequisites block for the full s
 
 That degradation does **not** extend to the test harness itself: pre-existing case
 `09-mvs-floor-hang-timeout.sh` needs a real `timeout`/`gtimeout` on the machine *running the
-test suite* — it hangs a stubbed `go` and asserts `SYNC_VERSIONS_PROBE_TIMEOUT` bounds it. On
-a host with neither binary, that case (and therefore `run-tests.sh` / `mise run verify`)
-hangs instead of failing loudly. This is a test-harness-only prerequisite, narrower than and
-separate from production's graceful degradation.
+test suite* — it stubs `go list` to sleep 5s (faking a hang) and asserts
+`SYNC_VERSIONS_PROBE_TIMEOUT` bounds it to ~1s. On a host with neither binary, the probe isn't
+bounded, so the stub's 5s sleep runs to completion, `go list` "succeeds", and the case fails
+on its warning-text assertion (~5s), not by hanging indefinitely — the fixed-length stub bounds
+even the unbounded path in this one test. This is a test-harness-only prerequisite, narrower
+than and separate from production's graceful degradation, where a real stalled module proxy or
+git remote has no such bound.
 
 `mise registry` maps `coreutils` to `aqua:uutils/coreutils`; checked directly against a local
 install, that backend provisions one multi-call `coreutils` binary (a `timeout` applet is

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -225,14 +225,24 @@ probe, so it is unaffected either way. This is production-runtime graceful degra
 a hard requirement — see `DEVELOPMENT.md`'s Prerequisites block for the full split.
 
 That degradation does **not** extend to the test harness itself: pre-existing case
-`09-mvs-floor-hang-timeout.sh` needs a real `timeout`/`gtimeout` on the machine *running the
-test suite* — it stubs `go list` to sleep 5s (faking a hang) and asserts
+`09-mvs-floor-hang-timeout.sh` and this PR's own `36-timeout-present-no-warning.sh` both need a
+real `timeout`/`gtimeout` on the machine *running the test suite* to pass — this is a
+test-harness-only prerequisite, narrower than and separate from production's graceful
+degradation, where a real stalled module proxy or git remote has no such bound.
+
+For case 09: it stubs `go list` to sleep 5s (faking a hang) and asserts
 `SYNC_VERSIONS_PROBE_TIMEOUT` bounds it to ~1s. On a host with neither binary, the probe isn't
-bounded, so the stub's 5s sleep runs to completion, `go list` "succeeds", and the case fails
-on its warning-text assertion (~5s), not by hanging indefinitely — the fixed-length stub bounds
-even the unbounded path in this one test. This is a test-harness-only prerequisite, narrower
-than and separate from production's graceful degradation, where a real stalled module proxy or
-git remote has no such bound.
+bounded, so the stub's 5s sleep runs to completion and `go list` "succeeds" (echoing a `go.mod`
+path) — but the case does **not** then fail on its warning-text assertion. The unbounded
+success reaches step 4 (`go mod edit -json` against that path), which the same stub fails for
+every mode but `ok`/`norequire`/`editfail`; `validate_mvs_floors` reports this as a hard
+**error** ("could not read ... go.mod requirements ... rc=3"), not the "could not resolve ...
+skipping" **warning** the case asserts, so `check` itself exits 1. The case therefore fails on
+its earlier `assert_rc 0`, not on the warning-text assertion, in ~6-11s (the 5s sleep plus the
+rest of `check`'s own guards) — confirmed by direct reproduction, not by hanging indefinitely.
+For case 36: with no real `timeout`/`gtimeout`, `resolve_timeout_bin` cannot resolve `TIMEOUT_BIN`
+and emits its startup warning, which is exactly the text `36-timeout-present-no-warning.sh`
+asserts is *absent* — so the case fails outright rather than skipping.
 
 `mise registry` maps `coreutils` to `aqua:uutils/coreutils`; checked directly against a local
 install, that backend provisions one multi-call `coreutils` binary (a `timeout` applet is

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -100,17 +100,29 @@ run_bounded() {
 }
 
 # make_temp <what> [mktemp-args...] -- echo a usable temp path or fail loudly.
-# Callers must use `|| return 1`: an unchecked empty path turns into an
-# ambiguous redirect or a `rm -f ''` RETURN trap instead of an explanation.
+# Callers must use `|| return 1`: an unchecked empty path turns into a
+# redirect to an empty filename (bash: "line N: : No such file or directory",
+# not an "ambiguous redirect" -- that specific message needs an unquoted
+# multi-/zero-word expansion, which "$DOCS_FILE"/"$GO_API_FILE" never are)
+# or a `rm -f ''` RETURN trap instead of an explanation.
 make_temp() {
     local what="$1"
     shift
     local path
-    path=$(mktemp "$@") || {
-        error "$what: mktemp failed -- no writable temporary directory (check \$TMPDIR and free space)"
+    # ${1+"$@"}, not a bare "$@": with zero mktemp-args (every call site here
+    # except generate_go_api's), "$@" has zero positional params -- referencing
+    # it under `set -u` is only safe on bash >= 4.4 (earlier bash raises
+    # "$@: unbound variable"). ${1+"$@"} sidesteps that entirely: it expands to
+    # nothing when there are no positional params, to "$@" unchanged otherwise.
+    path=$(mktemp ${1+"$@"}) || {
+        error "$what: mktemp failed -- either the mktemp binary is missing, or it could not create a file (check \$TMPDIR and free space)"
         return 1
     }
-    if [[ -z "$path" || ! -e "$path" ]]; then
+    # -f, not -e: every call site here (see above) has mktemp create a plain
+    # file, never a directory -- a future caller passing mktemp's `-d` would
+    # need its own review of the downstream cat/mv usage, not a silent pass
+    # through this check.
+    if [[ -z "$path" || ! -f "$path" ]]; then
         error "$what: mktemp produced an unusable path ('$path')"
         return 1
     fi
@@ -886,10 +898,16 @@ validate_docs_drift() {
     info ""
     info "Validating generated documentation is current..."
 
-    local expected
+    local expected cleanup_cmd
     expected=$(make_temp "validate_docs_drift") || return 1
-    # shellcheck disable=SC2064  # expand $expected now, not at trap time
-    trap "rm -f '$expected' '$expected.diff'" RETURN
+    # %q-quote both paths before building the trap string: a literal single
+    # quote anywhere in $expected (e.g. from a TMPDIR containing one) would
+    # otherwise break out of the '...' quoting below and either error at trap
+    # time or silently skip the rm -f, leaking both temp files -- reproduced
+    # directly against TMPDIR="/tmp/quote'dir" before this fix.
+    printf -v cleanup_cmd 'rm -f %q %q' "$expected" "$expected.diff"
+    # shellcheck disable=SC2064  # expand $expected now (already %q-quoted), not at trap time
+    trap "$cleanup_cmd" RETURN
 
     generate_docs "$expected" >/dev/null || return 1
 
@@ -916,10 +934,13 @@ validate_go_api_drift() {
     info ""
     info "Validating generated Go version API is current..."
 
-    local expected
+    local expected cleanup_cmd
     expected=$(make_temp "validate_go_api_drift") || return 1
-    # shellcheck disable=SC2064  # expand $expected now, not at trap time
-    trap "rm -f '$expected' '$expected.diff'" RETURN
+    # See validate_docs_drift's identical comment: %q-quote before building
+    # the trap string so a literal single quote in $expected cannot break it.
+    printf -v cleanup_cmd 'rm -f %q %q' "$expected" "$expected.diff"
+    # shellcheck disable=SC2064  # expand $expected now (already %q-quoted), not at trap time
+    trap "$cleanup_cmd" RETURN
 
     generate_go_api "$expected" >/dev/null || return 1
 

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -24,6 +24,9 @@
 #                                 the one it lives in -- do not set it outside the test harness.
 #   SYNC_VERSIONS_PROBE_TIMEOUT - override the 10s timeout on the validate_mvs_floors `go list`
 #                                 probe, so the harness's timeout case runs in ~1s instead of 10s.
+#   SYNC_VERSIONS_TIMEOUT_CMD   - override the resolved `timeout`/`gtimeout` binary name (even to
+#                                 "" for none), so the harness can exercise the unbounded fallback
+#                                 without making a real `timeout` unresolvable on PATH.
 
 set -euo pipefail
 
@@ -52,6 +55,66 @@ check_dependencies() {
         error "yq is required but not installed. Install with: brew install yq"
         exit 1
     fi
+}
+
+# Resolved once, from the start of the `check)` branch in main() -- not from
+# check_dependencies, and not for `generate` (see below). Empty means "no
+# bounded-execution binary available" -- run_bounded then runs the command
+# unbounded.
+TIMEOUT_BIN=""
+
+resolve_timeout_bin() {
+    # Test-only override: set (even to "") it wins, so the harness can exercise
+    # the unbounded fallback without making `timeout` unresolvable on PATH --
+    # a PATH truncation would also drop yq and trip check_dependencies first.
+    if [[ -n "${SYNC_VERSIONS_TIMEOUT_CMD+set}" ]]; then
+        TIMEOUT_BIN="$SYNC_VERSIONS_TIMEOUT_CMD"
+    else
+        local candidate
+        for candidate in timeout gtimeout; do
+            if command -v "$candidate" >/dev/null 2>&1; then
+                TIMEOUT_BIN="$candidate"
+                break
+            fi
+        done
+    fi
+    # Empty either way it got here means run_bounded runs unbounded -- warn
+    # once regardless of which branch produced it (a warning inside the
+    # override branch only would never fire for case 35's SYNC_VERSIONS_TIMEOUT_CMD="").
+    if [[ -z "$TIMEOUT_BIN" ]]; then
+        warning "no 'timeout' (or 'gtimeout') on PATH -- the MVS-floor go.mod probe and the git ls-remote tag lookup will run unbounded, so a stalled module proxy or git remote can hang this script. Install GNU coreutils to restore the bound."
+    fi
+}
+
+# run_bounded <seconds> <command...> -- bound the command when a timeout
+# binary exists, otherwise run it as-is. Keeps the caller's exit status and
+# stdout unchanged in both cases, so every rc test downstream is unaffected.
+run_bounded() {
+    local seconds="$1"
+    shift
+    if [[ -n "$TIMEOUT_BIN" ]]; then
+        "$TIMEOUT_BIN" "$seconds" "$@"
+    else
+        "$@"
+    fi
+}
+
+# make_temp <what> [mktemp-args...] -- echo a usable temp path or fail loudly.
+# Callers must use `|| return 1`: an unchecked empty path turns into an
+# ambiguous redirect or a `rm -f ''` RETURN trap instead of an explanation.
+make_temp() {
+    local what="$1"
+    shift
+    local path
+    path=$(mktemp "$@") || {
+        error "$what: mktemp failed -- no writable temporary directory (check \$TMPDIR and free space)"
+        return 1
+    }
+    if [[ -z "$path" || ! -e "$path" ]]; then
+        error "$what: mktemp produced an unusable path ('$path')"
+        return 1
+    fi
+    printf '%s' "$path"
 }
 
 # Extract version from go.mod for a given module
@@ -149,7 +212,7 @@ resolve_tag_commit() {
             return 1
         fi
         local ls_remote_out
-        ls_remote_out="$(timeout 5 git ls-remote "https://github.com/${repo}" "refs/tags/${tag}" "refs/tags/${tag}^{}" 2>/dev/null)"
+        ls_remote_out="$(run_bounded 5 git ls-remote "https://github.com/${repo}" "refs/tags/${tag}" "refs/tags/${tag}^{}" 2>/dev/null)"
         local ls_remote_rc=$?
         commit="$(printf '%s\n' "$ls_remote_out" | awk -v r="refs/tags/${tag}^{}" '$2 == r {print $1; found=1} END {exit !found}' || true)"
         if [[ -z "$commit" ]]; then
@@ -235,7 +298,7 @@ sync_gomod_pin_comment() {
     expected=$(expected_gomod_pin_comment) || return 1
 
     local tmp
-    tmp=$(mktemp)
+    tmp=$(make_temp "sync_gomod_pin_comment") || return 1
     if grep -qE '^// Current pin: ' "$GO_MOD_FILE"; then
         awk -v repl="$expected" '
             /^\/\/ Current pin: / { print repl; next }
@@ -338,10 +401,13 @@ validate_no_sha_in_notes() {
 # that invokes the script by absolute path from outside the checkout has no
 # enclosing go.mod, silently degrading to the warning branch below instead of
 # actually running the check.
-# timeout 10: this is the one external-resolution call in this function, and
-# a stalled module-proxy connection would otherwise hang here indefinitely
-# instead of reaching the warning branch promptly -- same discipline as
-# resolve_tag_commit()'s `timeout 5 git ls-remote` / `curl --max-time 5`.
+# run_bounded ... 10: this is the one external-resolution call in this
+# function, and a stalled module-proxy connection would otherwise hang here
+# indefinitely instead of reaching the warning branch promptly -- same
+# discipline as resolve_tag_commit()'s `run_bounded 5 git ls-remote` /
+# `curl --max-time 5`. When no `timeout`/`gtimeout` binary is on PATH,
+# run_bounded degrades to running the command unbounded (resolve_timeout_bin
+# warns once at startup); this probe can then hang on a stalled proxy.
 #
 # Three-way outcome, same discipline as resolve_tag_commit(): success,
 # definitive error, or (only for the "can we even ask the question" step)
@@ -391,7 +457,7 @@ validate_mvs_floors() {
         # network) degrades to a warning -- this is the "can we even ask"
         # step, not the comparison itself.
         local gomod_path gomod_rc=0
-        gomod_path=$(timeout "${SYNC_VERSIONS_PROBE_TIMEOUT:-10}" env GOWORK=off go list -C "$REPO_ROOT" -mod=readonly -m -f '{{.GoMod}}' "$floor_module" 2>/dev/null) || gomod_rc=$?
+        gomod_path=$(run_bounded "${SYNC_VERSIONS_PROBE_TIMEOUT:-10}" env GOWORK=off go list -C "$REPO_ROOT" -mod=readonly -m -f '{{.GoMod}}' "$floor_module" 2>/dev/null) || gomod_rc=$?
         if [[ $gomod_rc -ne 0 || -z "$gomod_path" || ! -f "$gomod_path" ]]; then
             warning "$dep: could not resolve $floor_module's own go.mod (no Go, cold module cache, or no network) -- skipping MVS-floor equality check"
             continue
@@ -745,7 +811,7 @@ generate_go_api() {
     # into a temp file was meant to prevent. Co-locating keeps `mv` a same-
     # filesystem rename(2), which is atomic.
     local tmp
-    tmp=$(mktemp "$(dirname "$out")/.versions_gen.XXXXXX")
+    tmp=$(make_temp "generate_go_api" "$(dirname "$out")/.versions_gen.XXXXXX") || return 1
 
     {
         printf '// Code generated by scripts/sync-versions.sh from versions.yaml. DO NOT EDIT.\n\n'
@@ -821,11 +887,11 @@ validate_docs_drift() {
     info "Validating generated documentation is current..."
 
     local expected
-    expected=$(mktemp)
+    expected=$(make_temp "validate_docs_drift") || return 1
     # shellcheck disable=SC2064  # expand $expected now, not at trap time
     trap "rm -f '$expected' '$expected.diff'" RETURN
 
-    generate_docs "$expected" >/dev/null
+    generate_docs "$expected" >/dev/null || return 1
 
     if diff -u "$DOCS_FILE" "$expected" > "$expected.diff" 2>&1; then
         success "$(basename "$DOCS_FILE") is up to date"
@@ -851,7 +917,7 @@ validate_go_api_drift() {
     info "Validating generated Go version API is current..."
 
     local expected
-    expected=$(mktemp)
+    expected=$(make_temp "validate_go_api_drift") || return 1
     # shellcheck disable=SC2064  # expand $expected now, not at trap time
     trap "rm -f '$expected' '$expected.diff'" RETURN
 
@@ -878,6 +944,7 @@ main() {
 
     case "$command" in
         check)
+            resolve_timeout_bin
             info "=== Version Consistency Check ==="
             info ""
             local gomod_result=0

--- a/scripts/test/cases/35-timeout-absent-fallback.sh
+++ b/scripts/test/cases/35-timeout-absent-fallback.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Row 35: no `timeout`/`gtimeout` binary available -- resolve_timeout_bin
+# falls back to running the two bounded probes unbounded, and warns once at
+# startup. Load-bearing assertion: the MVS-floor guard must still guard (the
+# same floor-match success line as case 01), proving the guard doesn't
+# silently stop guarding just because there's no timeout binary.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+export SYNC_VERSIONS_TIMEOUT_CMD=""
+run_check
+assert_rc 0
+assert_out_contains "floor-dep: pin v0.5.1 matches the floor set by github.com/example/floor-owner"
+assert_out_contains "will run unbounded"

--- a/scripts/test/cases/36-timeout-present-no-warning.sh
+++ b/scripts/test/cases/36-timeout-present-no-warning.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Row 36: a real `timeout`/`gtimeout` is on PATH (the harness's own default
+# environment) -- resolve_timeout_bin must resolve it and never print the
+# unbounded-fallback warning. Cheap, and it is the oracle for case 35:
+# without this case, a resolver stuck permanently in fallback mode (e.g. one
+# that ignores SYNC_VERSIONS_TIMEOUT_CMD's override the other way, or never
+# actually finds `timeout` on PATH) would leave case 35 green for the wrong
+# reason.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+run_check
+assert_rc 0
+assert_out_not_contains "will run unbounded"

--- a/scripts/test/cases/37-mktemp-failure.sh
+++ b/scripts/test/cases/37-mktemp-failure.sh
@@ -23,3 +23,12 @@ out=$(TMPDIR="$FIXTURE/no-such-dir" "$SYNC_VERSIONS" check 2>&1 1>/dev/null)
 rc=$?
 [[ $rc -eq 1 ]] || { echo "FAIL: expected rc 1, got $rc" >&2; exit 1; }
 [[ "$out" == *"mktemp failed"* ]] || { echo "FAIL: stderr missing 'mktemp failed': $out" >&2; exit 1; }
+# Discriminator: if the `|| return 1` guarding make_temp's result were ever
+# dropped, execution would continue on an empty/unusable path and reach a
+# downstream ambiguous redirect inside generate_docs/generate_go_api, whose
+# failure is reported by the *shell* (not mktemp) with this exact phrasing --
+# it never appears when the guard stops execution right after mktemp itself
+# fails. Without this check, rc==1 and "mktemp failed" alone hold in both the
+# guard-intact and guard-removed cases (mktemp's own message is unconditional),
+# so this case would pass vacuously against that regression.
+[[ "$out" != *"sync-versions.sh: line"* ]] || { echo "FAIL: guard did not stop execution -- downstream redirect failure leaked into stderr: $out" >&2; exit 1; }

--- a/scripts/test/cases/37-mktemp-failure.sh
+++ b/scripts/test/cases/37-mktemp-failure.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Row 37: mktemp itself fails (a broken TMPDIR) -- make_temp must name the
+# real defect instead of the caller dying on an ambiguous redirect or
+# installing a `rm -f ''` RETURN trap over an empty path.
+#
+# Cannot go through run_check/_run: _run (scripts/test/lib.sh:106-120) itself
+# allocates an `errfile` via a bare `mktemp` before ever invoking
+# $SYNC_VERSIONS, so a broken TMPDIR set ahead of run_check fails the
+# harness's own capture step first, never reaching sync-versions.sh. Invoke
+# the binary directly instead, scoping the broken TMPDIR to that one process.
+#
+# This exercises validate_docs_drift and validate_go_api_drift only (both
+# reached via `check`, both TMPDIR-honouring). generate_go_api's own mktemp
+# site is co-located with $out via a template argument and ignores TMPDIR
+# entirely; sync_gomod_pin_comment's site is generate-only. Neither is
+# reachable from this check-only case -- noted here rather than contriving
+# an unwritable-directory case for either.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+new_fixture
+out=$(TMPDIR="$FIXTURE/no-such-dir" "$SYNC_VERSIONS" check 2>&1 1>/dev/null)
+rc=$?
+[[ $rc -eq 1 ]] || { echo "FAIL: expected rc 1, got $rc" >&2; exit 1; }
+[[ "$out" == *"mktemp failed"* ]] || { echo "FAIL: stderr missing 'mktemp failed': $out" >&2; exit 1; }

--- a/scripts/test/cases/37-mktemp-failure.sh
+++ b/scripts/test/cases/37-mktemp-failure.sh
@@ -24,11 +24,16 @@ rc=$?
 [[ $rc -eq 1 ]] || { echo "FAIL: expected rc 1, got $rc" >&2; exit 1; }
 [[ "$out" == *"mktemp failed"* ]] || { echo "FAIL: stderr missing 'mktemp failed': $out" >&2; exit 1; }
 # Discriminator: if the `|| return 1` guarding make_temp's result were ever
-# dropped, execution would continue on an empty/unusable path and reach a
-# downstream ambiguous redirect inside generate_docs/generate_go_api, whose
-# failure is reported by the *shell* (not mktemp) with this exact phrasing --
-# it never appears when the guard stops execution right after mktemp itself
-# fails. Without this check, rc==1 and "mktemp failed" alone hold in both the
-# guard-intact and guard-removed cases (mktemp's own message is unconditional),
-# so this case would pass vacuously against that regression.
+# dropped, execution would continue with expected="" and reach a downstream
+# empty-filename redirect inside generate_docs/generate_go_api (`cat >
+# "$DOCS_FILE"` with $DOCS_FILE=""), whose failure is reported by the *shell*
+# (not mktemp) with this exact phrasing -- "line N: : No such file or
+# directory", NOT an "ambiguous redirect" (that specific bash error needs an
+# unquoted multi-/zero-word expansion, which this quoted, merely-empty
+# variable never produces). It never appears when the guard stops execution
+# right after mktemp itself fails. Without this check, rc==1 and "mktemp
+# failed" alone hold in both the guard-intact and guard-removed cases
+# (make_temp's own error() message fires unconditionally on mktemp failure,
+# regardless of whether the caller then checks the return), so this case
+# would pass vacuously against that regression.
 [[ "$out" != *"sync-versions.sh: line"* ]] || { echo "FAIL: guard did not stop execution -- downstream redirect failure leaked into stderr: $out" >&2; exit 1; }

--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -23,8 +23,11 @@ for case_file in "$TEST_DIR"/cases/*.sh; do
     # with `${VAR:-default}`, which preserves an inherited value -- so an
     # ambient STUB_GO_MODE/STUB_NET_MODE (say, left exported by a debugging
     # session) would silently run every case in a mode it never asked for,
-    # and an ambient SYNC_VERSIONS_REPO_ROOT/SYNC_VERSIONS_PROBE_TIMEOUT
-    # would reach sync-versions.sh directly. GOWORK is cleared for the same
+    # and an ambient SYNC_VERSIONS_REPO_ROOT/SYNC_VERSIONS_PROBE_TIMEOUT/
+    # SYNC_VERSIONS_TIMEOUT_CMD would reach sync-versions.sh directly -- an
+    # ambient SYNC_VERSIONS_TIMEOUT_CMD is exactly the GOWORK defect class:
+    # it would silently pin every case to one side of the timeout-resolver
+    # branch regardless of what the case itself sets. GOWORK is cleared for the same
     # reason: fixtures/stub-go/go's invocation-shape check for
     # sync-versions.sh:417's `GOWORK=off go mod edit` call works by testing
     # whether GOWORK=off reaches the stub -- an ambient GOWORK=off exported
@@ -36,6 +39,7 @@ for case_file in "$TEST_DIR"/cases/*.sh; do
     # working unchanged, since those all run after new_fixture.
     if out=$(env -u STUB_GO_MODE -u STUB_NET_MODE \
                  -u SYNC_VERSIONS_REPO_ROOT -u SYNC_VERSIONS_PROBE_TIMEOUT \
+                 -u SYNC_VERSIONS_TIMEOUT_CMD \
                  -u GOWORK \
                  bash "$case_file" 2>&1); then
         pass=$((pass + 1))

--- a/scripts/vendor-guard.sh
+++ b/scripts/vendor-guard.sh
@@ -58,7 +58,14 @@ fi
 
 url="https://raw.githubusercontent.com/go-kure/.github/${sha}/scripts/check-forbidden-terms.sh"
 
-fetched="$(mktemp)"
+fetched="$(mktemp)" || {
+    echo "vendor-guard: mktemp failed -- no writable temporary directory (check \$TMPDIR and free space)" >&2
+    exit 1
+}
+if [[ -z "$fetched" || ! -e "$fetched" ]]; then
+    echo "vendor-guard: mktemp produced an unusable path ('$fetched')" >&2
+    exit 1
+fi
 trap 'rm -f "$fetched"' EXIT
 
 if ! curl -fsSL "$url" -o "$fetched"; then

--- a/scripts/vendor-guard.sh
+++ b/scripts/vendor-guard.sh
@@ -59,10 +59,12 @@ fi
 url="https://raw.githubusercontent.com/go-kure/.github/${sha}/scripts/check-forbidden-terms.sh"
 
 fetched="$(mktemp)" || {
-    echo "vendor-guard: mktemp failed -- no writable temporary directory (check \$TMPDIR and free space)" >&2
+    echo "vendor-guard: mktemp failed -- either the mktemp binary is missing, or it could not create a file (check \$TMPDIR and free space)" >&2
     exit 1
 }
-if [[ -z "$fetched" || ! -e "$fetched" ]]; then
+# -f, not -e: this call takes no mktemp args, so it always creates a plain
+# file, never a directory.
+if [[ -z "$fetched" || ! -f "$fetched" ]]; then
     echo "vendor-guard: mktemp produced an unusable path ('$fetched')" >&2
     exit 1
 fi


### PR DESCRIPTION
Closes #715.

## Problem

`scripts/sync-versions.sh` uses `timeout` (2 call sites) and `mktemp` (4 sites) unguarded. #713
made the guard-test harness (`scripts/test/run-tests.sh`) a required dependency of `mise run verify`
and `make precommit`, which promoted these from theoretical gaps to things that can silently break
a contributor's local gate:

- No `timeout`/`gtimeout` on `PATH` → the two bounded probes return rc 127 and silently degrade
  (the MVS-floor guard stops guarding; a live tag lookup is misreported as "network unreachable").
- A failed `mktemp` call is never checked, so failure surfaces as an ambiguous-redirect error or an
  `rm -f ''` trap instead of a clear message.
- No prerequisites list exists anywhere in the repo.

## Fix

- `resolve_timeout_bin`/`run_bounded`: resolve `timeout` → `gtimeout` → unbounded-with-one-warning,
  once, from inside the `check` command path (never runs its probes under `generate`, so warning
  only fires when relevant).
- `make_temp`: guards every `mktemp` call site in `sync-versions.sh`, plus the one in
  `vendor-guard.sh` (same defect class, same directory).
- Three new harness cases (35/36/37) prove the fallback path, the no-warning path, and the mktemp
  failure message. `run-tests.sh`'s `env -u` sanitization list gained the new override var, guarding
  against the same ambient-leak class #713 hit with `GOWORK`.
- Evaluated whether mise's `coreutils` (`aqua:uutils/coreutils`) provisions a standalone `timeout`
  binary — it does not (ships one multi-call `coreutils` binary) — so `mise.toml` is intentionally
  left untouched; recorded in `docs/dependency-updates.md`.
- Added a Prerequisites list to `DEVELOPMENT.md` (none existed before).

## Verification

- `mise run verify` green (tidy, test, lint, check-tool-versions, check-govulncheck-docs,
  versions:test).
- Harness: 39 passed / 0 failed (36 pre-existing + 3 new).
- Fallback proven live: `SYNC_VERSIONS_TIMEOUT_CMD="" ./scripts/sync-versions.sh check` → rc 0,
  warning printed once, real floor-match success line still present (guard still guards).
- Oracle: 4 mutations proved against restore — each names the case it breaks (see PR review ledger
  for detail); one plan-disclosed, non-blocking coverage gap noted (case 37's committed assertions
  don't distinguish one of the four `make_temp` sites from another emitting the same substring in
  the same run — pre-scoped by the plan as a one-time manual proof, not permanent test code).
- `mise run versions:check` byte-identical against `origin/main` behavior (no production
  regression), from the worktree root and via absolute path from outside the checkout.
